### PR TITLE
HAWKULAR-650 - Provide (remote) agent install(er) for WF-agent

### DIFF
--- a/hawkular-wildfly-monitor-installer/README.adoc
+++ b/hawkular-wildfly-monitor-installer/README.adoc
@@ -1,0 +1,35 @@
+= Hawkular Wildfly Monitor Installer
+:source-language: java
+
+== About
+
+Hawkular Wildfly Monitor Installer is a standalone java application to install Hawkular Agent into stock Wildfly Server.
+
+== Running using Maven
+
+Installer is configured via maven exec plugin so it installs Hawkular Agent from this repository into local Wildfly located in `${wildfly.home}`
+
+    mvn exec:java -Dwildfly.home=/opt/wildfly-9.0.0.Final
+
+== Running as standalone java application
+
+=== Building standalone jar
+
+    mvn package assembly:single
+
+=== Running
+
+Command line parameter `module` is required unless installer retrieves Hawkular Monitor module from `hawkular-server-url`
+
+   java -jar target/hawkular-wildfly-monitor-installer-0.10.1.Final-SNAPSHOT-standalone.jar \
+     --module=/path/to/module.zip \
+     --wildfly-home=/opt/wildfly-9.0.0.Final \
+     --hawkular-server-url=http://localhost:8080
+
+Hawkular Agent is then installed to Wildfly Server `/opt/wildfly-9.0.0.Final` as a module and is able to report to Hawkular Server located at `http://localhost:8080`.
+
+=== Setting up SSL
+
+If needed, installer can setup secured connection between Hawkular Wildfly Monitor and Hawkular server. By specifying `https` scheme  (ie. `--server-url=https://localhost:8443`)
+following command-line options become required `--keystore-path` and `--key-alias`. Installer also needs `--keystore-password` and `--key-password` options
+but they can be omitted in case you run it in console (in such case, installer will prompt for passwords). For more details see http://www.hawkular.org/docs/user/secure-comm.html[Secure Communications].

--- a/hawkular-wildfly-monitor-installer/pom.xml
+++ b/hawkular-wildfly-monitor-installer/pom.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.hawkular.agent</groupId>
+    <artifactId>hawkular-agent-parent</artifactId>
+    <version>0.10.1.Final-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>hawkular-wildfly-monitor-installer</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Hawkular Wildfly Monitor Installer</name>
+  <description>Hawkular Monitoring Agent Installer</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.hawkular.agent</groupId>
+      <artifactId>wildfly-module-installer</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging</artifactId>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <configuration>
+          <mainClass>org.hawkular.wildfly.monitor.installer.AgentInstaller</mainClass>
+          <arguments>
+            <argument>--wildfly-home=${wildfly.home}</argument>
+            <argument>--module=${project.basedir}/../hawkular-wildfly-monitor/target/hawkular-monitor-${project.version}-module.zip</argument>
+            <argument>--hawkular-server-url=http://127.0.0.1:8080</argument>
+          </arguments>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <configuration>
+          <appendAssemblyId>true</appendAssemblyId>
+          <archive>
+            <manifest>
+              <mainClass>org.hawkular.wildfly.monitor.installer.AgentInstaller</mainClass>
+            </manifest>
+          </archive>
+          <descriptors>
+            <descriptor>src/main/assembly/standalone-jar-assembly.xml</descriptor>
+          </descriptors>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/hawkular-wildfly-monitor-installer/src/main/assembly/standalone-jar-assembly.xml
+++ b/hawkular-wildfly-monitor-installer/src/main/assembly/standalone-jar-assembly.xml
@@ -1,0 +1,38 @@
+<!--
+
+    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<assembly
+  xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+
+  <id>standalone</id>
+  <formats>
+    <format>jar</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <baseDirectory>${project.build.finalName}</baseDirectory>
+
+
+  <dependencySets>
+    <dependencySet>
+      <unpack>true</unpack>
+      <scope>compile</scope>
+    </dependencySet>
+  </dependencySets>
+</assembly>

--- a/hawkular-wildfly-monitor-installer/src/main/java/org/hawkular/wildfly/monitor/installer/AgentInstaller.java
+++ b/hawkular-wildfly-monitor-installer/src/main/java/org/hawkular/wildfly/monitor/installer/AgentInstaller.java
@@ -1,0 +1,350 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.wildfly.monitor.installer;
+
+import java.io.Console;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.apache.commons.io.IOUtils;
+import org.hawkular.wildfly.module.installer.DeploymentConfiguration;
+import org.hawkular.wildfly.module.installer.DeploymentConfiguration.Builder;
+import org.hawkular.wildfly.module.installer.ExtensionDeployer;
+import org.hawkular.wildfly.module.installer.XmlEdit;
+import org.jboss.logging.Logger;
+
+public class AgentInstaller {
+
+    private static final Logger log = Logger.getLogger(AgentInstaller.class);
+    private static final String SECURITY_REALM_NAME = "HawkularRealm";
+    private static final String OPTION_WILDFLY_HOME="wildfly-home";
+    private static final String OPTION_MODULE = "module";
+    private static final String OPTION_SERVER_CONFIG = "server-config";
+    private static final String OPTION_HAWKULAR_SERVER_URL = "hawkular-server-url";
+    private static final String OPTION_KEYSTORE_PATH = "keystore-path";
+    private static final String OPTION_KEYSTORE_PASSWORD="keystore-password";
+    private static final String OPTION_KEY_ALIAS="key-alias";
+    private static final String OPTION_KEY_PASSWORD="key-password";
+
+    private static Options OPTIONS;
+    private static InstallerDefaults defaults;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            defaults = new InstallerDefaults();
+            OPTIONS = commandLineOptions(defaults);
+            CommandLine commandLine = new DefaultParser().parse(OPTIONS, args);
+
+            String jbossHome = commandLine.getOptionValue(OPTION_WILDFLY_HOME);
+            String moduleZip = commandLine.getOptionValue(OPTION_MODULE, defaults.getModule());
+            String hawkularServerUrl = commandLine.getOptionValue(OPTION_HAWKULAR_SERVER_URL,
+                    defaults.getHawkularServerUrl());
+
+            URL moduleUrl = null;
+            // if --module is not supplied try to download agent module from server
+            if (moduleZip == null) {
+                moduleUrl = downloadModule(hawkularServerUrl);
+                if (moduleUrl == null) {
+                    throw new IOException("Failed to retrieve agent module from server, option [module]"
+                            + " is now required but it was not supplied");
+                }
+            } else if (moduleZip.startsWith("classpath:/")) {
+                // this special protocol tells us to read module as resource from classpath
+                String resourceUrl = moduleZip.substring(10);
+                moduleUrl = AgentInstaller.class.getResource(resourceUrl);
+                if (moduleUrl == null) {
+                    throw new IOException("Unable to load module.zip from classpath as resource "+resourceUrl);
+                }
+            }
+            else {
+                moduleUrl = new File(moduleZip).toURI().toURL();
+            }
+            URL serverUrl = new URL(hawkularServerUrl);
+            URL socketBinding = createSocketBindingSnippet(serverUrl);
+            // deploy given module into given wfHome and
+            // set it up the way it talks to hawkular server on hawkularServerUrl
+            // TODO support domain mode
+            Builder configuration = DeploymentConfiguration.builder()
+                    .jbossHome(new File(jbossHome))
+                    .module(moduleUrl)
+                    .socketBinding(socketBinding);
+
+            String serverConfig = commandLine.getOptionValue(OPTION_SERVER_CONFIG);
+            if (serverConfig != null) {
+                configuration.serverConfig(serverConfig);
+            } else {
+                serverConfig = DeploymentConfiguration.DEFAULT_SERVER_CONFIG;
+                // we'll use this in case of https to resolve server configuration directory
+            }
+
+            if (serverUrl.getProtocol().equals("https")) {
+                String keystorePath = commandLine.getOptionValue(OPTION_KEYSTORE_PATH);
+                String keystorePass = commandLine.getOptionValue(OPTION_KEYSTORE_PASSWORD);
+                String keyPass = commandLine.getOptionValue(OPTION_KEY_PASSWORD);
+                String keyAlias = commandLine.getOptionValue(OPTION_KEY_ALIAS);
+                if (keystorePath == null || keyAlias == null) {
+                    StringBuilder sbOptions = new StringBuilder(OPTION_KEYSTORE_PATH)
+                        .append(","+OPTION_KEY_ALIAS);
+
+                    throw new ParseException("When using https protocol, following keystore"
+                            + " command-line options are required: "+sbOptions.toString());
+                }
+
+                // password fields are not required, but if not supplied we'll ask user
+                if (keystorePass == null) {
+                    // try to read it from STDIN
+                    keystorePass = readPaswordFromStdin("Keystore password:");
+                    if (keystorePass == null || keystorePass.isEmpty()) {
+                        keystorePass = ""; // set to empty string
+                        log.warn("Option --"+OPTION_KEYSTORE_PASSWORD + " was not passed using empty password");
+                    }
+                }
+                if (keyPass == null) {
+                    // try to read it from STDIN
+                    keyPass = readPaswordFromStdin("Key password:");
+                    if (keyPass == null || keyPass.isEmpty()) {
+                        keyPass = ""; // set to empty string
+                        log.warn("Option --"+OPTION_KEY_PASSWORD + " was not passed using empty password");
+                    }
+                }
+
+                // in case given keystore path is not already present within server-config
+                // directory, copy it
+                File keystoreSrcFile = new File(keystorePath);
+                if (!(keystoreSrcFile.isFile() && keystoreSrcFile.canRead())) {
+                    throw new FileNotFoundException("Cannot read "+keystoreSrcFile.getAbsolutePath());
+                }
+                File serverConfigDir;
+                if (new File(serverConfig).isAbsolute()) {
+                    serverConfigDir = new File(serverConfig).getParentFile();
+                } else {
+                    serverConfigDir = new File(jbossHome, serverConfig).getParentFile();
+                }
+                Path keystoreDst = Paths.get(serverConfigDir.getAbsolutePath()).resolve(keystoreSrcFile.getName());
+                // never overwrite target keystore
+                if (!keystoreDst.toFile().exists()) {
+                    log.info("Copy ["+keystoreSrcFile.getAbsolutePath()+"] to ["+keystoreDst.toString()+"]");
+                    Files.copy(Paths.get(keystoreSrcFile.getAbsolutePath()), keystoreDst);
+                }
+                // setup security-realm and storage-adapter (within hawkular-wildfly-monitor subsystem)
+                String securityRealm = createSecurityRealm(keystoreSrcFile.getName(), keystorePass, keyPass, keyAlias);
+                configuration.addXmlEdit(new XmlEdit("/server/management/security-realms", securityRealm));
+                configuration.addXmlEdit(createStorageAdapter());
+            }
+            new ExtensionDeployer().install(configuration.build());
+        } catch (ParseException pe) {
+            log.warn(pe);
+            help();
+        } catch (Exception ex) {
+            log.warn(ex);
+        }
+    }
+
+    /**
+     * reads password from user
+     * @param message to present before reading
+     * @return password or null if console is not available
+     */
+    private static String readPaswordFromStdin(String message) {
+        Console console = System.console();
+        if (console == null) {
+            return null;
+        }
+        console.writer().write(message);
+        console.writer().flush();
+        return String.valueOf(console.readPassword());
+    }
+
+    /**
+     * creates xml snippet which sets up security-realm
+     * @param keystoreFile
+     * @param keystorePass
+     * @param keyPass
+     * @param keyAlias
+     * @return xml snippet
+     */
+    private static String createSecurityRealm(String keystoreFile, String keystorePass,
+            String keyPass, String keyAlias) {
+        return new StringBuilder("<security-realm name=\""+SECURITY_REALM_NAME+"\">")
+            .append("<server-identities><ssl>")
+            .append("<keystore path=\""+keystoreFile+"\"")
+            .append(" relative-to=\"jboss.server.config.dir\"")
+            .append(" keystore-password=\""+keystorePass+"\"")
+            .append(" key-password=\""+keyPass+"\"")
+            .append(" alias=\""+keyAlias+"\"")
+            .append(" /></ssl></server-identities></security-realm>").toString();
+    }
+
+    /**
+     * creates XML edit which sets up hawkular.agent.monitor storage-adapter, creates reference
+     * to security-realm and enables SSL.
+     * @return
+     */
+    private static XmlEdit createStorageAdapter() {
+        String select = "/server/profile/"
+                + "*[namespace-uri()='urn:org.hawkular.agent.monitor:monitor:1.0']/";
+        StringBuilder xml = new StringBuilder("<storage-adapter")
+                .append(" type=\"HAWKULAR\"")
+                .append(" useSSL=\"true\"")
+                .append(" username=\"" + defaults.getHawkularUsername() + "\"")
+                .append(" password=\"" + defaults.getHawkularPassword() + "\"")
+                .append(" securityRealm=\"" + SECURITY_REALM_NAME + "\"")
+                .append("/>");
+        // this will replace <storage-adapter type="HAWKULAR" under urn:org.hawkular.agent.monitor:monitor:1.0 subsystem
+        // with above content
+        return new XmlEdit(select, xml.toString()).withAttribute("type");
+    }
+
+    /**
+     * creates a (outbound) socket-binding snippet XML file
+     * @param serverUrl
+     * @return URL (path) to socket binding snippet file
+     * @throws IOException
+     */
+    private static URL createSocketBindingSnippet(URL serverUrl) throws IOException {
+        String host = serverUrl.getHost();
+        String port = String.valueOf(serverUrl.getPort());
+        StringBuilder xml = new StringBuilder("<outbound-socket-binding name=\"hawkular\">\n")
+            .append("  <remote-destination host=\""+host+"\" port=\""+port+"\" />\n")
+            .append("</outbound-socket-binding>");
+        Path tempFile = Files.createTempFile("hk-wf-module-installer", ".xml");
+        // TODO cleanup temp file
+        Files.write(tempFile, xml.toString().getBytes());
+        return tempFile.toUri().toURL();
+    }
+
+    /**
+     * downloads hawkular agent module ZIP from hawkular-server
+     * @param hawkularServerUrl
+     * @return absolute path to module downloaded locally or null if it could not be retrieved
+     */
+    private static URL downloadModule(String hawkularServerUrl) {
+        FileOutputStream fos = null;
+        try {
+            // TODO fix agent module location
+            // TODO do we need to authorize to get module.zip?
+            URL fileUrl = new URL(hawkularServerUrl+"/hawkular/hawkular-agent-module.zip");
+            File tempFile = File.createTempFile("agent-installer", ".zip");
+            fos = new FileOutputStream(tempFile);
+            IOUtils.copyLarge(fileUrl.openStream(), fos);
+            return tempFile.toURI().toURL();
+        } catch (Exception e) {
+            log.warn("Unable to download hawkular-agent module ZIP from "+hawkularServerUrl);
+        }finally {
+            if (fos != null) {
+                try {
+                    fos.close();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * print command-line help
+     */
+    private static void help() {
+        HelpFormatter formatter = new HelpFormatter();
+        formatter.setWidth(120);
+        formatter.setOptionComparator(null);
+        formatter.printHelp("hawkular-wildfly-monitor-installer", OPTIONS);
+    }
+
+    /**
+     * build options we understand from command-line
+     * @param defaults default values from bundled property file. Based on them, several command-line options
+     * might no longer be required
+     * @return
+     */
+    private static Options commandLineOptions(InstallerDefaults defaults) {
+        Options options = new Options();
+        options.addOption(Option.builder()
+                .required()
+                .argName("wildflyHome")
+                .desc("Target wildfly home")
+                .hasArg()
+                .numberOfArgs(1)
+                .longOpt(OPTION_WILDFLY_HOME)
+                .build()
+                );
+        options.addOption(Option.builder()
+                .argName("moduleZip")
+                .longOpt(OPTION_MODULE)
+                .desc("Extension Module")
+                .numberOfArgs(1)
+                .build()
+                );
+        Option serverUrl = Option.builder()
+                .argName("serverUrl")
+                .desc("Hawkular Server URL")
+                .numberOfArgs(1)
+                .longOpt(OPTION_HAWKULAR_SERVER_URL)
+                .build();
+        serverUrl.setRequired(defaults.getHawkularServerUrl() == null);
+        options.addOption(serverUrl);
+
+        options.addOption(Option.builder()
+                .argName("serverConfig")
+                .desc("Server config to write to. Can be either absolute path or relative to <wildflyHome>")
+                .numberOfArgs(1)
+                .longOpt(OPTION_SERVER_CONFIG)
+                .build());
+        // SSL related config options
+        options.addOption(Option.builder()
+                .argName("keyStore")
+                .desc("Keystore file. Required when <serverUrl> protocol is https")
+                .numberOfArgs(1)
+                .longOpt(OPTION_KEYSTORE_PATH)
+                .build());
+        options.addOption(Option.builder()
+                .argName("keystorePassword")
+                .desc("Keystore password. When <serverUrl> protocol is https and this option is not passed,"
+                        + " installer will ask for password")
+                .numberOfArgs(1)
+                .longOpt(OPTION_KEYSTORE_PASSWORD)
+                .build());
+        options.addOption(Option.builder()
+                .argName("keyPassword")
+                .desc("Key password. When <serverUrl> protocol is https and this option is not passed,"
+                        + " installer will ask for password")
+                .numberOfArgs(1)
+                .longOpt(OPTION_KEY_PASSWORD)
+                .build());
+        options.addOption(Option.builder()
+                .argName("alias")
+                .desc("Key alias. Required when <serverUrl> protocol is https")
+                .numberOfArgs(1)
+                .longOpt(OPTION_KEY_ALIAS)
+                .build());
+        return options;
+    }
+
+}

--- a/hawkular-wildfly-monitor-installer/src/main/java/org/hawkular/wildfly/monitor/installer/InstallerDefaults.java
+++ b/hawkular-wildfly-monitor-installer/src/main/java/org/hawkular/wildfly/monitor/installer/InstallerDefaults.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.wildfly.monitor.installer;
+
+import java.io.IOException;
+import java.util.Properties;
+/**
+ * Installer defaults keep default values to be used for installation. Those values are loaded from
+ * 'hawkular-wildfly-monitor-installer.properties' property file. Hawkular server can serve
+ * hawkular-wildfly-monitor-installer and serve special version of installer
+ * (with bundled module.zip) to each client. When serving it will probably generate
+ * hawkular-wildfly-monitor-installer.jar on the fly and thus can generate content
+ * of 'hawkular-wildfly-monitor-installer.properties'. In the end user may not need to
+ * supply any command-line options because server will define all required defaults
+ *  (like hawkular.server.url) upfront.
+ * @author lzoubek@redhat.com
+ */
+public class InstallerDefaults {
+
+    private final Properties properties;
+
+    public InstallerDefaults() throws IOException {
+        properties = new Properties();
+        properties.load(InstallerDefaults.class.getResourceAsStream("/hawkular-wildfly-monitor-installer.properties"));
+    }
+
+    public String getHawkularServerUrl() {
+        return properties.getProperty("hawkular.server.url");
+    }
+
+    public String getModule() {
+        return properties.getProperty("module");
+    }
+
+    public String getHawkularUsername() {
+        return properties.getProperty("hawkular.server.username", "jdoe");
+    }
+
+    public String getHawkularPassword() {
+        return properties.getProperty("hawkular.server.password", "password");
+    }
+}

--- a/hawkular-wildfly-monitor-installer/src/main/resources/hawkular-wildfly-monitor-installer.properties
+++ b/hawkular-wildfly-monitor-installer/src/main/resources/hawkular-wildfly-monitor-installer.properties
@@ -1,0 +1,30 @@
+#
+# Copyright 2015 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# do NOT keep properties with empty values here, rather comment property out
+
+# hawkular server url to be set up in outbound-socket-binding
+# hawkular.server.url=
+
+# login credential
+hawkular.server.username=jdoe
+hawkular.server.password=password
+
+# URL of hawkular-wildfly-monitor module ZIP. This value
+# can be regular URL or special URL in form "classpath:/path/to/resource"
+# which can be used in case this JAR is repacked and module.zip is bundled in it
+# module=

--- a/hawkular-wildfly-monitor/src/main/assembly/module-assembly.xml
+++ b/hawkular-wildfly-monitor/src/main/assembly/module-assembly.xml
@@ -39,6 +39,14 @@
       <directoryMode>0755</directoryMode>
     </fileSet>
   </fileSets>
+  <files>
+    <file>
+      <source>${project.basedir}/src/main/assembly/subsystem.xml</source>
+      <outputDirectory>/${moduleDir}/main</outputDirectory>
+      <destName>subsystem-snippet.xml</destName>
+    </file>
+  </files>
+
 
   <dependencySets>
     <dependencySet>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,8 @@
     <module>hawkular-wildfly-monitor</module>
     <module>hawkular-wildfly-monitor-feature-pack</module>
     <module>hawkular-agent-itest-parent</module>
+    <module>wildfly-module-installer</module>
+    <module>hawkular-wildfly-monitor-installer</module>
   </modules>
 
   <scm>

--- a/wildfly-module-installer/pom.xml
+++ b/wildfly-module-installer/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.hawkular.agent</groupId>
+    <artifactId>hawkular-agent-parent</artifactId>
+    <version>0.10.1.Final-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>wildfly-module-installer</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Wildfly Extension Installer</name>
+  <description>A library for installing and configuring Wifldfly Module as an extension</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.4</version>
+    </dependency>
+
+    <dependency>
+      <groupId>commons-cli</groupId>
+      <artifactId>commons-cli</artifactId>
+      <version>1.3.1</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <configuration>
+          <excludes combine.children="append">
+            <exclude>src/test/resources/**</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/wildfly-module-installer/src/main/java/org/hawkular/wildfly/module/installer/DeploymentConfiguration.java
+++ b/wildfly-module-installer/src/main/java/org/hawkular/wildfly/module/installer/DeploymentConfiguration.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.wildfly.module.installer;
+
+import java.io.File;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class DeploymentConfiguration {
+
+    /**
+     * Default path to to server config file (relative to {@link #jbossHome})
+     */
+    public static String DEFAULT_SERVER_CONFIG = "standalone/configuration/standalone.xml";
+
+    /**
+     * Location of JBoss input module.zip This file should have JBoss module
+     * directory structure so it can be laid down to {@link #modulesHome} directory.
+     */
+    private URL module;
+
+    /**
+     * Location of AS7/WildFly server to deploy to
+     */
+    private File jbossHome;
+
+    /**
+     * Location of modules home (either relative to {@link #jbossHome} or absolute).
+     * Set this value unless your structure inside {@link #moduleZip} does not include path to modules.
+     * Default is null, which means it is detected - for Wildfly, this path would be "modules/system/layers/base",
+     * for older AS7 versions it's just "modules".
+     */
+    private String modulesHome;
+
+    /**
+     * Location of source server configuration file (standalone.xml) write to
+     * (can be either relative to jbossHome or absolute)
+     */
+    private String sourceServerConfig = DEFAULT_SERVER_CONFIG;
+
+    /**
+     * Location of target server configuration file (standalone.xml) write to
+     * (can be either relative to jbossHome or absolute)
+     */
+    private String targetServerConfig = DEFAULT_SERVER_CONFIG;
+
+    /**
+     * Location where deployer will backup original server configuration file (standalone.xml)
+     * in case {@link #sourceServerConfig} and {@link #targetServerConfig} are same.
+     * Can be either relative to {@link #jbossHome} or absolute path.
+     */
+    private String serverConfigBackup = DEFAULT_SERVER_CONFIG + ".backup";
+
+    /**
+     * Location of subsystem content to be inserted into standalone.xml
+     */
+    private URL subsystem;
+
+    /**
+     * Location of socket-binding content to be inserted into standalone.xml
+     */
+    private URL socketBinding;
+
+    /**
+     * List of socket-binding-groups to set socketBinding in (only applies when socketBinding exists)
+     * Default : ["standard-sockets"]
+     */
+    private Set<String> socketBindingGroups = new HashSet<>();
+
+    /**
+     * List of data to be inserted to {@link #serverConfig}. This is pretty powerful
+     * stuff to put/replace any XML content anywhere in
+     * {@link #serverConfig}
+     */
+    private List<XmlEdit> edit;
+
+    /**
+     * List of target profiles (only applies when {@link #domain} is equal to true)
+     */
+    private Set<String> profiles = new HashSet<>();
+
+    /**
+     * Denotes whether we setup standalone-*.xml or domain.xml
+     */
+    private boolean domain;
+
+    /**
+     * Causes {@link ExtensionDeploymentException} to be thrown if any of <strong>select</strong>
+     * expression within {@link #edit} does not match any node (thus it wouldn't update
+     * {@link #serverConfig})
+     */
+    private boolean failNoMatch;
+
+    public Set<String> getProfiles() {
+        return profiles;
+    }
+
+    public boolean isDomain() {
+        return domain;
+    }
+
+    public URL getModule() {
+        return module;
+    }
+
+    public File getJbossHome() {
+        return jbossHome;
+    }
+
+    public String getModulesHome() {
+        return modulesHome;
+    }
+
+    public String getSourceServerConfig() {
+        return sourceServerConfig;
+    }
+
+    public String getTargetServerConfig() {
+        return targetServerConfig;
+    }
+
+    public String getServerConfigBackup() {
+        return serverConfigBackup;
+    }
+
+    public URL getSubsystem() {
+        return subsystem;
+    }
+
+    public URL getSocketBinding() {
+        return socketBinding;
+    }
+
+    public void setDomain(boolean domain) {
+        this.domain = domain;
+    }
+
+    public void setProfiles(Set<String> profiles) {
+        this.profiles = profiles;
+    }
+
+    public Set<String> getSocketBindingGroups() {
+        return socketBindingGroups;
+    }
+
+    public List<XmlEdit> getEdit() {
+        if (edit == null) {
+            edit = new ArrayList<>();
+        }
+        return edit;
+    }
+
+    public boolean isFailNoMatch() {
+        return failNoMatch;
+    }
+
+    public void setModule(URL module) {
+        this.module = module;
+    }
+
+    public void setJbossHome(File jbossHome) {
+        this.jbossHome = jbossHome;
+    }
+
+    public void setModulesHome(String modulesHome) {
+        this.modulesHome = modulesHome;
+    }
+
+    public void setSourceServerConfig(String sourceServerConfig) {
+        this.sourceServerConfig = sourceServerConfig;
+    }
+
+    public void setTargetServerConfig(String targetServerConfig) {
+        this.targetServerConfig = targetServerConfig;
+    }
+
+    public void setServerConfigBackup(String serverConfigBackup) {
+        this.serverConfigBackup = serverConfigBackup;
+    }
+
+    public void setSubsystem(URL subsystem) {
+        this.subsystem = subsystem;
+    }
+
+    public void setSocketBinding(URL socketBinding) {
+        this.socketBinding = socketBinding;
+    }
+
+    public void setSocketBindingGroups(Set<String> socketBindingGroups) {
+        this.socketBindingGroups = socketBindingGroups;
+    }
+
+    public void setEdit(List<XmlEdit> edit) {
+        this.edit = edit;
+    }
+
+    public void setFailNoMatch(boolean failNoMatch) {
+        this.failNoMatch = failNoMatch;
+    }
+
+    public static class Builder {
+        private final DeploymentConfiguration configuration = new DeploymentConfiguration();
+
+        public Builder module(URL module) {
+            configuration.setModule(module);
+            return this;
+        }
+
+        public Builder socketBinding(URL socketBinding) {
+            configuration.setSocketBinding(socketBinding);
+            return this;
+        }
+
+        public Builder jbossHome(File jbossHome) {
+            configuration.setJbossHome(jbossHome);
+            return this;
+        }
+
+        public Builder addXmlEdit(XmlEdit edit) {
+            configuration.getEdit().add(edit);
+            return this;
+        }
+
+        public Builder domain(boolean domain) {
+            configuration.setDomain(domain);
+            return this;
+        }
+
+        public Builder addProfile(String profile) {
+            configuration.getProfiles().add(profile);
+            return this;
+        }
+
+        public Builder addSocketBindingGroup(String groupName) {
+            configuration.getSocketBindingGroups().add(groupName);
+            return this;
+        }
+
+        public Builder serverConfig(String serverConfig) {
+            configuration.setSourceServerConfig(serverConfig);
+            configuration.setTargetServerConfig(serverConfig);
+            return this;
+        }
+
+        public DeploymentConfiguration build() {
+            // add defaults if needed
+            if (configuration.isDomain() && configuration.getProfiles().isEmpty()) {
+                addProfile("default");
+            }
+            if (configuration.getSocketBindingGroups().isEmpty()) {
+                configuration.getSocketBindingGroups().add("standard-sockets");
+            }
+            return configuration;
+        }
+
+    }
+    /**
+     * create Configuration Builder
+     * @return Configuration Builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+}

--- a/wildfly-module-installer/src/main/java/org/hawkular/wildfly/module/installer/ExtensionDeployer.java
+++ b/wildfly-module-installer/src/main/java/org/hawkular/wildfly/module/installer/ExtensionDeployer.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.wildfly.module.installer;
+
+import java.io.File;
+import java.nio.file.Paths;
+import java.util.List;
+
+import org.jboss.logging.Logger;
+
+/**
+ * Goal which deploys JBoss module to JBoss AS7/WildFly server
+ */
+public class ExtensionDeployer {
+    private final Logger log = Logger.getLogger(this.getClass());
+
+    private File targetServerConfigAbsolute;
+    private File sourceServerConfigBackupAbsolute;
+    private File modulesHomeAbsolute;
+
+    public void install(DeploymentConfiguration configuration) throws ExtensionDeploymentException {
+        debug("Validating configuration");
+        validConfiguration(configuration);
+
+        JBossModule module = null;
+        RegisterModuleConfiguration resolvedOptions = new RegisterModuleConfiguration();
+        if (configuration.getModule() != null) {
+            try {
+                debug("Reading module from "+configuration.getModule());
+                module = JBossModule.readFromURL(configuration.getModule());
+            } catch (Exception e) {
+                throw new ExtensionDeploymentException("Failed to read module", e);
+            }
+
+            try {
+                List<File> installedFiles = module.installTo(modulesHomeAbsolute);
+                resolvedOptions = resolveBundledXmlSnippets(installedFiles);
+
+            } catch (Exception e) {
+                throw new ExtensionDeploymentException("Failed to install module", e);
+            }
+        }
+
+        try {
+            RegisterModuleConfiguration options = new RegisterModuleConfiguration();
+            if (module != null) {
+                options.withExtension(module.getModuleId());
+            }
+
+            options
+                .targetServerConfig(targetServerConfigAbsolute)
+                .sourceServerConfig(sourceServerConfigBackupAbsolute)
+                .subsystem(configuration.getSubsystem())
+                .socketBinding(configuration.getSocketBinding())
+                .socketBindingGroups(configuration.getSocketBindingGroups())
+                .xmlEdits(configuration.getEdit())
+                .domain(configuration.isDomain())
+                .profiles(configuration.getProfiles())
+                .failNoMatch(configuration.isFailNoMatch());
+
+            resolvedOptions.extend(options);
+            debug("Proceeding with \n" + resolvedOptions);
+            register(resolvedOptions);
+
+        } catch (Exception e) {
+            log.error(e);
+            throw new ExtensionDeploymentException("Failed to update server configuration file", e);
+        }
+    }
+
+    private RegisterModuleConfiguration resolveBundledXmlSnippets(List<File> installedFiles) throws Exception {
+        RegisterModuleConfiguration options = new RegisterModuleConfiguration();
+        for (File file : installedFiles) {
+            if ("subsystem-snippet.xml".equals(file.getName())) {
+                log.debug("Found packaged subsystem snippet " + file.getAbsolutePath());
+                options.subsystem(file.toURI().toURL());
+            }
+            if ("socket-binding-snippet.xml".equals(file.getName())) {
+                log.debug("Found packaged socket-binding snippet " + file.getAbsolutePath());
+                options.socketBinding(file.toURI().toURL());
+            }
+        }
+        return options;
+    }
+
+    public void register(RegisterModuleConfiguration options) throws Exception {
+        new RegisterExtension().register(options);
+    }
+
+    private void debug(String message) {
+        if (log.isDebugEnabled()) {
+            log.debug(message);
+        }
+    }
+
+    private void validConfiguration(DeploymentConfiguration configuration) throws ExtensionDeploymentException {
+        File jbossHome = configuration.getJbossHome();
+
+        if (!(jbossHome.exists() && jbossHome.isDirectory() && jbossHome.canRead())) {
+            throw new ExtensionDeploymentException("wildflyHome = " + jbossHome.getAbsolutePath()
+                    + " is not readable and existing directory");
+        }
+        if (!new File(jbossHome, "modules").isDirectory()) {
+            throw new ExtensionDeploymentException("wildflyHome = " + jbossHome.getAbsolutePath()
+                    + " does not seem to point to AS7/WildFly installation dir");
+        }
+
+        if (new File(configuration.getTargetServerConfig()).isAbsolute()) {
+            targetServerConfigAbsolute = new File(configuration.getTargetServerConfig());
+        } else {
+            targetServerConfigAbsolute = new File(jbossHome, configuration.getTargetServerConfig());
+        }
+        if (!(targetServerConfigAbsolute.exists() && targetServerConfigAbsolute.isFile() && targetServerConfigAbsolute
+                .canWrite())) {
+            throw new ExtensionDeploymentException(
+                    "targetServerConfig = "
+                            + configuration.getTargetServerConfig()
+                            + " is not writable and existing file. [targetserverConfig]"
+                            + "must be either absolute path or relative to [jbossHome]");
+        }
+
+        if (new File(configuration.getSourceServerConfig()).isAbsolute()) {
+            sourceServerConfigBackupAbsolute = new File(configuration.getSourceServerConfig());
+        } else {
+            sourceServerConfigBackupAbsolute = new File(jbossHome, configuration.getSourceServerConfig());
+        }
+        if (!(sourceServerConfigBackupAbsolute.getParentFile().exists()
+                && targetServerConfigAbsolute.getParentFile().isDirectory() && targetServerConfigAbsolute
+                .getParentFile().canWrite())) {
+            throw new ExtensionDeploymentException(
+                    "sourceServerConfig = "
+                            + configuration.getSourceServerConfig()
+                            + " 's parent directory does not exist or is writable."
+                            + "[sourceServerConfig] must be either absolute path or relative to [jbossHome]");
+        }
+        String modulesHome = configuration.getModulesHome();
+
+        if (configuration.getModulesHome() == null) {
+            // auto-detect modulesHome
+            File wfHome = Paths.get(jbossHome.getAbsolutePath(), "modules", "system", "layers", "base").toFile();
+            if (!wfHome.exists()) {
+                wfHome = Paths.get(jbossHome.getAbsolutePath(),"modules").toFile();
+            }
+            modulesHomeAbsolute = wfHome;
+        }
+
+        if (!(modulesHomeAbsolute.exists() && modulesHomeAbsolute.isDirectory() && modulesHomeAbsolute.canWrite())) {
+            throw new ExtensionDeploymentException(
+                    "modulesHome = "
+                            + modulesHome
+                            + " is not writable and existing directory. [modulesHome]"
+                            + "must be either absolute path or relative to [jbossHome]");
+        }
+    }
+}

--- a/wildfly-module-installer/src/main/java/org/hawkular/wildfly/module/installer/ExtensionDeploymentException.java
+++ b/wildfly-module-installer/src/main/java/org/hawkular/wildfly/module/installer/ExtensionDeploymentException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.wildfly.module.installer;
+
+public class ExtensionDeploymentException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    public ExtensionDeploymentException(String message) {
+        super(message);
+    }
+
+    public ExtensionDeploymentException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/wildfly-module-installer/src/main/java/org/hawkular/wildfly/module/installer/JBossModule.java
+++ b/wildfly-module-installer/src/main/java/org/hawkular/wildfly/module/installer/JBossModule.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.wildfly.module.installer;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.jboss.logging.Logger;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+
+class JBossModule {
+
+    private final Logger log = Logger.getLogger(this.getClass());
+    private URL root;
+    private String moduleId;
+    private List<String> resources = new ArrayList<String>();
+
+    private JBossModule() {
+    }
+
+    public String getModuleId() {
+        return moduleId;
+    }
+
+    public static JBossModule readFromURL(URL moduleZip) throws Exception {
+        JBossModule m = new JBossModule();
+        m.root = moduleZip;
+
+        ZipInputStream zin = null;
+        BufferedInputStream bin = null;
+        boolean moduleXmlFound = false;
+        try {
+            bin = new BufferedInputStream(moduleZip.openStream());
+            zin = new ZipInputStream(bin);
+            ZipEntry ze = null;
+            while ((ze = zin.getNextEntry()) != null) {
+                if (ze.getName().endsWith("main/module.xml")) {
+                    moduleXmlFound = true;
+                    DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+                    DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+                    Document doc = dBuilder.parse(zin);
+                    m.readModuleXmlInfo(doc);
+                    break;
+                }
+            }
+        } finally {
+            try {
+                // it should be enough to close the latest created stream in
+                // case of chained (nested) streams, @see
+                // http://www.javapractices.com/topic/TopicAction.do?Id=8
+                if (zin != null) {
+                    zin.close();
+                }
+            } catch (IOException ex) {
+            }
+        }
+        if (!moduleXmlFound) {
+            throw new FileNotFoundException("module.xml was not found in " + moduleZip);
+        }
+        return m;
+    }
+
+    private void readModuleXmlInfo(Document doc) throws Exception {
+        this.moduleId = doc.getDocumentElement().getAttribute("name");
+        XPath xPath = XPathFactory.newInstance().newXPath();
+        NodeList nodeList = (NodeList) xPath.compile("//resources/resource-root")
+                .evaluate(doc, XPathConstants.NODESET);
+        for (int i = 0; i < nodeList.getLength(); i++) {
+            this.resources.add(nodeList.item(i).getAttributes().getNamedItem("path").getTextContent());
+        }
+    }
+
+    /**
+     * uninstall (delete) JBossModule from given directory
+     * @param modulesHome target directory
+     */
+    public void uninstallFrom(File modulesHome) throws Exception {
+        log.info("Uninstalling module [" + this.root+ "] from [" + modulesHome.getAbsolutePath() + "]");
+        ZipInputStream zin = null;
+        try {
+            zin = new ZipInputStream(this.root.openStream());
+            ZipEntry ze = null;
+            while ((ze = zin.getNextEntry()) != null) {
+                String fileName = ze.getName();
+                File newFile = new File(modulesHome + File.separator + fileName);
+                if (!ze.isDirectory()) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Deleting "+newFile.getAbsolutePath());
+                    }
+                    FileUtils.deleteQuietly(newFile);
+                }
+            }
+        } finally {
+            try {
+                // it should be enough to close the latest created stream in
+                // case of chained (nested) streams, @see
+                // http://www.javapractices.com/topic/TopicAction.do?Id=8
+                if (zin != null) {
+                    zin.close();
+                }
+            } catch (IOException ex) {
+            }
+        }
+    }
+
+    /**
+     * installs JBossModule to given directory
+     * @param modulesHome
+     *            target directory to install module
+     * @return list of installed files
+     * @throws Exception
+     */
+    public List<File> installTo(File modulesHome) throws Exception {
+        List<File> installedFiles = new ArrayList<File>();
+
+        ZipInputStream zin = null;
+        FileOutputStream fos;
+        log.info("Extracting module [" + this.root+ "] to [" + modulesHome.getAbsolutePath() + "]");
+        try {
+            zin = new ZipInputStream(this.root.openStream());
+            ZipEntry ze = null;
+            while ((ze = zin.getNextEntry()) != null) {
+                String fileName = ze.getName();
+                File newFile = new File(modulesHome + File.separator + fileName);
+                if (!ze.isDirectory()) {
+                    log.debug("Writing " + newFile.getAbsolutePath());
+                    File parent = newFile.getParentFile();
+                    if (!parent.exists()) {
+                        parent.mkdirs();
+                    }
+                    fos = new FileOutputStream(newFile);
+
+                    IOUtils.copy(zin, fos);
+                    IOUtils.closeQuietly(fos);
+                    installedFiles.add(newFile);
+                }
+            }
+        } finally {
+            try {
+                // it should be enough to close the latest created stream in
+                // case of chained (nested) streams, @see
+                // http://www.javapractices.com/topic/TopicAction.do?Id=8
+                if (zin != null) {
+                    zin.close();
+                }
+            } catch (IOException ex) {
+            }
+        }
+
+        return installedFiles;
+    }
+
+}

--- a/wildfly-module-installer/src/main/java/org/hawkular/wildfly/module/installer/NamespaceContextImpl.java
+++ b/wildfly-module-installer/src/main/java/org/hawkular/wildfly/module/installer/NamespaceContextImpl.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.wildfly.module.installer;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import javax.xml.namespace.NamespaceContext;
+
+class NamespaceContextImpl implements NamespaceContext {
+
+    private final Map<String, String> mapping = new HashMap<String, String>();
+
+    public NamespaceContextImpl mapping(String prefix, String namespaceURI) {
+        mapping.put(prefix, namespaceURI);
+        return this;
+    }
+
+    public String getNamespaceURI(String prefix) {
+        return mapping.get(prefix);
+    }
+
+    public String getPrefix(String namespaceURI) {
+        return null;
+    }
+
+    public Iterator getPrefixes(String namespaceURI) {
+        return null;
+    }
+
+}

--- a/wildfly-module-installer/src/main/java/org/hawkular/wildfly/module/installer/RegisterExtension.java
+++ b/wildfly-module-installer/src/main/java/org/hawkular/wildfly/module/installer/RegisterExtension.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.wildfly.module.installer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.logging.Logger;
+
+class RegisterExtension {
+
+    private final Logger log = Logger.getLogger(this.getClass());
+
+    public RegisterExtension() {
+    }
+
+    /**
+     * registers extension to standalone.xml or domain.xml
+     * @param options
+     * @throws Exception
+     */
+    public void register(RegisterModuleConfiguration options) throws Exception {
+        if (options.isDomain()) {
+            registerToDomain(options);
+        } else {
+            registerToStandalone(options);
+        }
+
+        log.info("New serverConfig file written to [" + options.getTargetServerConfig().getAbsolutePath() + "]");
+    }
+
+    private void registerToStandalone(RegisterModuleConfiguration options) throws Exception {
+        List<XmlEdit> inserts = new ArrayList<XmlEdit>();
+        inserts.addAll(options.getXmlEdits());
+        if (options.getModuleId() != null) {
+            log.info("Register extension module=" + options.getModuleId());
+            inserts.add(new XmlEdit("/server/extensions", "<extension module=\"" + options.getModuleId() + "\"/>"));
+        }
+
+        if (options.getSubsystem() != null) {
+            inserts.add(new XmlEdit("/server/profile", options.getSubsystem()));
+        }
+        if (options.getSocketBindingGroups() != null && options.getSocketBinding() != null) {
+            for (String group : options.getSocketBindingGroups()) {
+                inserts.add(new XmlEdit("/server/socket-binding-group[@name='" + group + "']", options
+                        .getSocketBinding()).withAttribute("name"));
+            }
+        }
+        new XmlConfigBuilder(options.getSourceServerConfig(), options.getTargetServerConfig())
+                .edits(inserts)
+                .failNoMatch(options.isFailNoMatch()).build();
+    }
+
+    private void registerToDomain(RegisterModuleConfiguration options) throws Exception {
+        List<XmlEdit> inserts = new ArrayList<XmlEdit>();
+        inserts.addAll(options.getXmlEdits());
+        if (options.getModuleId() != null) {
+            log.info("Register extension module=" + options.getModuleId());
+            inserts.add(new XmlEdit("/domain/extensions", "<extension module=\"" + options.getModuleId() + "\"/>"));
+        }
+
+        if (options.getSubsystem() != null) {
+            for (String profile : options.getProfiles()) {
+                inserts.add(new XmlEdit("/domain/profiles/profile[@name='"+profile+"']", options.getSubsystem()));
+            }
+        }
+        if (options.getSocketBindingGroups() != null && options.getSocketBinding() != null) {
+            for (String group : options.getSocketBindingGroups()) {
+                inserts.add(new XmlEdit("/domain/socket-binding-group[@name='" + group + "']", options
+                        .getSocketBinding()).withAttribute("name"));
+            }
+        }
+        new XmlConfigBuilder(options.getSourceServerConfig(), options.getTargetServerConfig())
+                .edits(inserts)
+                .failNoMatch(options.isFailNoMatch()).build();
+    }
+
+}

--- a/wildfly-module-installer/src/main/java/org/hawkular/wildfly/module/installer/RegisterModuleConfiguration.java
+++ b/wildfly-module-installer/src/main/java/org/hawkular/wildfly/module/installer/RegisterModuleConfiguration.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.wildfly.module.installer;
+
+import java.io.File;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * this class holds all inputs for changes to be made in standalone.xml or domain.xml
+ * @author lzoubek
+ */
+class RegisterModuleConfiguration {
+
+    private File targetServerConfig;
+    private File sourceServerConfig;
+    private URL subsystem;
+    private URL socketBinding;
+    private Set<String> socketBindingGroups;
+    private List<XmlEdit> xmlEdits;
+    private String moduleId;
+    private boolean domain;
+    private Set<String> profiles;
+    private boolean failNoMatch;
+
+    public RegisterModuleConfiguration() {
+
+    }
+
+    @Override
+    public String toString() {
+        return new StringBuilder("RegisterOptions: [")
+                .append("\n  serverConfig = " + targetServerConfig)
+                .append("\n  serverConfigBackup = " + sourceServerConfig)
+                .append("\n  moduleId = " + moduleId)
+                .append("\n  subsystem = " + subsystem)
+                .append("\n  socket-binding = " + socketBinding)
+                .append("\n  socketBindingGroups = " + (socketBindingGroups == null? "null" :
+                    Arrays.toString(socketBindingGroups.toArray())))
+                .append("\n  edit = " + (xmlEdits == null ? "null" : Arrays.toString(xmlEdits.toArray())))
+                .append("\n  failNoMatch = " + failNoMatch)
+                .append("\n]")
+                .toString();
+    }
+
+    /**
+     * merge data from another instance to this instance, but do not overwrite non-null values with null values
+     * @param configuration another instance
+     * @return
+     */
+    public RegisterModuleConfiguration extend(RegisterModuleConfiguration configuration) {
+        this.targetServerConfig = configuration.targetServerConfig == null ? this.targetServerConfig
+                : configuration.targetServerConfig;
+        this.sourceServerConfig = configuration.sourceServerConfig == null ? this.sourceServerConfig
+                : configuration.sourceServerConfig;
+        this.subsystem = configuration.subsystem == null ? this.subsystem : configuration.subsystem;
+        this.socketBinding = configuration.socketBinding == null ? this.socketBinding : configuration.socketBinding;
+        this.socketBindingGroups = configuration.socketBindingGroups == null ? this.socketBindingGroups
+                : configuration.socketBindingGroups;
+        this.xmlEdits = configuration.xmlEdits == null ? this.xmlEdits : configuration.xmlEdits;
+        this.moduleId = configuration.moduleId == null ? this.moduleId : configuration.moduleId;
+        this.failNoMatch = configuration.failNoMatch;
+        this.domain = configuration.domain;
+        this.profiles = configuration.profiles == null ? this.profiles : configuration.profiles;
+        return this;
+    }
+
+    public RegisterModuleConfiguration failNoMatch(boolean failNoMatch) {
+        this.failNoMatch = failNoMatch;
+        return this;
+    }
+
+    public RegisterModuleConfiguration withExtension(String moduleId) {
+        this.moduleId = moduleId;
+        return this;
+    }
+
+    public RegisterModuleConfiguration sourceServerConfig(File sourceServerConfig) {
+        this.sourceServerConfig = sourceServerConfig;
+        return this;
+    }
+
+    public RegisterModuleConfiguration targetServerConfig(File targetServerConfig) {
+        this.targetServerConfig = targetServerConfig;
+        return this;
+    }
+
+    public RegisterModuleConfiguration subsystem(URL subsystem) {
+        this.subsystem = subsystem;
+        return this;
+    }
+
+    public RegisterModuleConfiguration socketBinding(URL socketBinding) {
+        this.socketBinding = socketBinding;
+        return this;
+    }
+
+    public RegisterModuleConfiguration socketBindingGroups(Set<String> socketBindingGroups) {
+        this.socketBindingGroups = socketBindingGroups;
+        return this;
+    }
+
+    public RegisterModuleConfiguration xmlEdits(List<XmlEdit> inserts) {
+        this.xmlEdits = inserts;
+        return this;
+    }
+
+    public RegisterModuleConfiguration domain(boolean domain) {
+        this.domain = domain;
+        return this;
+    }
+
+    public RegisterModuleConfiguration profiles(Set<String> profiles) {
+        this.profiles = profiles;
+        return this;
+    }
+
+    public List<XmlEdit> getXmlEdits() {
+        if (xmlEdits == null) {
+            xmlEdits = new ArrayList<>();
+        }
+        return xmlEdits;
+    }
+
+    public File getTargetServerConfig() {
+        return targetServerConfig;
+    }
+
+    public URL getSocketBinding() {
+        return socketBinding;
+    }
+
+    public URL getSubsystem() {
+        return subsystem;
+    }
+
+    public Set<String> getSocketBindingGroups() {
+        return socketBindingGroups;
+    }
+
+    public String getModuleId() {
+        return moduleId;
+    }
+
+    public File getSourceServerConfig() {
+        return sourceServerConfig;
+    }
+
+    public boolean isFailNoMatch() {
+        return failNoMatch;
+    }
+
+    public boolean isDomain() {
+        return domain;
+    }
+
+    public Set<String> getProfiles() {
+        if (profiles == null) {
+            profiles = new HashSet<>();
+        }
+        return profiles;
+    }
+
+}

--- a/wildfly-module-installer/src/main/java/org/hawkular/wildfly/module/installer/XmlConfigBuilder.java
+++ b/wildfly-module-installer/src/main/java/org/hawkular/wildfly/module/installer/XmlConfigBuilder.java
@@ -1,0 +1,404 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.wildfly.module.installer;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+
+import org.jboss.logging.Logger;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+class XmlConfigBuilder {
+
+    private static final String PREFIX = "x";
+    private static final String PREFIX_CONTENT = "ns";
+    private static final Pattern NS_IN_XPATH = Pattern.compile("namespace-uri\\(\\)[^\']+\'([^\']+)");
+    private List<XmlEdit> edits;
+    private boolean failNoMatch;
+    private final File targetFile;
+    private final File sourceFile;
+    final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    final XPath xpath = XPathFactory.newInstance().newXPath();
+    final NamespaceContextImpl namespaceContext = new NamespaceContextImpl();
+    private final Logger log = Logger.getLogger(this.getClass());
+
+    public XmlConfigBuilder(File sourceFile, File targetFile) {
+        factory.setNamespaceAware(true);
+        xpath.setNamespaceContext(namespaceContext);
+        this.sourceFile = sourceFile;
+        this.targetFile = targetFile;
+    }
+
+    public File getSourceFile() {
+        return sourceFile;
+    }
+
+    public File getTargetFile() {
+        return targetFile;
+    }
+
+    private void debug(String message) {
+        if (log.isDebugEnabled()) {
+            log.debug(message);
+        }
+    }
+
+    private void warning(String message) {
+        log.warn(message);
+    }
+
+    public void build() throws Exception {
+        DocumentBuilder dBuilder = factory.newDocumentBuilder();
+        Document srcDoc = dBuilder.parse(sourceFile);
+
+        // sort inserts by the shortest
+        Collections.sort(getXmlEdits(), new Comparator<XmlEdit>() {
+
+            public int compare(XmlEdit o1, XmlEdit o2) {
+                Integer o1Size = o1.getSelect().split("/").length;
+                Integer o2Size = o2.getSelect().split("/").length;
+                return o1Size.compareTo(o2Size);
+            }
+        });
+        debug("Building [" + this.sourceFile + "] ");
+        // if our target document defines namespace in root element, let's read
+        // it
+        String namespace = getNameSpace(srcDoc);
+        if (namespace != null) {
+            namespaceContext.mapping(PREFIX, namespace);
+        }
+
+        for (XmlEdit xmlEdit : getXmlEdits()) {
+            debug("Applying " + xmlEdit);
+            String expression = xmlEdit.getSelect();
+
+            if (namespace != null) {
+                // enhance given xpath to use namespaces
+                expression = xpath2Namespaced(expression, PREFIX);
+                debug("Expression " + expression);
+            }
+            XPathExpression expr = xpath.compile(expression);
+            try {
+                NodeList nl = (NodeList) expr.evaluate(srcDoc, XPathConstants.NODESET);
+                if (nl.getLength() == 0) {
+                    if (failNoMatch) {
+                        throw new Exception("Failed to update [" + targetFile.getAbsolutePath() + "] " + xmlEdit
+                                + " does not select any element");
+                    }
+                    warning(xmlEdit + " does not select any element");
+                    continue;
+                }
+                debug("Expression evaluated to " + nl.getLength() + " nodes");
+                Document contentDoc = null;
+                if (xmlEdit.getContent() != null) {
+                    debug("Loading content XML from file " + xmlEdit.getContent());
+                    contentDoc = dBuilder.parse(xmlEdit.getContent().openStream());
+                } else {
+                    debug("Loading content XML from string");
+                    contentDoc = dBuilder.parse(new ByteArrayInputStream(xmlEdit.getXml().getBytes()));
+                }
+
+                for (int i = 0; i < nl.getLength(); i++) {
+                    Node node = nl.item(i);
+                    if (node instanceof Element) {
+                        Element element = (Element) node;
+                        Node inserting = contentDoc.getDocumentElement().cloneNode(true);
+                        srcDoc.adoptNode(inserting);
+                        String recentNs = findRecentNamespaceFromXpath(expression);
+                        // is the root node of inserting content already
+                        // present?
+
+                        XPathExpression contentExpr = createContentRootExpression(contentDoc, recentNs, namespace,
+                                xmlEdit.getAttribute());
+                        NodeList existingNodes = (NodeList) contentExpr.evaluate(element, XPathConstants.NODESET);
+                        if (existingNodes.getLength() > 0) {
+                            // we need to remove those? (could be many)
+                            // we'll replace the last guy
+                            element.replaceChild(inserting, existingNodes.item(existingNodes.getLength() - 1));
+                        } else {
+                            element.appendChild(inserting);
+                        }
+
+                        String contentNs = getNameSpace(contentDoc);
+                        // find most recent NS from inserted node back to root
+                        // node and assign to it
+                        recentNs = findRecentNamespace(srcDoc, inserting);
+                        if (contentNs == null && recentNs != null) {
+                            // content document does not have namespace, let's
+                            // rename it to our namespace
+                            renameNamespaceRecursive(srcDoc, inserting, recentNs);
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+        writeTargetDcoument(srcDoc);
+    }
+
+    /**
+     * looks for most recent namespace query in xpath (denoted by namespace-uri()='')
+     * @param expression
+     * @return
+     */
+    public static String findRecentNamespaceFromXpath(String expression) {
+        Matcher m = NS_IN_XPATH.matcher(expression);
+        String ns = null;
+        while (m.find()) {
+            ns = m.group(1);
+        }
+        return ns;
+    }
+
+    private String findRecentNamespace(Document doc, Node node) {
+        Node parent = null;
+        while ((parent = node.getParentNode()) != null) {
+            Element parentEl = (Element) parent;
+            String ns = parentEl.getAttribute("xmlns");
+            if (!ns.isEmpty()) {
+                return ns;
+            }
+            if (parent.isSameNode(doc.getDocumentElement())) {
+                return null;
+            }
+            if (parent.isEqualNode(node)) {
+                return null;
+            }
+            node = parent;
+        }
+        return null;
+    }
+
+    private void writeTargetDcoument(Document doc) throws Exception {
+        debug("Writing target file..");
+        TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        Transformer transformer = transformerFactory.newTransformer();
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+        transformer.setOutputProperty(OutputKeys.METHOD, "xml");
+        transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
+
+        // remove empty/text nodes in order to "properly" format it
+        XPathExpression xpathExp = xpath.compile(
+                "//text()[normalize-space(.) = '']");
+            NodeList emptyTextNodes = (NodeList) xpathExp.evaluate(doc, XPathConstants.NODESET);
+
+            // Remove each empty text node from document.
+            for (int i = 0; i < emptyTextNodes.getLength(); i++) {
+                Node emptyTextNode = emptyTextNodes.item(i);
+                emptyTextNode.getParentNode().removeChild(emptyTextNode);
+            }
+
+        DOMSource source = new DOMSource(doc);
+        StreamResult result = new StreamResult(targetFile);
+
+        transformer.transform(source, result);
+    }
+
+    public static String xpath2Namespaced(String expression, String prefix) {
+        String[] components = expression.split("/");
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < components.length; i++) {
+            String piece = components[i];
+            if (piece.matches("^\\w+.*")) {
+                piece = prefix + ":" + piece;
+            }
+            sb.append(piece + "/");
+        }
+        if (sb.length() > 0) {
+            sb.deleteCharAt(sb.length() - 1);
+        }
+        return sb.toString();
+    }
+
+    public static String element2Xpath(Element element, String prefix, String defaultPrefix) {
+        return element2Xpath(element, prefix, defaultPrefix, null);
+    }
+
+    public static String element2Xpath(Element element, String prefix, String defaultPrefix, String identityAttribute) {
+        StringBuilder sb = new StringBuilder("/");
+        String ns = element.getAttribute("xmlns");
+        String pref = "";
+        if (!ns.isEmpty()) {
+            pref = prefix + ":";
+        } else if (defaultPrefix != null) {
+            pref = defaultPrefix + ":";
+        }
+        sb.append(pref + element.getLocalName());
+        if (identityAttribute != null && !identityAttribute.isEmpty()) {
+            sb.append("[@" + identityAttribute + "='" + element.getAttribute(identityAttribute) + "']");
+        } else {
+            // use all attributes
+            NamedNodeMap attributes = element.getAttributes();
+            if (attributes.getLength() > 0) {
+                StringBuilder sbAttributes = new StringBuilder();
+                sbAttributes.append("[");
+                int validAttributes = 0;
+                for (int i = 0; i < attributes.getLength(); i++) {
+                    Node node = attributes.item(i);
+                    if ("xmlns".equals(node.getNodeName())) {
+                        // ignore this guy as it's handled with prefixing
+                        continue;
+                    }
+                    validAttributes++;
+                    sbAttributes.append("@" + node.getNodeName() + "='" + node.getNodeValue() + "' and ");
+                }
+                if (validAttributes > 0) {
+                    sbAttributes.delete(sbAttributes.length() - 5, sbAttributes.length()); // delete
+                                                                                           // last
+                                                                                           // '
+                                                                                           // and
+                                                                                           // '
+                    sbAttributes.append("]");
+                    sb.append(sbAttributes.toString());
+                }
+            }
+        }
+
+        return sb.toString();
+    }
+
+    private XPathExpression createContentRootExpression(Document contentDoc, String contentNamespace,
+            String rootNamespace, String identityAttribute)
+            throws Exception {
+        String expression = null;
+
+        if (contentNamespace != null) {
+            expression = element2Xpath(contentDoc.getDocumentElement(), PREFIX_CONTENT, PREFIX_CONTENT,
+                    identityAttribute);
+            namespaceContext.mapping(PREFIX_CONTENT, contentNamespace);
+        } else {
+            String ns = getNameSpace(contentDoc);
+            if (ns != null) {
+                expression = element2Xpath(contentDoc.getDocumentElement(), PREFIX_CONTENT, null, identityAttribute);
+                namespaceContext.mapping(PREFIX_CONTENT, ns);
+            } else {
+                expression = element2Xpath(contentDoc.getDocumentElement(), PREFIX_CONTENT,
+                        rootNamespace == null ? null : PREFIX, identityAttribute);
+            }
+        }
+
+        debug("Content expression " + expression);
+        // our expression always starts with /, but we'll be evaluating it in
+        // context of some other node, thus it needs to be relative
+        return xpath.compile(expression.substring(1));
+    }
+
+    public XmlConfigBuilder failNoMatch(boolean failNoMatch) throws Exception {
+        this.failNoMatch = failNoMatch;
+        return this;
+    }
+
+    public XmlConfigBuilder edit(XmlEdit insert) throws Exception {
+        validateInsert(insert);
+        getXmlEdits().add(insert);
+        return this;
+    }
+
+    public XmlConfigBuilder edits(List<XmlEdit> inserts) throws Exception {
+        for (XmlEdit i : inserts) {
+            validateInsert(i);
+            getXmlEdits().add(i);
+        }
+        return this;
+    }
+
+    private List<XmlEdit> getXmlEdits() {
+        if (edits == null) {
+            edits = new ArrayList<XmlEdit>();
+        }
+        return edits;
+    }
+
+    private void validateInsert(XmlEdit insert) throws IllegalArgumentException, XPathExpressionException {
+        URL f = insert.getContent();
+        if (f == null && insert.getXml() == null) {
+            throw new IllegalArgumentException("Either content or xml must be specified");
+        }
+        String expression = insert.getSelect();
+        if (expression.length() > 1 && expression.endsWith("/")) { // remove
+                                                                   // trailing
+                                                                   // slash
+            insert.setSelect(expression.substring(0, expression.length() - 1));
+        }
+        try {
+            xpath.compile(insert.getSelect());
+        } catch (XPathExpressionException xee) {
+            throw new XPathExpressionException(insert.getSelect() + " is not a valid xpath : " + xee.getMessage());
+        }
+
+        // TODO validate expression must eval to NODELIST
+    }
+
+    /**
+     * return XML namespace for root of given document
+     * @param doc
+     * @return null if namespace is not defined
+     */
+    private static String getNameSpace(Document doc) {
+        if (doc == null) {
+            return null;
+        }
+        String ns = doc.getDocumentElement().getAttribute("xmlns");
+        if (ns.isEmpty()) {
+            return null;
+        }
+        return ns;
+    }
+
+    private static void renameNamespaceRecursive(Document doc, Node node, String namespace) {
+        if (node.getNodeType() == Node.ELEMENT_NODE) {
+            Element el = (Element) node;
+            if (el.getAttribute("xmlns").isEmpty()) {
+                doc.renameNode(node, namespace, node.getNodeName());
+            } else {
+                return; // stop renaming ns here, since all children of this
+                        // node belong to it's ns
+            }
+
+        }
+
+        NodeList list = node.getChildNodes();
+        for (int i = 0; i < list.getLength(); ++i) {
+            renameNamespaceRecursive(doc, list.item(i), namespace);
+        }
+    }
+}

--- a/wildfly-module-installer/src/main/java/org/hawkular/wildfly/module/installer/XmlEdit.java
+++ b/wildfly-module-installer/src/main/java/org/hawkular/wildfly/module/installer/XmlEdit.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.wildfly.module.installer;
+
+import java.net.URL;
+
+/**
+ * An insert item represents 1 edit action to be performed on target XML document.
+ * Each 'insert' has {@link #select} attribute. Which denotes location
+ * of content you wish to insert/replace. Then it must set either {@link #content} - path
+ * to location of another XML file that will appear as a child
+ * of elements evaluated by {@link #select} expression or {@link #xml} - which denotes
+ * XML content as String. Optionally, {@link attribute} can be
+ * defined to identify inserted/replaced content. If {@link attribute} is not defined,
+ * content (defined either via {@link #xml} or {@link content}) is
+ * loaded and xpath expression is created from root element's attributes and their values,
+ * otherwise {@link attribute} is taken as the only one for
+ * xpath expression.
+ *
+ * @author lzoubek@redhat.com
+ *
+ */
+public class XmlEdit {
+
+    private String select;
+    private URL content;
+    private String xml;
+    private String attribute;
+
+    public XmlEdit() {
+
+    }
+
+    public XmlEdit(String select, String xml) {
+        this.select = select;
+        this.xml = xml;
+    }
+
+    public XmlEdit(String select, URL content) {
+        this.select = select;
+        this.content = content;
+    }
+
+    public XmlEdit withAttribute(String attribute) {
+        this.attribute = attribute;
+        return this;
+    }
+
+    public String getAttribute() {
+        return attribute;
+    }
+
+    public void setAttribute(String attribute) {
+        this.attribute = attribute;
+    }
+
+    public void setXml(String xml) {
+        this.xml = xml;
+    }
+
+    public String getXml() {
+        return xml;
+    }
+
+    public String getSelect() {
+        return select;
+    }
+
+    public void setSelect(String select) {
+        this.select = select;
+    }
+
+    public URL getContent() {
+        return content;
+    }
+
+    public void setContent(URL content) {
+        this.content = content;
+    }
+
+    @Override
+    public String toString() {
+        return new StringBuilder(getClass().getName()+"[").append("select=" + this.select)
+                .append(content == null ? "" : " content=" + content)
+                .append(attribute == null ? "" : " attribute=" + attribute)
+                .append(xml == null ? "" : " xml=" + this.xml).append("]").toString();
+    }
+
+}

--- a/wildfly-module-installer/src/test/java/org/hawkular/wildfly/module/installer/ExtensionDeployerTest.java
+++ b/wildfly-module-installer/src/test/java/org/hawkular/wildfly/module/installer/ExtensionDeployerTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.wildfly.module.installer;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathFactory;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+
+public class ExtensionDeployerTest {
+
+    static final File widlflyHome = Paths.get("target","fake-wildfly").toFile();
+    static final File standaloneXml = Paths.get(widlflyHome.getAbsolutePath(),"standalone",
+            "configuration","standalone.xml").toFile();
+
+    static final File domainXml = Paths.get(widlflyHome.getAbsolutePath(),"domain",
+            "configuration","domain.xml").toFile();
+
+    static final File modulesHome = Paths.get(widlflyHome.getAbsolutePath(), "modules",
+            "system", "layers","base").toFile();
+    private File moduleZip = Paths.get("target","test-module.zip").toFile();
+
+    final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    DocumentBuilder dBuilder;
+    final XPath xpath = XPathFactory.newInstance().newXPath();
+
+    public ExtensionDeployerTest() {
+        try {
+            factory.setNamespaceAware(true);
+            dBuilder = factory.newDocumentBuilder();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static File getResourceFile(String name) {
+        return new File("src/test/resources/" + name);
+    }
+
+    private void createModuleZip(String... resources) throws Exception {
+        FileOutputStream fout = new FileOutputStream(moduleZip);
+        ZipOutputStream zout = new ZipOutputStream(fout);
+        // nest to some subdir
+        for (String res : resources)
+        {
+            ZipEntry ze = new ZipEntry("fake-module/main/"+res);
+            zout.putNextEntry(ze);
+            zout.write(IOUtils.toByteArray(getClass().getResourceAsStream("/module/"+res)));
+            zout.closeEntry();
+        }
+        zout.close();
+
+    }
+
+    @BeforeClass
+    public static void prepareTargetWildfly() throws Exception {
+        modulesHome.mkdirs();
+        standaloneXml.getParentFile().mkdirs();
+        domainXml.getParentFile().mkdirs();
+    }
+
+    @Before
+    public void beforeTest() throws IOException {
+        if (moduleZip != null) {
+            moduleZip.delete();
+        }
+        // clean up deployed module in fake wildfly
+        FileUtils.deleteDirectory(new File(modulesHome, "fake-module"));
+        // copy minimal configs
+        FileUtils.copyFile(getResourceFile("standalone-minimal.xml"), standaloneXml);
+        FileUtils.copyFile(getResourceFile("domain-minimal.xml"), domainXml);
+    }
+
+    @Test
+    public void deployEmptyModule() throws Exception {
+        createModuleZip("module.xml");
+        DeploymentConfiguration configuration = DeploymentConfiguration.builder()
+                .jbossHome(widlflyHome)
+                .module(moduleZip.toURI().toURL())
+                .build();
+        new ExtensionDeployer().install(configuration);
+        File deployedModuleXml = Paths.get(modulesHome.getAbsolutePath(),"fake-module","main","module.xml").toFile();
+        Assert.assertTrue("Deployed module.xml exists", deployedModuleXml.exists());
+    }
+
+    @Test
+    public void deployModuleWithSnippetsIncluded() throws Exception {
+        createModuleZip("module.xml", "subsystem-snippet.xml","socket-binding-snippet.xml");
+        DeploymentConfiguration configuration = DeploymentConfiguration.builder()
+                .jbossHome(widlflyHome)
+                .module(moduleZip.toURI().toURL())
+                .build();
+        new ExtensionDeployer().install(configuration);
+        File deployedModuleXml = Paths.get(modulesHome.getAbsolutePath(),"fake-module","main","module.xml").toFile();
+        Assert.assertTrue("Deployed module.xml exists", deployedModuleXml.exists());
+        Document doc = dBuilder.parse(standaloneXml);
+        String xmlns = doc.getDocumentElement().getAttribute("xmlns");
+        xpath.setNamespaceContext(new NamespaceContextImpl().mapping("x", xmlns).mapping("foo", "foo"));
+
+        // verify extension was installed
+        assertXpath("/x:server/x:extensions/x:extension[@module='org.hawkular.agent.monitor']", doc, 1);
+        // verify subsystem is defined, in module.xml we have "org.hawkular.agent.monitor"
+        assertXpath("/x:server/x:profile/foo:subsystem", doc, 1);
+        // verify socket binding was installed
+        assertXpath("/x:server/x:socket-binding-group[@name='standard-sockets']"
+                + "/x:outbound-socket-binding[@name='hawkular']", doc, 1);
+    }
+
+    @Test
+    public void deployModuleWithDefaultSocketBinding() throws Exception {
+        createModuleZip("module.xml");
+
+        DeploymentConfiguration configuration = DeploymentConfiguration.builder()
+                .jbossHome(widlflyHome)
+                .module(moduleZip.toURI().toURL())
+                .socketBinding(getClass().getResource("/module/socket-binding-snippet.xml"))
+                .build();
+        new ExtensionDeployer().install(configuration);
+        File deployedModuleXml = Paths.get(modulesHome.getAbsolutePath(),"fake-module","main","module.xml").toFile();
+        Assert.assertTrue("Deployed module.xml exists", deployedModuleXml.exists());
+        Document doc = dBuilder.parse(standaloneXml);
+        String xmlns = doc.getDocumentElement().getAttribute("xmlns");
+        xpath.setNamespaceContext(new NamespaceContextImpl().mapping("x", xmlns).mapping("foo", "foo"));
+
+        // verify extension was installed
+        assertXpath("/x:server/x:extensions/x:extension[@module='org.hawkular.agent.monitor']", doc, 1);
+        // verify socket binding was installed
+        assertXpath("/x:server/x:socket-binding-group[@name='standard-sockets']"
+                + "/x:outbound-socket-binding[@name='hawkular']", doc, 1);
+    }
+
+    @Test
+    public void deployToDomainDefaultProfile() throws Exception {
+        createModuleZip("module.xml", "subsystem-snippet.xml");
+        DeploymentConfiguration configuration = DeploymentConfiguration.builder()
+                .jbossHome(widlflyHome)
+                .module(moduleZip.toURI().toURL())
+                .domain(true)
+                .serverConfig("domain/configuration/domain.xml")
+                .build();
+        new ExtensionDeployer().install(configuration);
+        File deployedModuleXml = Paths.get(modulesHome.getAbsolutePath(),"fake-module","main","module.xml").toFile();
+        Assert.assertTrue("Deployed module.xml exists", deployedModuleXml.exists());
+
+        Document doc = dBuilder.parse(domainXml);
+        String xmlns = doc.getDocumentElement().getAttribute("xmlns");
+        xpath.setNamespaceContext(new NamespaceContextImpl().mapping("x", xmlns).mapping("foo", "foo"));
+
+        // verify extension was installed
+        assertXpath("/x:domain/x:extensions/x:extension[@module='org.hawkular.agent.monitor']", doc, 1);
+
+        // verify subsystem was setup in default profile only
+        assertXpath("/x:domain/x:profiles/x:profile[@name='default']/foo:subsystem", doc, 1);
+        assertXpath("/x:domain/x:profiles/x:profile[@name!='default']/foo:subsystem", doc, 0);
+    }
+
+    @Test
+    public void deployToDomain() throws Exception {
+        createModuleZip("module.xml", "subsystem-snippet.xml");
+        DeploymentConfiguration configuration = DeploymentConfiguration.builder()
+                .jbossHome(widlflyHome)
+                .module(moduleZip.toURI().toURL())
+                .domain(true)
+                .addProfile("ha")
+                .addProfile("full-ha")
+                .serverConfig("domain/configuration/domain.xml")
+                .build();
+        new ExtensionDeployer().install(configuration);
+        File deployedModuleXml = Paths.get(modulesHome.getAbsolutePath(),"fake-module","main","module.xml").toFile();
+        Assert.assertTrue("Deployed module.xml exists", deployedModuleXml.exists());
+
+        Document doc = dBuilder.parse(domainXml);
+        String xmlns = doc.getDocumentElement().getAttribute("xmlns");
+        xpath.setNamespaceContext(new NamespaceContextImpl().mapping("x", xmlns).mapping("foo", "foo"));
+
+        // verify extension was installed
+        assertXpath("/x:domain/x:extensions/x:extension[@module='org.hawkular.agent.monitor']", doc, 1);
+
+        // verify subsystem was setup in selected profiles
+        assertXpath("/x:domain/x:profiles/x:profile[@name='ha']/foo:subsystem", doc, 1);
+        assertXpath("/x:domain/x:profiles/x:profile[@name='full-ha']/foo:subsystem", doc, 1);
+        assertXpath("/x:domain/x:profiles/x:profile[@name!='full-ha' and @name!='ha']/foo:subsystem", doc, 0);
+    }
+
+    private void assertXpath(String expression, Document doc, int expectedCount) throws Exception {
+        XPathExpression expr = xpath.compile(expression);
+        NodeList nl = (NodeList) expr.evaluate(doc, XPathConstants.NODESET);
+        Assert.assertEquals(expectedCount, nl.getLength());
+    }
+}

--- a/wildfly-module-installer/src/test/java/org/hawkular/wildfly/module/installer/RegisterModuleConfigurationTest.java
+++ b/wildfly-module-installer/src/test/java/org/hawkular/wildfly/module/installer/RegisterModuleConfigurationTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.wildfly.module.installer;
+
+import java.io.File;
+import java.net.URL;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class RegisterModuleConfigurationTest {
+
+    @Test
+    public void textExtendWithNull() throws Exception {
+        URL subsystem = new File("foo").toURI().toURL();
+        RegisterModuleConfiguration o1 = new RegisterModuleConfiguration()
+            .subsystem(subsystem)
+            .socketBinding(subsystem);
+
+        RegisterModuleConfiguration o2 = new RegisterModuleConfiguration();
+        o1.extend(o2);
+        Assert.assertEquals(subsystem, o1.getSubsystem());
+        Assert.assertEquals(subsystem, o1.getSocketBinding());
+    }
+
+    @Test
+    public void testExtend() throws Exception {
+        URL subsystem = new File("foo").toURI().toURL();
+        RegisterModuleConfiguration o1 = new RegisterModuleConfiguration()
+            .subsystem(subsystem);
+
+        URL subsystem2 = new File("foo2").toURI().toURL();
+        RegisterModuleConfiguration o2 = new RegisterModuleConfiguration()
+            .subsystem(subsystem2);
+
+        o1.extend(o2);
+        Assert.assertEquals(subsystem2, o1.getSubsystem());
+    }
+}

--- a/wildfly-module-installer/src/test/java/org/hawkular/wildfly/module/installer/XmlConfigBuilderTest.java
+++ b/wildfly-module-installer/src/test/java/org/hawkular/wildfly/module/installer/XmlConfigBuilderTest.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.wildfly.module.installer;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.StringReader;
+import java.net.URL;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+public class XmlConfigBuilderTest {
+
+    final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    DocumentBuilder dBuilder;
+    final XPath xpath = XPathFactory.newInstance().newXPath();
+
+    public XmlConfigBuilderTest() {
+        try {
+            factory.setNamespaceAware(true);
+            dBuilder = factory.newDocumentBuilder();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void printTempFile() {
+        try {
+            System.out.println(IOUtils.toString(new FileReader(getTempFile())));
+        } catch (Exception e) {
+
+        }
+    }
+
+    private File getResourceFile(String name) {
+        return new File("src/test/resources/" + name);
+    }
+
+    private URL getResourceURL(String name) throws Exception {
+        return new File("src/test/resources/" + name).toURI().toURL();
+    }
+
+    private File getTempFile() {
+        return new File(System.getProperty("java.io.tmpdir"), "test.xml");
+    }
+
+    private Document xml(String xml) throws Exception {
+        InputSource is = new InputSource(new StringReader(xml));
+        return dBuilder.parse(is);
+    }
+
+    private void assertXpath(String expression, Document doc, int expectedCount) throws Exception {
+        XPathExpression expr = xpath.compile(expression);
+        NodeList nl = (NodeList) expr.evaluate(doc, XPathConstants.NODESET);
+        Assert.assertEquals(expectedCount, nl.getLength());
+    }
+
+    @Test
+    public void findNamespaceFromXpath() {
+        Assert.assertEquals("test", XmlConfigBuilder.findRecentNamespaceFromXpath("/*[namespace-uri()='test']/test"));
+        Assert.assertEquals("test", XmlConfigBuilder
+                .findRecentNamespaceFromXpath("/*[namespace-uri()='foo']/test/*[namespace-uri()='test']"));
+    }
+
+    @Test
+    public void testXpath2Namespaced() {
+        Assert.assertEquals("", XmlConfigBuilder.xpath2Namespaced("", ""));
+        Assert.assertEquals("x:test/x:test1", XmlConfigBuilder.xpath2Namespaced("test/test1", "x"));
+        Assert.assertEquals("/x:test[@a='x']/*[@b='y']",
+                XmlConfigBuilder.xpath2Namespaced("/test[@a='x']/*[@b='y']", "x"));
+    }
+
+    @Test
+    public void testElement2Xpath() throws Exception {
+        // element without ns
+        Assert.assertEquals("/test",
+                XmlConfigBuilder.element2Xpath(xml("<test></test>").getDocumentElement(), "x", null));
+        // element without ns default prefix passed
+        Assert.assertEquals("/y:test",
+                XmlConfigBuilder.element2Xpath(xml("<test></test>").getDocumentElement(), "x", "y"));
+        // element with ns
+        Assert.assertEquals("/x:test",
+                XmlConfigBuilder.element2Xpath(xml("<test xmlns=\"foo\"></test>").getDocumentElement(), "x", null));
+        // element with attributes
+        Assert.assertEquals("/test[@attr1='val1' and @attr2='val2']",
+                XmlConfigBuilder.element2Xpath(xml("<test attr1=\"val1\"  attr2=\"val2\"></test>")
+                        .getDocumentElement(), "x", null));
+        // element with ns and attributes
+        Assert.assertEquals("/x:test[@attr1='val1' and @attr2='val2']",
+                XmlConfigBuilder.element2Xpath(xml("<test attr1=\"val1\" xmlns=\"foo\"  attr2=\"val2\"></test>")
+                        .getDocumentElement(), "x", null));
+
+    }
+
+    @Test
+    public void testRootAppend() throws Exception {
+        XmlConfigBuilder builder = new XmlConfigBuilder(getResourceFile("root.xml"), getTempFile());
+        builder.edit(new XmlEdit("/server", getResourceURL("content1Append.xml")));
+        builder.build();
+        Document doc = dBuilder.parse(builder.getTargetFile());
+        assertXpath("/server/subsystem[@name='foobar']/child", doc, 2);
+        assertXpath("/server/subsystem[@name='foo']/child", doc, 1); // subsystem
+                                                                     // without
+                                                                     // with
+                                                                     // different
+                                                                     // name
+                                                                     // unchanged
+    }
+
+    @Test
+    public void testRootAppendKeepNestedNS() throws Exception {
+        XmlConfigBuilder builder = new XmlConfigBuilder(getResourceFile("root.xml"), getTempFile());
+        builder.edit(new XmlEdit("/server", getResourceURL("content1AppendNestedNS.xml")));
+        builder.build();
+        Document doc = dBuilder.parse(builder.getTargetFile());
+        xpath.setNamespaceContext(new NamespaceContextImpl().mapping("x", "keepme"));
+        assertXpath("/server/subsystem[@name='foobar']/child", doc, 2);
+        assertXpath("/server/subsystem[@name='foo']/child", doc, 1); // subsystem
+                                                                     // without
+                                                                     // with
+                                                                     // different
+                                                                     // name
+                                                                     // unchanged
+        assertXpath("/server/subsystem[@name='foobar']/x:child2/x:keepme", doc, 1); // verify
+                                                                                    // we
+                                                                                    // did
+                                                                                    // not
+                                                                                    // overwrite
+                                                                                    // nested
+                                                                                    // namespace
+    }
+
+    @Test
+    public void testRootReplace() throws Exception {
+        XmlConfigBuilder builder = new XmlConfigBuilder(getResourceFile("root.xml"), getTempFile());
+        builder.edit(new XmlEdit("/server", getResourceURL("content1Replace.xml")));
+        builder.build();
+        Document doc = dBuilder.parse(builder.getTargetFile());
+        assertXpath("/server/subsystem[@name='foo']/child", doc, 2); // subsystem
+                                                                     // modified
+    }
+
+    @Test
+    public void testNSRrootAppend() throws Exception {
+        XmlConfigBuilder builder = new XmlConfigBuilder(getResourceFile("rootNS.xml"), getTempFile());
+        builder.edit(new XmlEdit("/server", getResourceURL("content1Append.xml")));
+        builder.build();
+        Document doc = dBuilder.parse(builder.getTargetFile());
+        String xmlns = doc.getDocumentElement().getAttribute("xmlns");
+        xpath.setNamespaceContext(new NamespaceContextImpl().mapping("x", xmlns));
+        assertXpath("/x:server/x:subsystem[@name='foobar']/x:child", doc, 2);
+        assertXpath("/x:server/x:subsystem[@name='foo']/x:child", doc, 1); // subsystem
+                                                                           // without
+                                                                           // with
+                                                                           // different
+                                                                           // name
+                                                                           // unchanged
+    }
+
+    @Test
+    public void testNSRootReplace() throws Exception {
+        XmlConfigBuilder builder = new XmlConfigBuilder(getResourceFile("rootNS.xml"), getTempFile());
+        builder.edit(new XmlEdit("/server", getResourceURL("content1Replace.xml")));
+        builder.build();
+        Document doc = dBuilder.parse(builder.getTargetFile());
+        String xmlns = doc.getDocumentElement().getAttribute("xmlns");
+        xpath.setNamespaceContext(new NamespaceContextImpl().mapping("x", xmlns).mapping("ns", "foo"));
+        assertXpath("/x:server/ns:subsystem/ns:child", doc, 5); // subsystem
+                                                                // without name
+                                                                // attribute
+                                                                // unchaned (4
+                                                                // +1 already
+                                                                // present)
+        assertXpath("/x:server/x:subsystem[@name='foo']/x:child", doc, 2); // subsystem
+                                                                           // without
+                                                                           // ns
+                                                                           // replaced
+    }
+
+    @Test
+    public void testNSRootNSAppend() throws Exception {
+        XmlConfigBuilder builder = new XmlConfigBuilder(getResourceFile("rootNS.xml"), getTempFile());
+        builder.edit(new XmlEdit("/server", getResourceURL("content1NSAppend.xml")));
+        builder.build();
+        Document doc = dBuilder.parse(builder.getTargetFile());
+        String xmlns = doc.getDocumentElement().getAttribute("xmlns");
+        xpath.setNamespaceContext(new NamespaceContextImpl().mapping("x", xmlns).mapping("ns", "something"));
+        assertXpath(
+                "/*[local-name()='server']/*[local-name()='subsystem'"
+                + " and namespace-uri()='something']/*[local-name()='child']",
+                doc, 2);
+        // query using namespaces
+        assertXpath("/x:server/ns:subsystem/ns:child", doc, 2);
+        assertXpath("/x:server/x:subsystem[@name='foo']/x:child", doc, 1); // subsystem
+                                                                           // without
+                                                                           // ns
+                                                                           // unchanged
+    }
+
+    @Test
+    public void testNSRootNSReplace() throws Exception {
+        XmlConfigBuilder builder = new XmlConfigBuilder(getResourceFile("rootNS.xml"), getTempFile());
+        builder.edit(new XmlEdit("/server", getResourceURL("content1NSReplace.xml")));
+        builder.build();
+        Document doc = dBuilder.parse(builder.getTargetFile());
+        String xmlns = doc.getDocumentElement().getAttribute("xmlns");
+        xpath.setNamespaceContext(new NamespaceContextImpl().mapping("x", xmlns).mapping("ns", "foo"));
+        assertXpath(
+                "/*[local-name()='server']/*[local-name()='subsystem'"
+                + " and namespace-uri()='foo' and @name='bar']/*[local-name()='child']",
+                doc, 2);
+        // query using namespaces
+        assertXpath("/x:server/ns:subsystem[@name='bar']/ns:child", doc, 2); // replaced
+        assertXpath("/x:server/ns:subsystem/ns:child", doc, 6); // subsystem
+                                                                // without name
+                                                                // attribute
+                                                                // unchaned (4
+                                                                // already
+                                                                // present + 2
+                                                                // added)
+        assertXpath("/x:server/x:subsystem[@name='foo']/x:child", doc, 1); // subsystem
+                                                                           // without
+                                                                           // ns
+                                                                           // unchanged
+    }
+
+    @Test
+    public void testNSRootAppendUnderNS() throws Exception {
+        XmlConfigBuilder builder = new XmlConfigBuilder(getResourceFile("rootNS.xml"), getTempFile());
+        builder.edit(new XmlEdit("/server/*[local-name()='subsystem' and namespace-uri()='foo' and @name='bar']",
+                getResourceURL("content1Append.xml")));
+        builder.build();
+        Document doc = dBuilder.parse(builder.getTargetFile());
+        String xmlns = doc.getDocumentElement().getAttribute("xmlns");
+        xpath.setNamespaceContext(new NamespaceContextImpl().mapping("x", xmlns).mapping("ns", "foo"));
+        assertXpath("/x:server/ns:subsystem[@name='bar']/ns:subsystem[@name='foobar']", doc, 1);
+        assertXpath("/x:server/ns:subsystem[@name='bar']/ns:subsystem[@name='foobar']/ns:child", doc, 2);
+    }
+
+    @Test(expected = XPathExpressionException.class)
+    public void invalidSelect() throws Exception {
+        XmlConfigBuilder builder = new XmlConfigBuilder(getResourceFile("rotNS.xml"), getTempFile());
+        builder.edit(new XmlEdit("/serv hello?", getResourceURL("content1Append.xml")));
+        builder.build();
+    }
+
+    @Test(expected = FileNotFoundException.class)
+    public void contentDoesNotExist() throws Exception {
+        XmlConfigBuilder builder = new XmlConfigBuilder(getResourceFile("rotNS.xml"), getTempFile());
+        builder.edit(new XmlEdit("/server", getResourceURL("foo.xml")));
+        builder.build();
+    }
+
+    // @Test()
+    public void invalidSelectNoNodeset() throws Exception {
+        // TODO expect exception
+        XmlConfigBuilder builder = new XmlConfigBuilder(getResourceFile("rootNS.xml"), getTempFile());
+        builder.edit(new XmlEdit("/server/@attr", getResourceURL("content1.xml")));
+        builder.build();
+    }
+}

--- a/wildfly-module-installer/src/test/resources/content1Append.xml
+++ b/wildfly-module-installer/src/test/resources/content1Append.xml
@@ -1,0 +1,4 @@
+<subsystem name="foobar">
+  <child attr="value1"></child>
+  <child attr="value2"></child>
+</subsystem>

--- a/wildfly-module-installer/src/test/resources/content1AppendNestedNS.xml
+++ b/wildfly-module-installer/src/test/resources/content1AppendNestedNS.xml
@@ -1,0 +1,7 @@
+<subsystem name="foobar">
+  <child attr="value1"></child>
+  <child attr="value2"></child>
+  <child2 xmlns="keepme">
+    <keepme></keepme>
+  </child2>
+</subsystem>

--- a/wildfly-module-installer/src/test/resources/content1NSAppend.xml
+++ b/wildfly-module-installer/src/test/resources/content1NSAppend.xml
@@ -1,0 +1,4 @@
+<subsystem xmlns="something">
+  <child attr="value1"></child>
+  <child attr="value2"></child>
+</subsystem>

--- a/wildfly-module-installer/src/test/resources/content1NSReplace.xml
+++ b/wildfly-module-installer/src/test/resources/content1NSReplace.xml
@@ -1,0 +1,4 @@
+<subsystem name="bar" xmlns="foo">
+  <child attr="value1"></child>
+  <child attr="value2"></child>
+</subsystem>

--- a/wildfly-module-installer/src/test/resources/content1Replace.xml
+++ b/wildfly-module-installer/src/test/resources/content1Replace.xml
@@ -1,0 +1,4 @@
+<subsystem name="foo">
+  <child attr="value1"></child>
+  <child attr="value2"></child>
+</subsystem>

--- a/wildfly-module-installer/src/test/resources/domain-minimal.xml
+++ b/wildfly-module-installer/src/test/resources/domain-minimal.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" ?>
+<domain xmlns="urn:jboss:domain:3.0">
+  <extensions>
+  </extensions>
+  <system-properties>
+    <property name="java.net.preferIPv4Stack" value="true" />
+  </system-properties>
+  <management>
+    <access-control provider="simple">
+      <role-mapping>
+        <role name="SuperUser">
+          <include>
+            <user name="$local" />
+          </include>
+        </role>
+      </role-mapping>
+    </access-control>
+  </management>
+  <profiles>
+    <profile name="default">
+    </profile>
+    <profile name="ha">
+    </profile>
+    <profile name="full">
+    </profile>
+    <profile name="full-ha">
+    </profile>
+  </profiles>
+
+  <interfaces>
+    <interface name="management" />
+    <interface name="public" />
+    <interface name="unsecure" />
+  </interfaces>
+  <socket-binding-groups>
+    <socket-binding-group name="standard-sockets"
+      default-interface="public">
+      <!-- Needed for server groups using the 'default' profile -->
+      <socket-binding name="ajp" port="${jboss.ajp.port:8009}" />
+      <socket-binding name="http" port="${jboss.http.port:8080}" />
+      <socket-binding name="https" port="${jboss.https.port:8443}" />
+      <socket-binding name="txn-recovery-environment"
+        port="4712" />
+      <socket-binding name="txn-status-manager" port="4713" />
+      <outbound-socket-binding name="mail-smtp">
+        <remote-destination host="localhost" port="25" />
+      </outbound-socket-binding>
+    </socket-binding-group>
+    <socket-binding-group name="ha-sockets"
+      default-interface="public">
+      <!-- Needed for server groups using the 'ha' profile -->
+      <socket-binding name="ajp" port="${jboss.ajp.port:8009}" />
+      <socket-binding name="http" port="${jboss.http.port:8080}" />
+      <socket-binding name="https" port="${jboss.https.port:8443}" />
+      <socket-binding name="jgroups-mping" port="0"
+        multicast-address="${jboss.default.multicast.address:230.0.0.4}"
+        multicast-port="45700" />
+      <socket-binding name="jgroups-tcp" port="7600" />
+      <socket-binding name="jgroups-tcp-fd" port="57600" />
+      <socket-binding name="jgroups-udp" port="55200"
+        multicast-address="${jboss.default.multicast.address:230.0.0.4}"
+        multicast-port="45688" />
+      <socket-binding name="jgroups-udp-fd" port="54200" />
+      <socket-binding name="modcluster" port="0"
+        multicast-address="224.0.1.105" multicast-port="23364" />
+      <socket-binding name="txn-recovery-environment"
+        port="4712" />
+      <socket-binding name="txn-status-manager" port="4713" />
+      <outbound-socket-binding name="mail-smtp">
+        <remote-destination host="localhost" port="25" />
+      </outbound-socket-binding>
+    </socket-binding-group>
+    <socket-binding-group name="full-sockets"
+      default-interface="public">
+      <!-- Needed for server groups using the 'full' profile -->
+      <socket-binding name="ajp" port="${jboss.ajp.port:8009}" />
+      <socket-binding name="http" port="${jboss.http.port:8080}" />
+      <socket-binding name="https" port="${jboss.https.port:8443}" />
+      <socket-binding name="iiop" interface="unsecure"
+        port="3528" />
+      <socket-binding name="iiop-ssl" interface="unsecure"
+        port="3529" />
+      <socket-binding name="txn-recovery-environment"
+        port="4712" />
+      <socket-binding name="txn-status-manager" port="4713" />
+      <outbound-socket-binding name="mail-smtp">
+        <remote-destination host="localhost" port="25" />
+      </outbound-socket-binding>
+    </socket-binding-group>
+    <socket-binding-group name="full-ha-sockets"
+      default-interface="public">
+      <!-- Needed for server groups using the 'full-ha' profile -->
+      <socket-binding name="ajp" port="${jboss.ajp.port:8009}" />
+      <socket-binding name="http" port="${jboss.http.port:8080}" />
+      <socket-binding name="https" port="${jboss.https.port:8443}" />
+      <socket-binding name="iiop" interface="unsecure"
+        port="3528" />
+      <socket-binding name="iiop-ssl" interface="unsecure"
+        port="3529" />
+      <socket-binding name="jgroups-mping" port="0"
+        multicast-address="${jboss.default.multicast.address:230.0.0.4}"
+        multicast-port="45700" />
+      <socket-binding name="jgroups-tcp" port="7600" />
+      <socket-binding name="jgroups-tcp-fd" port="57600" />
+      <socket-binding name="jgroups-udp" port="55200"
+        multicast-address="${jboss.default.multicast.address:230.0.0.4}"
+        multicast-port="45688" />
+      <socket-binding name="jgroups-udp-fd" port="54200" />
+      <socket-binding name="modcluster" port="0"
+        multicast-address="224.0.1.105" multicast-port="23364" />
+      <socket-binding name="txn-recovery-environment"
+        port="4712" />
+      <socket-binding name="txn-status-manager" port="4713" />
+      <outbound-socket-binding name="mail-smtp">
+        <remote-destination host="localhost" port="25" />
+      </outbound-socket-binding>
+    </socket-binding-group>
+  </socket-binding-groups>
+  <server-groups>
+    <server-group name="main-server-group" profile="full">
+      <jvm name="default">
+        <heap size="64m" max-size="512m" />
+      </jvm>
+      <socket-binding-group ref="full-sockets" />
+    </server-group>
+    <server-group name="other-server-group" profile="full-ha">
+      <jvm name="default">
+        <heap size="64m" max-size="512m" />
+      </jvm>
+      <socket-binding-group ref="full-ha-sockets" />
+    </server-group>
+  </server-groups>
+</domain>

--- a/wildfly-module-installer/src/test/resources/module/module.xml
+++ b/wildfly-module-installer/src/test/resources/module/module.xml
@@ -1,0 +1,5 @@
+<module xmlns="urn:jboss:module:1.3" name="org.hawkular.agent.monitor">
+  <resources>
+    <resource-root path="hawkular-monitor.jar" />
+  </resources>
+</module>

--- a/wildfly-module-installer/src/test/resources/module/socket-binding-snippet.xml
+++ b/wildfly-module-installer/src/test/resources/module/socket-binding-snippet.xml
@@ -1,0 +1,3 @@
+<outbound-socket-binding name="hawkular">
+  <remote-destination host="your-hawkular-server-hostname" port="the-port" />
+</outbound-socket-binding>

--- a/wildfly-module-installer/src/test/resources/module/subsystem-snippet.xml
+++ b/wildfly-module-installer/src/test/resources/module/subsystem-snippet.xml
@@ -1,0 +1,6 @@
+<subsystem xmlns="foo">
+  <child attr="value2"></child>
+  <child attr="value2"></child>
+  <child attr="value2"></child>
+  <child attr="value2"></child>
+</subsystem>

--- a/wildfly-module-installer/src/test/resources/root.xml
+++ b/wildfly-module-installer/src/test/resources/root.xml
@@ -1,0 +1,14 @@
+<server>
+  <subsystem xmlns="foo">
+    <child attr="value2"></child>
+    <child attr="value2"></child>
+    <child attr="value2"></child>
+    <child attr="value2"></child>
+  </subsystem>
+  <subsystem xmlns="foo" name="bar">
+    <child attr="value2"></child>
+  </subsystem>
+  <subsystem name="foo">
+    <child attr="value2"></child>
+  </subsystem>
+</server>

--- a/wildfly-module-installer/src/test/resources/rootNS.xml
+++ b/wildfly-module-installer/src/test/resources/rootNS.xml
@@ -1,0 +1,14 @@
+<server xmlns="urn:jboss:domain:2.1">
+  <subsystem xmlns="foo">
+    <child attr="value2"></child>
+    <child attr="value2"></child>
+    <child attr="value2"></child>
+    <child attr="value2"></child>
+  </subsystem>
+  <subsystem xmlns="foo" name="bar">
+    <child attr="value2"></child>
+  </subsystem>
+  <subsystem name="foo">
+    <child attr="value2"></child>
+  </subsystem>
+</server>

--- a/wildfly-module-installer/src/test/resources/standalone-minimal.xml
+++ b/wildfly-module-installer/src/test/resources/standalone-minimal.xml
@@ -1,0 +1,22 @@
+<server xmlns="urn:jboss:domain:3.0">
+  <extensions>
+  </extensions>
+  <profile>
+
+  </profile>
+  <socket-binding-group name="standard-sockets"
+    default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
+    <socket-binding name="management-http" interface="management"
+      port="${jboss.management.http.port:9990}" />
+    <socket-binding name="management-https" interface="management"
+      port="${jboss.management.https.port:9993}" />
+    <socket-binding name="ajp" port="${jboss.ajp.port:8009}" />
+    <socket-binding name="http" port="${jboss.http.port:8080}" />
+    <socket-binding name="https" port="${jboss.https.port:8443}" />
+    <socket-binding name="txn-recovery-environment" port="4712" />
+    <socket-binding name="txn-status-manager" port="4713" />
+    <outbound-socket-binding name="mail-smtp">
+      <remote-destination host="localhost" port="25" />
+    </outbound-socket-binding>
+  </socket-binding-group>
+</server>


### PR DESCRIPTION
This PR adds ability to install hawkular-widfly-agent to a widlfly server.

Hawkular Widlfly agent  module packaging has been changed, so it includes subsystem-snippet.xml within module zip. extension-installer can find snippet and add such subsystem configuration into standalone.xml

Agent installer does not bundle agent module within itself. It's capable of downloading agent module from hawkular server (module location needs to be fixed, and hawkular server needs to provide such file) or can install module usin `--module` command-line option.

extension-installer even supports installation to domain - but it's not used yet.
