### PR TITLE
HWKAGENT-71 Get agent to be installable and runnable inside host controller

### DIFF
--- a/hawkular-wildfly-agent-feature-pack/src/main/resources/modules/system/add-ons/hawkular-agent/org/hawkular/agent/main/module.xml
+++ b/hawkular-wildfly-agent-feature-pack/src/main/resources/modules/system/add-ons/hawkular-agent/org/hawkular/agent/main/module.xml
@@ -81,6 +81,7 @@
     <!-- modules required by any subsystem -->
     <module name="javax.api"/>
     <module name="org.jboss.as.controller"/>
+    <module name="org.jboss.as.host-controller"/> <!-- in case we are deployed in host controller -->
     <module name="org.jboss.as.server"/>
     <module name="org.jboss.logging"/>
     <module name="org.jboss.modules"/>

--- a/hawkular-wildfly-agent-installer/pom.xml
+++ b/hawkular-wildfly-agent-installer/pom.xml
@@ -59,7 +59,9 @@
 
   <build>
     <plugins>
-      <!-- USAGE: mvn -Dorg.hawkular.wildfly.home=/opt/wildfly9 exec:java -->
+      <!-- USAGE: mvn -Dorg.hawkular.wildfly.home=/opt/wildfly10 exec:java -->
+      <!-- If you want to run the installer in a debugger: -->
+      <!-- USAGE: mvn -Dorg.hawkular.wildfly.home=/opt/wildfly10 exec:exec -Pdebug-installer -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
@@ -70,6 +72,10 @@
             <argument>--module-dist=${project.basedir}/../hawkular-wildfly-agent-wf-extension/target/hawkular-wildfly-agent-wf-extension-${project.version}.zip</argument>
             <argument>--server-url=http://127.0.0.1:8080</argument>
             <argument>--enabled=true</argument>
+            <!--
+            <argument>-target-config=domain/configuration/host.xml</argument>
+            <argument>-target-config=domain/configuration/domain.xml</argument>
+            -->
           </arguments>
           <systemProperties>
             <systemProperty>
@@ -101,5 +107,45 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>debug-installer</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>test</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <executable>java</executable>
+              <arguments>
+                <argument>-Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y</argument>
+                <argument>-Dorg.hawkular.wildfly.agent.installer.throw-exception-on-error=true</argument>
+                <argument>-classpath</argument>
+                <classpath />
+                <argument>org.hawkular.wildfly.agent.installer.AgentInstaller</argument>
+                <argument>--target-location=${org.hawkular.wildfly.home}</argument>
+                <argument>--module-dist=${project.basedir}/../hawkular-wildfly-agent-wf-extension/target/hawkular-wildfly-agent-wf-extension-${project.version}.zip</argument>
+                <argument>--server-url=http://127.0.0.1:8080</argument>
+                <argument>--enabled=true</argument>
+                <!--
+                <argument>-target-config=domain/configuration/domain.xml</argument>
+                <argument>-target-config=domain/configuration/host.xml</argument>
+                -->
+              </arguments>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
 </project>

--- a/hawkular-wildfly-agent-installer/src/main/java/org/hawkular/wildfly/agent/installer/DomainTargetConfigInfo.java
+++ b/hawkular-wildfly-agent-installer/src/main/java/org/hawkular/wildfly/agent/installer/DomainTargetConfigInfo.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.wildfly.agent.installer;
+
+public class DomainTargetConfigInfo implements TargetConfigInfo {
+
+    @Override
+    public String getRootXPath() {
+        return "/domain";
+    }
+
+    @Override
+    public String getSecurityRealmsXPath() {
+        return getRootXPath() + "/management/security-realms";
+    }
+
+    @Override
+    public String getProfileXPath() {
+        // notice we only support the <profile name="default">
+        return getRootXPath() + "/profiles/profile[@name='default']";
+    }
+
+}

--- a/hawkular-wildfly-agent-installer/src/main/java/org/hawkular/wildfly/agent/installer/HostTargetConfigInfo.java
+++ b/hawkular-wildfly-agent-installer/src/main/java/org/hawkular/wildfly/agent/installer/HostTargetConfigInfo.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.wildfly.agent.installer;
+
+public class HostTargetConfigInfo implements TargetConfigInfo {
+
+    @Override
+    public String getRootXPath() {
+        return "/host";
+    }
+
+    @Override
+    public String getSecurityRealmsXPath() {
+        return getRootXPath() + "/management/security-realms";
+    }
+
+    @Override
+    public String getProfileXPath() {
+        return getRootXPath() + "/profile";
+    }
+}

--- a/hawkular-wildfly-agent-installer/src/main/java/org/hawkular/wildfly/agent/installer/StandaloneTargetConfigInfo.java
+++ b/hawkular-wildfly-agent-installer/src/main/java/org/hawkular/wildfly/agent/installer/StandaloneTargetConfigInfo.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.wildfly.agent.installer;
+
+public class StandaloneTargetConfigInfo implements TargetConfigInfo {
+
+    @Override
+    public String getRootXPath() {
+        return "/server";
+    }
+
+    @Override
+    public String getSecurityRealmsXPath() {
+        return getRootXPath() + "/management/security-realms";
+    }
+
+    @Override
+    public String getProfileXPath() {
+        return getRootXPath() + "/profile";
+    }
+
+}

--- a/hawkular-wildfly-agent-installer/src/main/java/org/hawkular/wildfly/agent/installer/TargetConfigInfo.java
+++ b/hawkular-wildfly-agent-installer/src/main/java/org/hawkular/wildfly/agent/installer/TargetConfigInfo.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.wildfly.agent.installer;
+
+public interface TargetConfigInfo {
+    /**
+     * The root that all other xpaths are relative to.
+     */
+    String getRootXPath();
+
+    /**
+     * @return the XPath that refers to the security-realms element in the config file.
+     */
+    String getSecurityRealmsXPath();
+
+    /**
+     * @return the XPath that refers to the profile element in the config file.
+     */
+    String getProfileXPath();
+
+}

--- a/hawkular-wildfly-agent/pom.xml
+++ b/hawkular-wildfly-agent/pom.xml
@@ -135,6 +135,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.wildfly.core</groupId>
+      <artifactId>wildfly-host-controller</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.wildfly</groupId>
       <artifactId>wildfly-naming</artifactId>
       <scope>provided</scope>

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/SubsystemExtension.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/SubsystemExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -56,6 +56,9 @@ public class SubsystemExtension implements Extension {
     public void initialize(ExtensionContext context) {
         final SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME,
                 MAJOR_VERSION, MINOR_VERSION, MICRO_VERSION);
+
+        // This subsystem should be runnable on a host
+        subsystem.setHostCapable();
 
         final ManagementResourceRegistration registration = subsystem
                 .registerSubsystemModel(SubsystemDefinition.INSTANCE);

--- a/pom.xml
+++ b/pom.xml
@@ -221,6 +221,12 @@
       </dependency>
 
       <dependency>
+        <groupId>org.wildfly.core</groupId>
+        <artifactId>wildfly-host-controller</artifactId>
+        <version>${version.org.wildfly.core}</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.wildfly</groupId>
         <artifactId>wildfly-naming</artifactId>
         <version>${version.org.wildfly}</version>

--- a/wildfly-module-installer/src/main/java/org/hawkular/wildfly/module/installer/ConfigType.java
+++ b/wildfly-module-installer/src/main/java/org/hawkular/wildfly/module/installer/ConfigType.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.wildfly.module.installer;
+
+public enum ConfigType {
+    STANDALONE, HOST, DOMAIN
+}

--- a/wildfly-module-installer/src/main/java/org/hawkular/wildfly/module/installer/ExtensionDeployer.java
+++ b/wildfly-module-installer/src/main/java/org/hawkular/wildfly/module/installer/ExtensionDeployer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -61,6 +61,9 @@ public class ExtensionDeployer {
                 options.withExtension(module.getModuleId());
             }
 
+            if (configuration.getConfigType() != null) {
+                options.configType(configuration.getConfigType());
+            }
             options
                 .targetServerConfig(targetServerConfigAbsolute)
                 .sourceServerConfig(sourceServerConfigBackupAbsolute)
@@ -68,7 +71,6 @@ public class ExtensionDeployer {
                 .socketBinding(configuration.getSocketBinding())
                 .socketBindingGroups(configuration.getSocketBindingGroups())
                 .xmlEdits(configuration.getEdit())
-                .domain(configuration.isDomain())
                 .profiles(configuration.getProfiles())
                 .failNoMatch(configuration.isFailNoMatch());
 

--- a/wildfly-module-installer/src/main/java/org/hawkular/wildfly/module/installer/XmlConfigBuilder.java
+++ b/wildfly-module-installer/src/main/java/org/hawkular/wildfly/module/installer/XmlConfigBuilder.java
@@ -242,6 +242,18 @@ class XmlConfigBuilder {
         transformer.transform(source, result);
     }
 
+    // to help debugging
+    /*
+    private void printDocument(Document doc) {
+        try {
+            DOMImplementationLS domImplementation = (DOMImplementationLS) doc.getImplementation();
+            log.fatal("XML DOCUMENT:\n" + domImplementation.createLSSerializer().writeToString(doc));
+        } catch (Throwable t) {
+            log.warn("Can't print doc: " + t);
+        }
+    }
+    */
+
     public static String xpath2Namespaced(String expression, String prefix) {
         String[] components = expression.split("/");
         StringBuilder sb = new StringBuilder();

--- a/wildfly-module-installer/src/test/resources/host-minimal.xml
+++ b/wildfly-module-installer/src/test/resources/host-minimal.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<host xmlns="urn:jboss:domain:4.0" name="master">
+  <extensions>
+    <extension module="org.jboss.as.jmx" />
+  </extensions>
+  <management>
+    <security-realms>
+      <security-realm name="ManagementRealm">
+        <authentication>
+          <local default-user="$local" skip-group-loading="true" />
+          <properties path="mgmt-users.properties" relative-to="jboss.domain.config.dir" />
+        </authentication>
+        <authorization map-groups-to-roles="false">
+          <properties path="mgmt-groups.properties" relative-to="jboss.domain.config.dir" />
+        </authorization>
+      </security-realm>
+      <security-realm name="ApplicationRealm">
+        <authentication>
+          <local allowed-users="*" default-user="$local" skip-group-loading="true" />
+          <properties path="application-users.properties" relative-to="jboss.domain.config.dir" />
+        </authentication>
+        <authorization>
+          <properties path="application-roles.properties" relative-to="jboss.domain.config.dir" />
+        </authorization>
+      </security-realm>
+    </security-realms>
+    <audit-log>
+      <formatters>
+        <json-formatter name="json-formatter" />
+      </formatters>
+      <handlers>
+        <file-handler formatter="json-formatter" name="host-file" path="audit-log.log" relative-to="jboss.domain.data.dir" />
+        <file-handler formatter="json-formatter" name="server-file" path="audit-log.log" relative-to="jboss.server.data.dir" />
+      </handlers>
+      <logger enabled="false" log-boot="true" log-read-only="false">
+        <handlers>
+          <handler name="host-file" />
+        </handlers>
+      </logger>
+      <server-logger enabled="false" log-boot="true" log-read-only="false">
+        <handlers>
+          <handler name="server-file" />
+        </handlers>
+      </server-logger>
+    </audit-log>
+    <management-interfaces>
+      <native-interface security-realm="ManagementRealm">
+        <socket interface="management" port="${jboss.management.native.port:9999}" />
+      </native-interface>
+      <http-interface http-upgrade-enabled="true" security-realm="ManagementRealm">
+        <socket interface="management" port="${jboss.management.http.port:9990}" />
+      </http-interface>
+    </management-interfaces>
+  </management>
+  <domain-controller>
+    <local />
+    <!-- Alternative remote domain controller configuration with a host and port -->
+    <!-- <remote protocol="remote" host="${jboss.domain.master.address}" port="${jboss.domain.master.port:9999}" security-realm="ManagementRealm"/> -->
+  </domain-controller>
+  <interfaces>
+    <interface name="management">
+      <inet-address value="${jboss.bind.address.management:127.0.0.1}" />
+    </interface>
+    <interface name="public">
+      <inet-address value="${jboss.bind.address:127.0.0.1}" />
+    </interface>
+  </interfaces>
+  <jvms>
+    <jvm name="default">
+      <heap max-size="256m" size="64m" />
+      <jvm-options>
+        <option value="-server" />
+        <option value="-XX:MetaspaceSize=96m" />
+        <option value="-XX:MaxMetaspaceSize=256m" />
+      </jvm-options>
+    </jvm>
+  </jvms>
+  <servers>
+    <server group="main-server-group" name="server-one">
+      <!--
+        ~ Remote JPDA debugging for a specific server
+        ~ <jvm name="default">
+        ~ <jvm-options>
+        ~ <option value="-agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=n"/>
+        ~ </jvm-options>
+        ~ </jvm>
+        ~
+      -->
+    </server>
+    <server auto-start="true" group="main-server-group" name="server-two">
+      <!--
+        ~ server-two avoids port conflicts by incrementing the ports in
+        ~ the default socket-group declared in the server-group
+      -->
+      <socket-bindings port-offset="150" />
+    </server>
+    <server auto-start="false" group="other-server-group" name="server-three">
+      <!--
+        ~ server-three avoids port conflicts by incrementing the ports in
+        ~ the default socket-group declared in the server-group
+      -->
+      <socket-bindings port-offset="250" />
+    </server>
+  </servers>
+  <profile>
+    <subsystem xmlns="urn:jboss:domain:jmx:1.3">
+      <expose-resolved-model />
+      <expose-expression-model />
+      <remoting-connector />
+    </subsystem>
+  </profile>
+</host>


### PR DESCRIPTION
this simply allows the agent to be installed in a host controller and run in a host controller.

It runs, but because some DMR resources are missing or in different paths when in host controller vs. standalone, the monitoring fails. We'd just have to figure out what, if anything, we want to monitor in here. But I think that's a separate issue we can work on later. This simply gets the installation correct so it can at least run in the different container environments.
