### PR TITLE
escaping character issues

### DIFF
--- a/hawkular-wildfly-monitor/src/main/java/org/hawkular/agent/monitor/inventory/ID.java
+++ b/hawkular-wildfly-monitor/src/main/java/org/hawkular/agent/monitor/inventory/ID.java
@@ -25,7 +25,7 @@ public class ID {
     private final String id;
 
     public ID(String id) {
-        this.id = id;
+        this.id = id != null && id.endsWith("/") ? id.substring(0, id.length() - 1) + '~' : id;
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <!-- TODO DELETE THIS WHEN WE NO LONGER SEND TWO MESSAGES PER METRIC -->
     <version.org.apache.httpcomponents>4.4.1</version.org.apache.httpcomponents>
     <version.org.hawkular.bus>0.3.4</version.org.hawkular.bus>
-    <version.org.hawkular.inventory>0.2.0.Final</version.org.hawkular.inventory>
+    <version.org.hawkular.inventory>0.3.0</version.org.hawkular.inventory>
     <version.org.hawkular.metrics>0.5.0.Final</version.org.hawkular.metrics>
     <version.org.jgrapht>0.9.1</version.org.jgrapht>
   </properties>


### PR DESCRIPTION
**This is a sub set of the #36**

This change is needed to work properly with inventory 0.3.0, otherwise the discovery is stopped after first failure that happens because of the way how agent escapes the slashes... it was changed in the 0.3.0, (no more '\/').
