### PR TITLE
UI needs the metrics immediately after Hawkular server starts, 

### DIFF
--- a/hawkular-wildfly-monitor/src/main/java/org/hawkular/agent/monitor/service/MonitorService.java
+++ b/hawkular-wildfly-monitor/src/main/java/org/hawkular/agent/monitor/service/MonitorService.java
@@ -503,6 +503,9 @@ public class MonitorService implements Service<MonitorService> {
         schedulerService = new SchedulerService(schedulerConfig, selfId, diagnostics, storageAdapter,
                 createLocalClientFactory(), this.httpClientBuilder);
 
+        // now we can begin collecting metrics
+        schedulerService.start();
+
         // if we are participating in a full hawkular environment, add resource and its metadata to inventory now
         if (this.configuration.storageAdapter.type == MonitorServiceConfiguration.StorageReportTo.HAWKULAR) {
 
@@ -526,9 +529,6 @@ public class MonitorService implements Service<MonitorService> {
                         "Failed to completely add our inventory - but we will keep going with partial inventory");
             }
         }
-
-        // now we can begin collecting metrics
-        schedulerService.start();
     }
 
     private SchedulerConfiguration prepareSchedulerConfig() {


### PR DESCRIPTION
UI needs the metrics immediately after Hawkular server starts, however, the inventory feeding process blocks the metrics collection, so let's reverse it. Starting the schedulerService is a non-blocking call (well, it generates the task queue, but it's done in an instant) and the blocking inventory feeding goes after this fast step.

NOTE/TODO: we should improve the inventory performance (for writes)
