### PR TITLE
initial ansible playbooks/roles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ nb-configuration.xml
 
 # MacOS DS_Store
 .DS_Store
+
+# Vi swap files
+*.swp

--- a/hawkular-wildfly-agent-ansible-playbook/README.adoc
+++ b/hawkular-wildfly-agent-ansible-playbook/README.adoc
@@ -1,0 +1,34 @@
+This set of Ansible playbooks/roles allows you to install WildFly application servers with embedded Hawkular WildFly Agents that monitor those WildFly instances.
+
+* To configure the Ansible playbooks/roles:
+
+1. *hosts*: Lists all the hosts where you want to put your WildFly application servers or where your existing WildFly application servers are.
+2. *group_vars/wildfly-servers/main.yml*: Configures the file system locations of the WildFly application servers, credentials to use to obtain and run the Hawkular WildFly agent, and other things.
+
+* To install WildFly application servers that are monitored by Hawkular WildFly Agents:
+
+```
+ansible-playbook -i hosts install-wildfly-with-hawkular-wildfly-agent.yml
+```
+
+Once installed, you can start and stop the WildFly application servers, and get their statuses.
+
+NOTE: If you are running multiple WildFly application servers on the same machine, you must specify their bind addresses or port offsets by setting either the _wildfly_bind_address_ variable or increase the _wildfly_port_offset_ variable. Both are defined in the _group_vars/wildfly-servers/main.yml_ file or you may optionally pass one or both to the ansible-playbook via the command line option _--extra-vars "name1=value1 name2=value2"_)
+
+* To start the WildFly application servers:
+
+```
+ansible-playbook -i hosts start-wildfly.yml
+```
+
+* To stop the WildFly application servers:
+
+```
+ansible-playbook -i hosts stop-wildfly.yml
+```
+
+* To see the statuses of the WildFly application servers:
+
+```
+ansible-playbook -i hosts status-wildfly.yml
+```

--- a/hawkular-wildfly-agent-ansible-playbook/discover-wildfly.yml
+++ b/hawkular-wildfly-agent-ansible-playbook/discover-wildfly.yml
@@ -1,0 +1,22 @@
+#
+# Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+---
+- hosts: wildfly-servers
+  roles:
+    - discover-wildfly

--- a/hawkular-wildfly-agent-ansible-playbook/group_vars/wildfly-servers/main.yml
+++ b/hawkular-wildfly-agent-ansible-playbook/group_vars/wildfly-servers/main.yml
@@ -1,0 +1,53 @@
+#
+# Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+---
+# For fetching and installing a WildFly application server
+wildfly_version:         "10.0.0.Final"
+wildfly_distro_filename: "wildfly-{{wildfly_version}}.zip"
+wildfly_distro_root_dir: "wildfly-{{wildfly_version}}"
+wildfly_download_url:    "http://download.jboss.org/wildfly/{{wildfly_version}}/{{wildfly_distro_filename}}"
+wildfly_download_tmpdir: "/tmp/wildfly-download"
+wildfly_install_dir:     "/tmp/wildfly-installation"
+
+# For starting a WildFly application server
+wildfly_bind_address:    "{{ansible_default_ipv4.address}}"
+wildfly_port_offset:     0
+wildfly_home_dir:        "{{wildfly_install_dir}}/{{wildfly_distro_root_dir}}"
+
+# For discoverying WildFly application servers - these are root directories to scan
+wildfly_discover_scan_directories: "/opt /usr /home"
+
+# For fetching and installing a Hawkular WildFly Agent
+hawkular_server_url:             "http://localhost:8080"
+hawkular_download_tmpdir:        "/tmp/hawkular-download"
+hawkular_server_url_username:    "jdoe"
+hawkular_server_url_password:    "password"
+hawkular_wildfly_agent_username: "jdoe"
+hawkular_wildfly_agent_password: "password"
+
+# If the agent is to run in metrics only mode, a tenant ID must also be set
+hawkular_wildfly_agent_metrics_only: "false"
+hawkular_wildfly_agent_tenant_id:
+
+# For the agent to autogenerate its own feed ID, set this to an empty value
+hawkular_wildfly_agent_feed_id:  "{{ansible_default_ipv4.address}}"
+
+# If you want to use the fully customized subsystem role file, set this to true
+# and make sure the role file "subsystem-snippet.xml" is configured
+hawkular_wildfly_agent_use_subsystem_snippet: false

--- a/hawkular-wildfly-agent-ansible-playbook/hosts
+++ b/hawkular-wildfly-agent-ansible-playbook/hosts
@@ -1,0 +1,3 @@
+[wildfly-servers]
+
+localhost

--- a/hawkular-wildfly-agent-ansible-playbook/inject-hawkular-wildfly-agent-into-multiple-discovered-wildflys.yml
+++ b/hawkular-wildfly-agent-ansible-playbook/inject-hawkular-wildfly-agent-into-multiple-discovered-wildflys.yml
@@ -1,0 +1,23 @@
+#
+# Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+---
+- hosts: wildfly-servers
+  roles:
+    - discover-wildfly
+    - { role: fetch-and-install-hawkular-wildfly-agent, wildfly_home_dir: "{{ discover.stdout_lines}}" }

--- a/hawkular-wildfly-agent-ansible-playbook/install-wildfly-with-hawkular-wildfly-agent.yml
+++ b/hawkular-wildfly-agent-ansible-playbook/install-wildfly-with-hawkular-wildfly-agent.yml
@@ -1,0 +1,24 @@
+#
+# Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+---
+- hosts: wildfly-servers
+  roles:
+    - fetch-wildfly
+    - unpack-wildfly
+    - fetch-and-install-hawkular-wildfly-agent

--- a/hawkular-wildfly-agent-ansible-playbook/install-wildfly.yml
+++ b/hawkular-wildfly-agent-ansible-playbook/install-wildfly.yml
@@ -1,0 +1,23 @@
+#
+# Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+---
+- hosts: wildfly-servers
+  roles:
+    - fetch-wildfly
+    - unpack-wildfly

--- a/hawkular-wildfly-agent-ansible-playbook/roles/discover-wildfly/files/discover-wildfly.py
+++ b/hawkular-wildfly-agent-ansible-playbook/roles/discover-wildfly/files/discover-wildfly.py
@@ -1,0 +1,59 @@
+#!/bin/python
+#
+# Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Scans for running and installed (but not running) WildFly application servers.
+# This takes an option set of directory names to scan. If none are given, /opt, /usr, and /home are scanned.
+
+import os
+import subprocess
+import sys
+
+#  First find the WildFly servers that are actually running
+_running = set()
+
+_openJavaFiles = subprocess.check_output('/usr/sbin/lsof -w -c java | tail -n +2 | tr -s [:blank:] | grep " REG " | cut --delimiter=\' \' -f9 | sort -u', shell=True)
+
+for line in _openJavaFiles.split("\n"):
+  while line and not os.path.isdir(line + "/modules/system/layers/base"):
+    parent = os.path.dirname(line)
+    if line == parent:
+      line = "" # we are at the root, stop checking
+    else:
+      line = parent
+  if line: _running.add(line)
+
+# Now find the WildFly servers that are installed but may not be running
+# This only goes down a max depth of 4 directories (so it will find /opt/a/b/wildfly but not /opt/a/b/c/wildfly).
+_installed = set()
+
+if len(sys.argv) == 1:
+  _scanDirectories = ["/opt", "/usr", "/home"]
+else:
+  _scanDirectories = sys.argv[1:]
+
+for sdir in _scanDirectories:
+  find_results = subprocess.check_output('find ' + sdir + ' -maxdepth 8 -type d -path "*/modules/system/layers/base" -print 2>/dev/null | xargs -I \'{}\' echo {} | rev | cut -d\'/\' -f5- | rev', shell=True)
+  for line in find_results.split("\n"):
+    if line: _installed.add(line)
+
+#print "* WF are running: ", _running
+#print "* WF are installed:", _installed
+#print "* WF are running and installed:", _running | _installed
+
+for discovered in sorted(_running | _installed):
+  print discovered

--- a/hawkular-wildfly-agent-ansible-playbook/roles/discover-wildfly/files/discover-wildfly.sh
+++ b/hawkular-wildfly-agent-ansible-playbook/roles/discover-wildfly/files/discover-wildfly.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+#
+# Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Scans for running and installed (but not running) WildFly application servers.
+# This takes an option set of directory names to scan. If none are given, /opt, /usr, and /home are scanned.
+
+#  First find the WildFly servers that are actually running
+_openJavaFiles=$(/usr/sbin/lsof -w -c java | tail -n +2 | tr -s [:blank:] | grep " REG " | cut --delimiter=' ' -f9 | sort -u)
+_running=$(
+  for dir in $_openJavaFiles; do
+    _d=${dir};
+    while [[ "$_d" != "" && ! -e "${_d}/modules/system/layers/base" ]]; do
+      _d=${_d%/*}
+    done
+    if [ ! -z ${_d} ]; then
+      echo ${_d};
+    fi
+  done | uniq
+)
+
+# Now find the WildFly servers that are installed but may not be running
+# This only goes down a max depth of 4 directories (so it will find /opt/a/b/wildfly but not /opt/a/b/c/wildfly).
+_scanDirectories=${*:-"/opt /usr /home"}
+
+_installed=$(
+  for dir in $_scanDirectories
+  do
+    find $dir -maxdepth 8 -type d -path "*/modules/system/layers/base" -print 2>/dev/null | xargs -I '{}' echo {} | rev | cut -d'/' -f5- | rev
+  done
+)
+
+#echo "* WF are running: $_running"
+#echo "* WF are installed: $_installed"
+
+echo $_running $_installed | tr ' ' '\n' | sort -u

--- a/hawkular-wildfly-agent-ansible-playbook/roles/discover-wildfly/tasks/main.yml
+++ b/hawkular-wildfly-agent-ansible-playbook/roles/discover-wildfly/tasks/main.yml
@@ -1,0 +1,27 @@
+#
+# Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+---
+- name: Discover WildFly app servers
+  script: "discover-wildfly.py {{ wildfly_discover_scan_directories }}"
+  register: discover
+
+- name: WildFly Discovery Report
+  debug: msg="Found WildFly Server -> {{ item }}"
+  with_items: "{{ discover.stdout_lines }}"
+

--- a/hawkular-wildfly-agent-ansible-playbook/roles/fetch-and-install-hawkular-wildfly-agent/files/subsystem-snippet.xml
+++ b/hawkular-wildfly-agent-ansible-playbook/roles/fetch-and-install-hawkular-wildfly-agent/files/subsystem-snippet.xml
@@ -1,0 +1,839 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<subsystem xmlns="urn:org.hawkular.agent:agent:1.0"
+           enabled="true"
+           autoDiscoveryScanPeriodSecs="777">
+
+  <diagnostics enabled="true"
+               reportTo="LOG"
+               interval="1"
+               timeUnits="minutes"/>
+
+  <storage-adapter type="HAWKULAR"
+                   username="SET_ME"
+                   password="SET_ME" />
+
+  <metric-set-dmr name="WildFly Memory Metrics" enabled="true">
+    <metric-dmr name="Heap Used"
+                interval="30"
+                timeUnits="seconds"
+                metricUnits="bytes"
+                path="/core-service=platform-mbean/type=memory"
+                attribute="heap-memory-usage#used" />
+    <metric-dmr name="Heap Committed"
+                interval="1"
+                timeUnits="minutes"
+                path="/core-service=platform-mbean/type=memory"
+                attribute="heap-memory-usage#committed" />
+    <metric-dmr name="Heap Max"
+                interval="1"
+                timeUnits="minutes"
+                path="/core-service=platform-mbean/type=memory"
+                attribute="heap-memory-usage#max" />
+    <metric-dmr name="NonHeap Used"
+                interval="30"
+                timeUnits="seconds"
+                path="/core-service=platform-mbean/type=memory"
+                attribute="non-heap-memory-usage#used" />
+    <metric-dmr name="NonHeap Committed"
+                interval="1"
+                timeUnits="minutes"
+                path="/core-service=platform-mbean/type=memory"
+                attribute="non-heap-memory-usage#committed" />
+    <metric-dmr name="Accumulated GC Duration"
+                metricType="counter"
+                interval="1"
+                timeUnits="minutes"
+                path="/core-service=platform-mbean/type=garbage-collector/name=*"
+                attribute="collection-time" />
+  </metric-set-dmr>
+
+  <metric-set-dmr name="WildFly Threading Metrics" enabled="true">
+    <metric-dmr name="Thread Count"
+                interval="2"
+                timeUnits="minutes"
+                metricUnits="none"
+                path="/core-service=platform-mbean/type=threading"
+                attribute="thread-count" />
+  </metric-set-dmr>
+
+  <metric-set-dmr name="WildFly Aggregated Web Metrics" enabled="true">
+    <metric-dmr name="Aggregated Active Web Sessions"
+                interval="1"
+                timeUnits="minutes"
+                path="/deployment=*/subsystem=undertow"
+                attribute="active-sessions" />
+    <metric-dmr name="Aggregated Max Active Web Sessions"
+                interval="1"
+                timeUnits="minutes"
+                path="/deployment=*/subsystem=undertow"
+                attribute="max-active-sessions" />
+    <metric-dmr name="Aggregated Expired Web Sessions"
+                metricType="counter"
+                interval="1"
+                timeUnits="minutes"
+                path="/deployment=*/subsystem=undertow"
+                attribute="expired-sessions" />
+    <metric-dmr name="Aggregated Rejected Web Sessions"
+                metricType="counter"
+                interval="1"
+                timeUnits="minutes"
+                path="/deployment=*/subsystem=undertow"
+                attribute="rejected-sessions" />
+    <metric-dmr name="Aggregated Servlet Request Time"
+                metricType="counter"
+                interval="1"
+                timeUnits="minutes"
+                path="/deployment=*/subsystem=undertow/servlet=*"
+                attribute="total-request-time" />
+    <metric-dmr name="Aggregated Servlet Request Count"
+                metricType="counter"
+                interval="1"
+                timeUnits="minutes"
+                path="/deployment=*/subsystem=undertow/servlet=*"
+                attribute="request-count" />
+  </metric-set-dmr>
+
+  <metric-set-dmr name="Undertow Metrics" enabled="true">
+    <metric-dmr name="Active Sessions"
+                interval="2"
+                timeUnits="minutes"
+                path="/subsystem=undertow"
+                attribute="active-sessions" />
+    <metric-dmr name="Sessions Created"
+                metricType="counter"
+                interval="2"
+                timeUnits="minutes"
+                path="/subsystem=undertow"
+                attribute="sessions-created" />
+    <metric-dmr name="Expired Sessions"
+                metricType="counter"
+                interval="2"
+                timeUnits="minutes"
+                path="/subsystem=undertow"
+                attribute="expired-sessions" />
+    <metric-dmr name="Rejected Sessions"
+                metricType="counter"
+                interval="2"
+                timeUnits="minutes"
+                path="/subsystem=undertow"
+                attribute="rejected-sessions" />
+    <metric-dmr name="Max Active Sessions"
+                interval="2"
+                timeUnits="minutes"
+                path="/subsystem=undertow"
+                attribute="max-active-sessions" />
+  </metric-set-dmr>
+
+  <metric-set-dmr name="Servlet Metrics" enabled="true">
+    <metric-dmr name="Max Request Time"
+                interval="5"
+                timeUnits="minutes"
+                metricUnits="milliseconds"
+                path="/"
+                attribute="max-request-time" />
+    <metric-dmr name="Min Request Time"
+                interval="5"
+                timeUnits="minutes"
+                path="/"
+                attribute="min-request-time" />
+    <metric-dmr name="Total Request Time"
+                interval="5"
+                timeUnits="minutes"
+                path="/"
+                attribute="total-request-time" />
+    <metric-dmr name="Request Count"
+                metricType="counter"
+                interval="5"
+                timeUnits="minutes"
+                path="/"
+                attribute="request-count" />
+  </metric-set-dmr>
+
+  <metric-set-dmr name="Singleton EJB Metrics" enabled="true">
+    <metric-dmr name="Execution Time"
+                interval="5"
+                timeUnits="minutes"
+                path="/"
+                attribute="execution-time" />
+    <metric-dmr name="Invocations"
+                metricType="counter"
+                interval="5"
+                timeUnits="minutes"
+                path="/"
+                attribute="invocations" />
+    <metric-dmr name="Peak Concurrent Invocations"
+                interval="5"
+                timeUnits="minutes"
+                path="/"
+                attribute="peak-concurrent-invocations" />
+    <metric-dmr name="Wait Time"
+                interval="5"
+                timeUnits="minutes"
+                path="/"
+                attribute="wait-time" />
+  </metric-set-dmr>
+
+  <metric-set-dmr name="Message Driven EJB Metrics" enabled="true">
+    <metric-dmr name="Execution Time"
+                interval="5"
+                timeUnits="minutes"
+                path="/"
+                attribute="execution-time" />
+    <metric-dmr name="Invocations"
+                metricType="counter"
+                interval="5"
+                timeUnits="minutes"
+                path="/"
+                attribute="invocations" />
+    <metric-dmr name="Peak Concurrent Invocations"
+                interval="5"
+                timeUnits="minutes"
+                path="/"
+                attribute="peak-concurrent-invocations" />
+    <metric-dmr name="Wait Time"
+                interval="5"
+                timeUnits="minutes"
+                path="/"
+                attribute="wait-time" />
+    <metric-dmr name="Pool Available Count"
+                interval="5"
+                timeUnits="minutes"
+                path="/"
+                attribute="pool-available-count" />
+    <metric-dmr name="Pool Create Count"
+                interval="5"
+                timeUnits="minutes"
+                path="/"
+                attribute="pool-create-count" />
+    <metric-dmr name="Pool Current Size"
+                interval="5"
+                timeUnits="minutes"
+                path="/"
+                attribute="pool-current-size" />
+    <metric-dmr name="Pool Max Size"
+                interval="5"
+                timeUnits="minutes"
+                path="/"
+                attribute="pool-max-size" />
+    <metric-dmr name="Pool Remove Count"
+                interval="5"
+                timeUnits="minutes"
+                path="/"
+                attribute="pool-remove-count" />
+  </metric-set-dmr>
+
+  <metric-set-dmr name="Stateless Session EJB Metrics" enabled="true">
+    <metric-dmr name="Execution Time"
+                interval="5"
+                timeUnits="minutes"
+                path="/"
+                attribute="execution-time" />
+    <metric-dmr name="Invocations"
+                metricType="counter"
+                interval="5"
+                timeUnits="minutes"
+                path="/"
+                attribute="invocations" />
+    <metric-dmr name="Peak Concurrent Invocations"
+                interval="5"
+                timeUnits="minutes"
+                path="/"
+                attribute="peak-concurrent-invocations" />
+    <metric-dmr name="Wait Time"
+                interval="5"
+                timeUnits="minutes"
+                path="/"
+                attribute="wait-time" />
+    <metric-dmr name="Pool Availabile Count"
+                interval="5"
+                timeUnits="minutes"
+                path="/"
+                attribute="pool-available-count" />
+    <metric-dmr name="Pool Create Count"
+                interval="5"
+                timeUnits="minutes"
+                path="/"
+                attribute="pool-create-count" />
+    <metric-dmr name="Pool Current Size"
+                interval="5"
+                timeUnits="minutes"
+                path="/"
+                attribute="pool-current-size" />
+    <metric-dmr name="Pool Max Size"
+                interval="5"
+                timeUnits="minutes"
+                path="/"
+                attribute="pool-max-size" />
+    <metric-dmr name="Pool Remove Count"
+                interval="5"
+                timeUnits="minutes"
+                path="/"
+                attribute="pool-remove-count" />
+  </metric-set-dmr>
+
+  <metric-set-dmr name="Datasource JDBC Metrics" enabled="true">
+    <metric-dmr name="Prepared Statement Cache Access Count"
+                interval="10"
+                timeUnits="minutes"
+                path="/statistics=jdbc"
+                attribute="PreparedStatementCacheAccessCount" />
+    <metric-dmr name="Prepared Statement Cache Add Count"
+                interval="10"
+                timeUnits="minutes"
+                path="/statistics=jdbc"
+                attribute="PreparedStatementCacheAddCount" />
+    <metric-dmr name="Prepared Statement Cache Current Size"
+                interval="10"
+                timeUnits="minutes"
+                path="/statistics=jdbc"
+                attribute="PreparedStatementCacheCurrentSize" />
+    <metric-dmr name="Prepared Statement Cache Delete Count"
+                interval="10"
+                timeUnits="minutes"
+                path="/statistics=jdbc"
+                attribute="PreparedStatementCacheDeleteCount" />
+    <metric-dmr name="Prepared Statement Cache Hit Count"
+                interval="10"
+                timeUnits="minutes"
+                path="/statistics=jdbc"
+                attribute="PreparedStatementCacheHitCount" />
+    <metric-dmr name="Prepared Statement Cache Miss Count"
+                interval="10"
+                timeUnits="minutes"
+                path="/statistics=jdbc"
+                attribute="PreparedStatementCacheMissCount" />
+  </metric-set-dmr>
+
+  <metric-set-dmr name="Datasource Pool Metrics" enabled="true">
+    <metric-dmr name="Active Count"
+                interval="30"
+                timeUnits="seconds"
+                path="/statistics=pool"
+                attribute="ActiveCount" />
+    <metric-dmr name="Available Count"
+                interval="30"
+                timeUnits="seconds"
+                path="/statistics=pool"
+                attribute="AvailableCount" />
+    <metric-dmr name="Average Blocking Time"
+                interval="10"
+                timeUnits="minutes"
+                path="/statistics=pool"
+                attribute="AverageBlockingTime" />
+    <metric-dmr name="Average Creation Time"
+                interval="30"
+                timeUnits="seconds"
+                path="/statistics=pool"
+                attribute="AverageCreationTime" />
+    <metric-dmr name="Average Get Time"
+                interval="30"
+                timeUnits="seconds"
+                path="/statistics=pool"
+                attribute="AverageGetTime" />
+    <metric-dmr name="Blocking Failure Count"
+                interval="10"
+                timeUnits="minutes"
+                path="/statistics=pool"
+                attribute="BlockingFailureCount" />
+    <metric-dmr name="Created Count"
+                interval="10"
+                timeUnits="minutes"
+                path="/statistics=pool"
+                attribute="CreatedCount" />
+    <metric-dmr name="Destroyed Count"
+                interval="10"
+                timeUnits="minutes"
+                path="/statistics=pool"
+                attribute="DestroyedCount" />
+    <metric-dmr name="Idle Count"
+                interval="10"
+                timeUnits="minutes"
+                path="/statistics=pool"
+                attribute="IdleCount" />
+    <metric-dmr name="In Use Count"
+                interval="30"
+                timeUnits="seconds"
+                path="/statistics=pool"
+                attribute="InUseCount" />
+    <metric-dmr name="Max Creation Time"
+                interval="10"
+                timeUnits="minutes"
+                path="/statistics=pool"
+                attribute="MaxCreationTime" />
+    <metric-dmr name="Max Get Time"
+                interval="10"
+                timeUnits="minutes"
+                path="/statistics=pool"
+                attribute="MaxGetTime" />
+    <metric-dmr name="Max Used Count"
+                interval="10"
+                timeUnits="minutes"
+                path="/statistics=pool"
+                attribute="MaxUsedCount" />
+    <metric-dmr name="Max Wait Count"
+                interval="10"
+                timeUnits="minutes"
+                path="/statistics=pool"
+                attribute="MaxWaitCount" />
+    <metric-dmr name="Max Wait Time"
+                interval="10"
+                timeUnits="minutes"
+                path="/statistics=pool"
+                attribute="MaxWaitTime" />
+    <metric-dmr name="Timed Out"
+                interval="30"
+                timeUnits="seconds"
+                path="/statistics=pool"
+                attribute="TimedOut" />
+    <metric-dmr name="Total Blocking Time"
+                interval="10"
+                timeUnits="minutes"
+                path="/statistics=pool"
+                attribute="TotalBlockingTime" />
+    <metric-dmr name="Total Creation Time"
+                interval="10"
+                timeUnits="minutes"
+                path="/statistics=pool"
+                attribute="TotalCreationTime" />
+    <metric-dmr name="Total Get Time"
+                interval="10"
+                timeUnits="minutes"
+                path="/statistics=pool"
+                attribute="TotalGetTime" />
+    <metric-dmr name="Wait Count"
+                interval="10"
+                timeUnits="minutes"
+                path="/statistics=pool"
+                attribute="WaitCount" />
+  </metric-set-dmr>
+
+  <metric-set-dmr name="Transactions Metrics" enabled="true">
+    <metric-dmr name="Number of Aborted Transactions"
+                metricType="counter"
+                interval="30"
+                timeUnits="seconds"
+                path="/"
+                attribute="number-of-aborted-transactions" />
+    <metric-dmr name="Number of Application Rollbacks"
+                metricType="counter"
+                interval="30"
+                timeUnits="seconds"
+                path="/"
+                attribute="number-of-application-rollbacks" />
+    <metric-dmr name="Number of Committed Transactions"
+                metricType="counter"
+                interval="30"
+                timeUnits="seconds"
+                path="/"
+                attribute="number-of-committed-transactions" />
+    <metric-dmr name="Number of Heuristics"
+                metricType="counter"
+                interval="30"
+                timeUnits="seconds"
+                path="/"
+                attribute="number-of-heuristics" />
+    <metric-dmr name="Number of In-Flight Transactions"
+                interval="30"
+                timeUnits="seconds"
+                path="/"
+                attribute="number-of-inflight-transactions" />
+    <metric-dmr name="Number of Nested Transactions"
+                metricType="counter"
+                interval="30"
+                timeUnits="seconds"
+                path="/"
+                attribute="number-of-nested-transactions" />
+    <metric-dmr name="Number of Resource Rollbacks"
+                metricType="counter"
+                interval="30"
+                timeUnits="seconds"
+                path="/"
+                attribute="number-of-resource-rollbacks" />
+    <metric-dmr name="Number of Timed Out Transactions"
+                metricType="counter"
+                interval="30"
+                timeUnits="seconds"
+                path="/"
+                attribute="number-of-timed-out-transactions" />
+    <metric-dmr name="Number of Transactions"
+                metricType="counter"
+                interval="30"
+                timeUnits="seconds"
+                path="/"
+                attribute="number-of-transactions" />
+  </metric-set-dmr>
+
+  <metric-set-dmr name="JMS Queue Metrics" enabled="true">
+    <metric-dmr name="Consumer Count"
+                interval="30"
+                timeUnits="seconds"
+                path="/"
+                attribute="consumer-count" />
+    <metric-dmr name="Delivering Count"
+                interval="30"
+                timeUnits="seconds"
+                path="/"
+                attribute="delivering-count" />
+    <metric-dmr name="Message Count"
+                interval="30"
+                timeUnits="seconds"
+                path="/"
+                attribute="message-count" />
+    <metric-dmr name="Messages Added"
+                metricType="counter"
+                interval="30"
+                timeUnits="seconds"
+                path="/"
+                attribute="messages-added" />
+    <metric-dmr name="Scheduled Count"
+                interval="30"
+                timeUnits="seconds"
+                path="/"
+                attribute="scheduled-count" />
+  </metric-set-dmr>
+
+  <metric-set-dmr name="JMS Topic Metrics" enabled="true">
+    <metric-dmr name="Durable Message Count"
+                interval="30"
+                timeUnits="seconds"
+                path="/"
+                attribute="durable-message-count" />
+    <metric-dmr name="Durable Subscription Count"
+                interval="30"
+                timeUnits="seconds"
+                path="/"
+                attribute="durable-subscription-count" />
+    <metric-dmr name="Delivering Count"
+                interval="30"
+                timeUnits="seconds"
+                path="/"
+                attribute="delivering-count" />
+    <metric-dmr name="Message Count"
+                interval="30"
+                timeUnits="seconds"
+                path="/"
+                attribute="message-count" />
+    <metric-dmr name="Messages Added"
+                metricType="counter"
+                interval="30"
+                timeUnits="seconds"
+                path="/"
+                attribute="messages-added" />
+    <metric-dmr name="Non-Durable Message Count"
+                interval="30"
+                timeUnits="seconds"
+                path="/"
+                attribute="non-durable-message-count" />
+    <metric-dmr name="Non-Durable Subscription Count"
+                interval="30"
+                timeUnits="seconds"
+                path="/"
+                attribute="non-durable-subscription-count" />
+    <metric-dmr name="Subscription Count"
+                interval="30"
+                timeUnits="seconds"
+                path="/"
+                attribute="subscription-count" />
+  </metric-set-dmr>
+
+  <avail-set-dmr name="Server Availability" enabled="true">
+    <avail-dmr name="App Server"
+               interval="30"
+               timeUnits="seconds"
+               path="/"
+               attribute="server-state"
+               upRegex="run.*" />
+  </avail-set-dmr>
+
+  <avail-set-dmr name="Deployment Status" enabled="true">
+    <avail-dmr name="Deployment Status"
+               interval="1"
+               timeUnits="minutes"
+               path="/"
+               attribute="status"
+               upRegex="OK" />
+  </avail-set-dmr>
+
+  <resource-type-set-dmr name="Main" enabled="true">
+    <resource-type-dmr name="WildFly Server"
+                       resourceNameTemplate="${jboss.node.name:localhost}/%ManagedServerName"
+                       path="/"
+                       metricSets="WildFly Memory Metrics,WildFly Threading Metrics,WildFly Aggregated Web Metrics"
+                       availSets="Server Availability">
+      <resource-config-dmr name="Hostname"
+                           path="/core-service=server-environment"
+                           attribute="qualified-host-name" />
+      <resource-config-dmr name="Version"
+                           attribute="product-version" />
+      <resource-config-dmr name="Product Name"
+                           attribute="product-name" />
+      <resource-config-dmr name="Bound Address"
+                           path="/socket-binding-group=standard-sockets/socket-binding=http"
+                           attribute="bound-address" />
+      <resource-config-dmr name="Server State"
+                           attribute="server-state" />
+
+      <operation-dmr name="JDR"      operationName="generate-jdr-report" path="/subsystem=jdr" />
+      <operation-dmr name="Reload"   operationName="reload" />
+      <operation-dmr name="Shutdown" operationName="shutdown" />
+      <operation-dmr name="Deploy"   operationName="deploy"   />
+
+    </resource-type-dmr>
+  </resource-type-set-dmr>
+
+  <resource-type-set-dmr name="Hawkular" enabled="true">
+    <resource-type-dmr name="Hawkular WildFly Agent"
+                       resourceNameTemplate="Hawkular WildFly Agent"
+                       path="/subsystem=hawkular-wildfly-agent"
+                       parents="WildFly Server">
+      <operation-dmr name="Status"                   operationName="status" />
+      <operation-dmr name="Inventory Discovery Scan" operationName="fullDiscoveryScan" />
+    </resource-type-dmr>
+  </resource-type-set-dmr>
+
+  <resource-type-set-dmr name="Deployment" enabled="true">
+    <resource-type-dmr name="Deployment"
+                       resourceNameTemplate="%2"
+                       path="/deployment=*"
+                       parents="WildFly Server"
+                       metricSets="Undertow Metrics"
+                       availSets="Deployment Status">
+      <operation-dmr name="Redeploy" operationName="redeploy" />
+      <operation-dmr name="Remove"   operationName="remove"   />
+      <operation-dmr name="Undeploy" operationName="undeploy" />
+    </resource-type-dmr>
+
+    <resource-type-dmr name="SubDeployment"
+                       resourceNameTemplate="SubDeployment [%-]"
+                       path="/subdeployment=*"
+                       parents="Deployment"
+                       metricSets="Undertow Metrics">
+    </resource-type-dmr>
+
+  </resource-type-set-dmr>
+
+  <resource-type-set-dmr name="Web Component" enabled="true">
+    <resource-type-dmr name="Servlet"
+                       resourceNameTemplate="Servlet [%-]"
+                       path="/subsystem=undertow/servlet=*"
+                       parents="Deployment,SubDeployment"
+                       metricSets="Servlet Metrics" />
+  </resource-type-set-dmr>
+
+  <resource-type-set-dmr name="EJB" enabled="true">
+    <resource-type-dmr name="Singleton EJB"
+                       resourceNameTemplate="Singleton EJB [%-]"
+                       path="/subsystem=ejb3/singleton-bean=*"
+                       parents="Deployment,SubDeployment"
+                       metricSets="Singleton EJB Metrics" />
+
+    <resource-type-dmr name="Message Driven EJB"
+                       resourceNameTemplate="Message Driven EJB [%-]"
+                       path="/subsystem=ejb3/message-driven-bean=*"
+                       parents="Deployment,SubDeployment"
+                       metricSets="Message Driven EJB Metrics" />
+
+    <resource-type-dmr name="Stateless Session EJB"
+                       resourceNameTemplate="Stateless Session EJB [%-]"
+                       path="/subsystem=ejb3/stateless-session-bean=*"
+                       parents="Deployment,SubDeployment"
+                       metricSets="Stateless Session EJB Metrics" />
+  </resource-type-set-dmr>
+
+  <resource-type-set-dmr name="Datasource" enabled="true">
+    <resource-type-dmr name="Datasource"
+                       resourceNameTemplate="%-"
+                       path="/subsystem=datasources/data-source=*"
+                       parents="WildFly Server"
+                       metricSets="Datasource Pool Metrics,Datasource JDBC Metrics">
+      <resource-config-dmr name="Connection URL"   attribute="connection-url" />
+      <resource-config-dmr name="Driver Name"      attribute="driver-name" />
+      <resource-config-dmr name="Driver Class"     attribute="driver-class" />
+      <resource-config-dmr name="Datasource Class" attribute="datasource-class" />
+      <resource-config-dmr name="Enabled"          attribute="enabled" />
+      <resource-config-dmr name="JNDI Name"        attribute="jndi-name" />
+      <resource-config-dmr name="Username"         attribute="user-name" />
+      <resource-config-dmr name="Password"         attribute="password" />
+      <resource-config-dmr name="Security Domain"  attribute="security-domain" />
+      <resource-config-dmr name="Connection Properties"
+                           path="/connection-properties=*"
+                           attribute="value" />
+    </resource-type-dmr>
+  </resource-type-set-dmr>
+
+  <resource-type-set-dmr name="XA Datasource" enabled="true">
+    <resource-type-dmr name="XA Datasource"
+                       resourceNameTemplate="%-"
+                       path="/subsystem=datasources/xa-data-source=*"
+                       parents="WildFly Server"
+                       metricSets="Datasource Pool Metrics,Datasource JDBC Metrics">
+      <resource-config-dmr name="Driver Name"         attribute="driver-name" />
+      <resource-config-dmr name="XA Datasource Class" attribute="xa-datasource-class" />
+      <resource-config-dmr name="Enabled"             attribute="enabled" />
+      <resource-config-dmr name="JNDI Name"           attribute="jndi-name" />
+      <resource-config-dmr name="Username"            attribute="user-name" />
+      <resource-config-dmr name="Password"            attribute="password" />
+      <resource-config-dmr name="Security Domain"     attribute="security-domain" />
+      <resource-config-dmr name="Datasource Properties"
+                           path="/xa-datasource-properties=*"
+                           attribute="value" />
+    </resource-type-dmr>
+  </resource-type-set-dmr>
+
+  <resource-type-set-dmr name="JDBC Driver" enabled="true">
+    <resource-type-dmr name="JDBC Driver"
+                       resourceNameTemplate="%-"
+                       path="/subsystem=datasources/jdbc-driver=*"
+                       parents="WildFly Server" />
+  </resource-type-set-dmr>
+
+  <resource-type-set-dmr name="Transaction Manager" enabled="true">
+    <resource-type-dmr name="Transaction Manager"
+                       resourceNameTemplate="Transaction Manager"
+                       path="/subsystem=transactions"
+                       parents="WildFly Server"
+                       metricSets="Transactions Metrics" />
+  </resource-type-set-dmr>
+
+  <resource-type-set-dmr name="Messaging" enabled="true">
+    <resource-type-dmr name="Messaging Server"
+                       resourceNameTemplate="Messaging Server [%-]"
+                       path="/subsystem=messaging-activemq/server=*"
+                       parents="WildFly Server" />
+    <resource-type-dmr name="JMS Queue"
+                       resourceNameTemplate="JMS Queue [%-]"
+                       path="/jms-queue=*"
+                       parents="Messaging Server"
+                       metricSets="JMS Queue Metrics" />
+    <resource-type-dmr name="JMS Topic"
+                       resourceNameTemplate="JMS Topic [%-]"
+                       path="/jms-topic=*"
+                       parents="Messaging Server"
+                       metricSets="JMS Topic Metrics" />
+  </resource-type-set-dmr>
+
+  <!-- JMX metadata for monitoring Jolokia-enabled applications -->
+
+  <avail-set-jmx name="RuntimeAvailsJMX" enabled="true">
+    <avail-jmx name="VM Avail"
+               interval="30"
+               timeUnits="seconds"
+               attribute="StartTime"
+               upRegex="[0123456789]+" />
+  </avail-set-jmx>
+
+  <avail-set-jmx name="MemoryPoolAvailsJMX" enabled="true">
+    <avail-jmx name="Memory Pool Avail"
+               interval="30"
+               timeUnits="seconds"
+               attribute="Valid"
+               upRegex="[tT].*" />
+  </avail-set-jmx>
+
+  <metric-set-jmx name="RuntimeMetricsJMX" enabled="true">
+    <metric-jmx name="VM Uptime"
+                interval="30"
+                timeUnits="seconds"
+                metricUnits="milliseconds"
+                attribute="Uptime" />
+    <metric-jmx name="Used Heap Memory"
+                interval="30"
+                timeUnits="seconds"
+                metricUnits="bytes"
+                objectName="java.lang:type=Memory"
+                attribute="HeapMemoryUsage#used" />
+    <metric-jmx name="Aggregate GC Collection Time"
+                interval="30"
+                timeUnits="seconds"
+                metricUnits="milliseconds"
+                objectName="java.lang:type=GarbageCollector,name=*"
+                attribute="CollectionTime" />
+  </metric-set-jmx>
+
+  <metric-set-jmx name="MemoryPoolMetricsJMX" enabled="true">
+    <metric-jmx name="Initial"
+                interval="2"
+                timeUnits="minutes"
+                metricUnits="bytes"
+                attribute="Usage#init" />
+    <metric-jmx name="Used"
+                interval="1"
+                timeUnits="minutes"
+                metricUnits="bytes"
+                attribute="Usage#used" />
+    <metric-jmx name="Committed"
+                interval="1"
+                timeUnits="minutes"
+                metricUnits="bytes"
+                attribute="Usage#committed" />
+    <metric-jmx name="Max"
+                interval="2"
+                timeUnits="minutes"
+                metricUnits="bytes"
+                attribute="Usage#max" />
+  </metric-set-jmx>
+
+  <resource-type-set-jmx name="MainJMX" enabled="true">
+    <resource-type-jmx name="Runtime MBean"
+                       resourceNameTemplate="JMX [%_ManagedServerName%][%type%]"
+                       objectName="java.lang:type=Runtime"
+                       metricSets="RuntimeMetricsJMX"
+                       availSets="RuntimeAvailsJMX" >
+      <resource-config-jmx name="OS Name" objectName="java.lang:type=OperatingSystem" attribute="Name" />
+      <resource-config-jmx name="Java VM Name" attribute="VmName" />
+    </resource-type-jmx>
+  </resource-type-set-jmx>
+
+  <resource-type-set-jmx name="MemoryPoolJMX" enabled="true">
+    <resource-type-jmx name="Memory Pool MBean"
+                       parents="Runtime MBean"
+                       resourceNameTemplate="JMX [%_ManagedServerName%] %type% %name%"
+                       objectName="java.lang:type=MemoryPool,name=*"
+                       metricSets="MemoryPoolMetricsJMX"
+                       availSets="MemoryPoolAvailsJMX" >
+      <resource-config-jmx name="Type" attribute="Type" />
+    </resource-type-jmx>
+  </resource-type-set-jmx>
+
+  <managed-servers>
+    <remote-dmr name="Another Remote Server"
+                enabled="false"
+                host="localhost"
+                port="9990"
+                username="adminUser"
+                password="adminPass"
+                resourceTypeSets="Main,Deployment,Web Component,EJB,Datasource,XA Datasource,JDBC Driver,Transaction Manager,Messaging" />
+
+    <local-dmr name="Local"
+               enabled="true"
+               resourceTypeSets="Main,Deployment,Web Component,EJB,Datasource,XA Datasource,JDBC Driver,Transaction Manager,Messaging,Hawkular" />
+
+    <remote-jmx name="Remote JMX" enabled="false" resourceTypeSets="MainJMX,MemoryPoolJMX" url="http://localhost:8080/jolokia-war"/>
+  </managed-servers>
+
+  <platform enabled="true">
+    <file-stores   enabled="true"  interval="5" timeUnits="minutes" />
+    <memory        enabled="true"  interval="1" timeUnits="minutes" />
+    <processors    enabled="true"  interval="1" timeUnits="minutes" />
+    <power-sources enabled="false" interval="5" timeUnits="minutes" />
+  </platform>
+
+</subsystem>

--- a/hawkular-wildfly-agent-ansible-playbook/roles/fetch-and-install-hawkular-wildfly-agent/tasks/main.yml
+++ b/hawkular-wildfly-agent-ansible-playbook/roles/fetch-and-install-hawkular-wildfly-agent/tasks/main.yml
@@ -1,0 +1,65 @@
+#
+# Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+---
+- name: Create Hawkular download tmp directory
+  file: path="{{hawkular_download_tmpdir}}" state=directory
+
+- name: Download Hawkular WildFly Agent installer
+
+  # Can't use due to bug: https://github.com/ansible/ansible-modules-core/issues/2166
+  #uri:
+  #  url="{{hawkular_server_url}}/hawkular/wildfly-agent/installer"
+  #  dest="{{hawkular_download_tmpdir}}/hawkular-wildfly-agent-installer.jar"
+  #  user="{{hawkular_server_url_username}}"
+  #  password="{{hawkular_server_url_password}}"
+  #  force_basic_auth=true
+  #  method=POST
+  #  body=""
+  #  follow_redirects=all
+  #  validate_certs=no
+
+  shell:
+    "curl --silent --show-error --create-dirs --user '{{hawkular_server_url_username}}:{{hawkular_server_url_password}}' --output '{{hawkular_download_tmpdir}}/hawkular-wildfly-agent-installer.jar' {{hawkular_server_url}}/hawkular/wildfly-agent/installer"
+
+- name: Copy the custom subsystem snippet configuration file if it is to be used
+  copy: src=subsystem-snippet.xml dest={{hawkular_download_tmpdir}}/subsystem-snippet.xml
+  when: hawkular_wildfly_agent_use_subsystem_snippet == true
+
+- name: Use the custom subsystem snippet if it is to be used
+  set_fact:
+    tmp_subsystem_snippet_option: "--subsystem-snippet={{hawkular_download_tmpdir}}/subsystem-snippet.xml"
+  when: hawkular_wildfly_agent_use_subsystem_snippet == true
+
+# This installs the agent into multiple WildFly app servers if the variable wildfly_home_dir is a list
+- name: Run the Hawkular WildFly Agent installer
+  with_items: "{{wildfly_home_dir}}"
+  command:
+    "java -jar {{hawkular_download_tmpdir}}/hawkular-wildfly-agent-installer.jar
+      {{tmp_subsystem_snippet_option|default('')}}
+      --username={{hawkular_wildfly_agent_username}}
+      --password={{hawkular_wildfly_agent_password}}
+      --target-location={{item}}
+      --server-url={{hawkular_server_url}}
+      --feed-id={{hawkular_wildfly_agent_feed_id}}
+      --metrics-only={{hawkular_wildfly_agent_metrics_only}}
+      --tenant-id={{hawkular_wildfly_agent_tenant_id}}"
+
+- name: Remove the Hawkular WildFly Agent installer
+  file: path="{{hawkular_download_tmpdir}}" state=absent
+

--- a/hawkular-wildfly-agent-ansible-playbook/roles/fetch-and-unpack-wildfly/tasks/main.yml
+++ b/hawkular-wildfly-agent-ansible-playbook/roles/fetch-and-unpack-wildfly/tasks/main.yml
@@ -1,0 +1,27 @@
+#
+# Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This only works with Ansible 2.0 (because unarchive src is an http URL)
+---
+  - name: Create WildFly installation directory
+    file: path="{{wildfly_install_dir}}" state=directory mode=0755
+
+  - name: Download and unpack WildFly app server
+    unarchive:
+      src="{{wildfly_download_url}}"
+      dest="{{wildfly_install_dir}}"
+      copy=no

--- a/hawkular-wildfly-agent-ansible-playbook/roles/fetch-wildfly/tasks/main.yml
+++ b/hawkular-wildfly-agent-ansible-playbook/roles/fetch-wildfly/tasks/main.yml
@@ -1,0 +1,27 @@
+#
+# Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+---
+- name: Create WildFly download tmp directory
+  file: path="{{wildfly_download_tmpdir}}" state=directory
+
+- name: Download WildFly app server distro
+  get_url:
+    url="{{wildfly_download_url}}"
+    dest="{{wildfly_download_tmpdir}}/{{wildfly_distro_filename}}"
+  delegate_to: 127.0.0.1

--- a/hawkular-wildfly-agent-ansible-playbook/roles/fetch-wildfly/tasks/main.yml
+++ b/hawkular-wildfly-agent-ansible-playbook/roles/fetch-wildfly/tasks/main.yml
@@ -19,6 +19,7 @@
 ---
 - name: Create WildFly download tmp directory
   file: path="{{wildfly_download_tmpdir}}" state=directory
+  delegate_to: 127.0.0.1
 
 - name: Download WildFly app server distro
   get_url:

--- a/hawkular-wildfly-agent-ansible-playbook/roles/start-wildfly/tasks/main.yml
+++ b/hawkular-wildfly-agent-ansible-playbook/roles/start-wildfly/tasks/main.yml
@@ -1,0 +1,25 @@
+#
+# Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+---
+- name: Start WildFly application server
+  shell: "nohup {{wildfly_home_dir}}/bin/standalone.sh -b {{wildfly_bind_address}} -Djboss.socket.binding.port-offset={{wildfly_port_offset}} &"
+  args:
+    chdir: "{{wildfly_home_dir}}"
+  environment:
+    LAUNCH_JBOSS_IN_BACKGROUND: true

--- a/hawkular-wildfly-agent-ansible-playbook/roles/status-wildfly/tasks/main.yml
+++ b/hawkular-wildfly-agent-ansible-playbook/roles/status-wildfly/tasks/main.yml
@@ -1,0 +1,48 @@
+#
+# Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+---
+- name: Get home directory for WildFly application server
+  shell: "{{wildfly_home_dir}}/bin/jboss-cli.sh
+    --connect
+    controller=localhost:{{ 9990 + wildfly_port_offset|int }}
+    'command=/core-service=server-environment:read-attribute(name=home-dir)'"
+  register: tmp_home_dir
+  ignore_errors: yes
+
+- debug: msg="Home Directory={{tmp_home_dir.stdout}}"
+
+- name: Get running mode for WildFly application server
+  shell: "{{wildfly_home_dir}}/bin/jboss-cli.sh
+    --connect
+    controller=localhost:{{ 9990 + wildfly_port_offset|int }}
+    'command=/:read-attribute(name=running-mode)'"
+  register: tmp_running_mode
+  ignore_errors: yes
+
+- debug: msg="Running Mode={{tmp_running_mode.stdout}}"
+
+- name: Get server state for WildFly application server
+  shell: "{{wildfly_home_dir}}/bin/jboss-cli.sh
+    --connect
+    controller=localhost:{{ 9990 + wildfly_port_offset|int }}
+    'command=/:read-attribute(name=server-state)'"
+  register: tmp_server_state
+  ignore_errors: yes
+
+- debug: msg="Server State={{tmp_server_state.stdout}}"

--- a/hawkular-wildfly-agent-ansible-playbook/roles/stop-wildfly/tasks/main.yml
+++ b/hawkular-wildfly-agent-ansible-playbook/roles/stop-wildfly/tasks/main.yml
@@ -1,0 +1,24 @@
+#
+# Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+---
+- name: Stop WildFly application server
+  shell: "{{wildfly_home_dir}}/bin/jboss-cli.sh
+    --connect
+    controller=localhost:{{ 9990 + wildfly_port_offset|int }}
+    command=/:shutdown"

--- a/hawkular-wildfly-agent-ansible-playbook/roles/unpack-wildfly/tasks/main.yml
+++ b/hawkular-wildfly-agent-ansible-playbook/roles/unpack-wildfly/tasks/main.yml
@@ -1,0 +1,26 @@
+#
+# Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+---
+- name: Create WildFly install directory
+  file: path="{{wildfly_install_dir}}" state=directory mode=0755
+
+- name: Unpack WildFly into its installation directory
+  unarchive:
+    src="{{wildfly_download_tmpdir}}/{{wildfly_distro_filename}}"
+    dest="{{wildfly_install_dir}}"

--- a/hawkular-wildfly-agent-ansible-playbook/start-wildfly.yml
+++ b/hawkular-wildfly-agent-ansible-playbook/start-wildfly.yml
@@ -1,0 +1,22 @@
+#
+# Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+---
+- hosts: wildfly-servers
+  roles:
+    - start-wildfly

--- a/hawkular-wildfly-agent-ansible-playbook/status-wildfly.yml
+++ b/hawkular-wildfly-agent-ansible-playbook/status-wildfly.yml
@@ -1,0 +1,22 @@
+#
+# Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+---
+- hosts: wildfly-servers
+  roles:
+    - status-wildfly

--- a/hawkular-wildfly-agent-ansible-playbook/stop-wildfly.yml
+++ b/hawkular-wildfly-agent-ansible-playbook/stop-wildfly.yml
@@ -1,0 +1,22 @@
+#
+# Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+---
+- hosts: wildfly-servers
+  roles:
+    - stop-wildfly

--- a/pom.xml
+++ b/pom.xml
@@ -241,4 +241,18 @@
     </dependencies>
   </dependencyManagement>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <configuration>
+          <excludes combine.children="append">
+            <exclude>hawkular-wildfly-agent-ansible-playbook/hosts</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>


### PR DESCRIPTION
@pilhuhn here's a PR with an initial set of Ansible roles/playbooks. See README.adoc for quick-start docs. I will blog about this, but first wanted to get your take.

Note that the Wildfly roles are really here just to make things easy on the person testing these. It does a download/install of WF 10 (so we can install an agent into it) and start/stop/status of the WildFly instances. The role we really care about is "fetch-and-install-hawkular-wildfly-agent" since that does the download and installation of the agent.
