### PR TITLE
HWKAGENT-68 change config at runtime

### DIFF
--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/dynamicprotocol/DynamicProtocolServices.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/dynamicprotocol/DynamicProtocolServices.java
@@ -118,16 +118,6 @@ public class DynamicProtocolServices {
         this.services = Collections.unmodifiableList(Arrays.asList(prometheusProtocolService));
     }
 
-    public DynamicEndpointService getDynamicEndpointService(String endpointName) {
-        for (DynamicProtocolService service : services) {
-            DynamicEndpointService result = service.getDynamicEndpointServices().get(endpointName);
-            if (result != null) {
-                return (DynamicEndpointService) result;
-            }
-        }
-        return null;
-    }
-
     public void start() {
         for (DynamicProtocolService service : services) {
             service.start();

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalDMRAdd.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalDMRAdd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,13 +16,53 @@
  */
 package org.hawkular.agent.monitor.extension;
 
-import org.jboss.as.controller.AbstractAddStepHandler;
+import org.hawkular.agent.monitor.log.AgentLoggers;
+import org.hawkular.agent.monitor.log.MsgLogger;
+import org.hawkular.agent.monitor.protocol.EndpointService;
+import org.hawkular.agent.monitor.protocol.ProtocolService;
+import org.hawkular.agent.monitor.protocol.ProtocolServices;
+import org.hawkular.agent.monitor.protocol.dmr.DMRNodeLocation;
+import org.hawkular.agent.monitor.protocol.dmr.DMRSession;
+import org.hawkular.agent.monitor.service.MonitorService;
+import org.hawkular.agent.monitor.util.Util;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.dmr.ModelNode;
 
-public class LocalDMRAdd extends AbstractAddStepHandler {
+public class LocalDMRAdd extends MonitorServiceAddStepHandler {
+    private static final MsgLogger log = AgentLoggers.getLogger(LocalDMRAdd.class);
 
     public static final LocalDMRAdd INSTANCE = new LocalDMRAdd();
 
     private LocalDMRAdd() {
         super(LocalDMRAttributes.ATTRIBUTES);
     }
+
+    @Override
+    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model)
+            throws OperationFailedException {
+
+        if (context.isBooting()) {
+            return;
+        }
+
+        MonitorService monitorService = getMonitorService(context);
+        if (monitorService == null) {
+            return; // the agent wasn't enabled, nothing to do
+        }
+
+        MonitorServiceConfiguration config = Util.getMonitorServiceConfiguration(context);
+
+        // create a new endpoint service
+        ProtocolServices newServices = monitorService.createProtocolServicesBuilder().dmrProtocolService(
+                monitorService.getLocalModelControllerClientFactory(), config.getDmrConfiguration()).build();
+        EndpointService<DMRNodeLocation, DMRSession> endpointService = newServices.getDmrProtocolService()
+                .getEndpointServices().get(context.getCurrentAddressValue());
+
+        // put the new endpoint service in the original protocol services container
+        ProtocolService<DMRNodeLocation, DMRSession> dmrService = monitorService.getProtocolServices()
+                .getDmrProtocolService();
+        dmrService.add(endpointService);
+    }
+
 }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalDMRAttributes.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalDMRAttributes.java
@@ -32,7 +32,7 @@ public interface LocalDMRAttributes {
             .setAllowNull(true)
             .setDefaultValue(new ModelNode(true))
             .setAllowExpression(true)
-            .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+            .addFlag(AttributeAccess.Flag.RESTART_NONE)
             .build();
 
     SimpleAttributeDefinition SET_AVAIL_ON_SHUTDOWN = new SimpleAttributeDefinitionBuilder("setAvailOnShutdown",

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalDMRDefinition.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalDMRDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,10 +19,23 @@ package org.hawkular.agent.monitor.extension;
 import java.util.Arrays;
 import java.util.Collection;
 
+import org.hawkular.agent.monitor.protocol.EndpointService;
+import org.hawkular.agent.monitor.protocol.ProtocolService;
+import org.hawkular.agent.monitor.protocol.ProtocolServices;
+import org.hawkular.agent.monitor.protocol.dmr.DMRNodeLocation;
+import org.hawkular.agent.monitor.protocol.dmr.DMRSession;
+import org.hawkular.agent.monitor.scheduler.SchedulerService;
+import org.hawkular.agent.monitor.service.MonitorService;
+import org.hawkular.agent.monitor.util.Util;
+import org.jboss.as.controller.AbstractWriteAttributeHandler;
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.PersistentResourceDefinition;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry.Flag;
+import org.jboss.dmr.ModelNode;
 
 public class LocalDMRDefinition extends PersistentResourceDefinition {
 
@@ -36,12 +49,83 @@ public class LocalDMRDefinition extends PersistentResourceDefinition {
                         LOCAL_DMR),
                 LocalDMRAdd.INSTANCE,
                 LocalDMRRemove.INSTANCE,
-                Flag.RESTART_RESOURCE_SERVICES,
-                Flag.RESTART_RESOURCE_SERVICES);
+                Flag.RESTART_NONE,
+                Flag.RESTART_NONE);
     }
 
     @Override
     public Collection<AttributeDefinition> getAttributes() {
         return Arrays.asList(LocalDMRAttributes.ATTRIBUTES);
     }
+
+    @Override
+    public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
+        Util.registerOnlyRestartAttributes(resourceRegistration, getAttributes());
+
+        resourceRegistration.registerReadWriteAttribute(LocalDMRAttributes.ENABLED, null,
+                new MonitorServiceWriteAttributeHandler<Void>() {
+                    @Override
+                    protected boolean applyUpdateToRuntime(
+                            OperationContext context,
+                            ModelNode operation,
+                            String attributeName,
+                            ModelNode newValue,
+                            ModelNode currentValue,
+                            AbstractWriteAttributeHandler.HandbackHolder<Void> handbackHolder)
+                                    throws OperationFailedException {
+
+                        if (context.isBooting()) {
+                            return false;
+                        }
+
+                        boolean currBool = LocalDMRAttributes.ENABLED.resolveValue(context, currentValue).asBoolean();
+                        boolean newBool = LocalDMRAttributes.ENABLED.resolveValue(context, newValue).asBoolean();
+                        if (currBool == newBool) {
+                            return false; // don't know if this would ever happen, but if it does, nothing changed
+                        }
+
+                        MonitorService monitorService = getMonitorService(context);
+                        ProtocolService<DMRNodeLocation, DMRSession> dmrService = monitorService.getProtocolServices()
+                                .getDmrProtocolService();
+                        String thisEndpointName = context.getCurrentAddressValue();
+
+                        if (newBool) {
+                            // add the endpoint so it begins to be monitored
+
+                            // first get our subsystem config
+                            MonitorServiceConfiguration config = Util.getMonitorServiceConfiguration(context);
+
+                            // create a new endpoint service
+                            ProtocolServices newServices = monitorService.createProtocolServicesBuilder()
+                                    .dmrProtocolService(monitorService.getLocalModelControllerClientFactory(),
+                                            config.getDmrConfiguration())
+                                    .build();
+                            EndpointService<DMRNodeLocation, DMRSession> endpointService = newServices
+                                    .getDmrProtocolService().getEndpointServices().get(thisEndpointName);
+
+                            // put the new endpoint service in the original protocol services container
+                            dmrService.add(endpointService);
+                        } else {
+                            // remove the endpoint so it is no longer monitored
+                            SchedulerService schedulerService = monitorService.getSchedulerService();
+                            dmrService.remove(thisEndpointName, schedulerService);
+                        }
+
+                        return false;
+                    }
+
+                    @Override
+                    protected void revertUpdateToRuntime(
+                            OperationContext context,
+                            ModelNode operation,
+                            String attributeName,
+                            ModelNode originalValue,
+                            ModelNode newBadValue,
+                            Void handback)
+                                    throws OperationFailedException {
+                        // nothing to revert?
+                    }
+                });
+    }
+
 }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/MonitorServiceAddStepHandler.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/MonitorServiceAddStepHandler.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.agent.monitor.extension;
+
+import org.hawkular.agent.monitor.service.MonitorService;
+import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceRegistry;
+
+/**
+ * Base class to any add-step handler that requires common functionality like a method
+ * to obtain the service.
+ */
+public abstract class MonitorServiceAddStepHandler extends AbstractAddStepHandler {
+
+    public MonitorServiceAddStepHandler(AttributeDefinition... attributes) {
+        super(attributes);
+    }
+
+    protected MonitorService getMonitorService(OperationContext opContext) {
+        ServiceName name = SubsystemExtension.SERVICE_NAME;
+        ServiceRegistry serviceRegistry = opContext.getServiceRegistry(true);
+        MonitorService service = (MonitorService) serviceRegistry.getRequiredService(name).getValue();
+        return service;
+    }
+}

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/MonitorServiceRemoveStepHandler.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/MonitorServiceRemoveStepHandler.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.agent.monitor.extension;
+
+import org.hawkular.agent.monitor.service.MonitorService;
+import org.jboss.as.controller.AbstractRemoveStepHandler;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceRegistry;
+
+/**
+ * Base class to any remove-step handler that requires common functionality like a method
+ * to obtain the service.
+ */
+public abstract class MonitorServiceRemoveStepHandler extends AbstractRemoveStepHandler {
+
+    public MonitorServiceRemoveStepHandler() {
+    }
+
+    /**
+     * @param opContext context this call is coming from
+     * @return the actual service - this will be null if the agent was not enabled
+     */
+    protected MonitorService getMonitorService(OperationContext opContext) {
+        ServiceName name = SubsystemExtension.SERVICE_NAME;
+        ServiceRegistry serviceRegistry = opContext.getServiceRegistry(true);
+        ServiceController<?> service = serviceRegistry.getService(name);
+        return (service != null) ? (MonitorService) service.getValue() : null;
+    }
+}

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/MonitorServiceWriteAttributeHandler.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/MonitorServiceWriteAttributeHandler.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.agent.monitor.extension;
+
+import java.util.Collection;
+
+import org.hawkular.agent.monitor.service.MonitorService;
+import org.jboss.as.controller.AbstractWriteAttributeHandler;
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceRegistry;
+
+/**
+ * Base class to all the write attribute handlers. Simply provides a method to obtain the service.
+ *
+ * @param <T> used to assist in the revert functionality. Can be <code>Void</code> if not needed.
+ */
+public abstract class MonitorServiceWriteAttributeHandler<T> extends AbstractWriteAttributeHandler<T> {
+
+    public MonitorServiceWriteAttributeHandler(AttributeDefinition... definitions) {
+        super(definitions);
+    }
+
+    public MonitorServiceWriteAttributeHandler(Collection<AttributeDefinition> definitions) {
+        super(definitions);
+    }
+
+    protected MonitorService getMonitorService(OperationContext opContext) {
+        ServiceName name = SubsystemExtension.SERVICE_NAME;
+        ServiceRegistry serviceRegistry = opContext.getServiceRegistry(true);
+        MonitorService service = (MonitorService) serviceRegistry.getRequiredService(name).getValue();
+        return service;
+    }
+
+}

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/PlatformAdd.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/PlatformAdd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,13 +16,49 @@
  */
 package org.hawkular.agent.monitor.extension;
 
-import org.jboss.as.controller.AbstractAddStepHandler;
+import org.hawkular.agent.monitor.protocol.EndpointService;
+import org.hawkular.agent.monitor.protocol.ProtocolService;
+import org.hawkular.agent.monitor.protocol.ProtocolServices;
+import org.hawkular.agent.monitor.protocol.platform.PlatformNodeLocation;
+import org.hawkular.agent.monitor.protocol.platform.PlatformSession;
+import org.hawkular.agent.monitor.service.MonitorService;
+import org.hawkular.agent.monitor.util.Util;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.dmr.ModelNode;
 
-public class PlatformAdd extends AbstractAddStepHandler {
+public class PlatformAdd extends MonitorServiceAddStepHandler {
 
     public static final PlatformAdd INSTANCE = new PlatformAdd();
 
     private PlatformAdd() {
         super(PlatformAttributes.ATTRIBUTES);
+    }
+
+    @Override
+    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model)
+            throws OperationFailedException {
+
+        if (context.isBooting()) {
+            return;
+        }
+
+        MonitorService monitorService = getMonitorService(context);
+        if (monitorService == null) {
+            return; // the agent wasn't enabled, nothing to do
+        }
+
+        MonitorServiceConfiguration config = Util.getMonitorServiceConfiguration(context);
+
+        // create a new endpoint service
+        ProtocolServices newServices = monitorService.createProtocolServicesBuilder()
+                .platformProtocolService(config.getPlatformConfiguration()).build();
+        EndpointService<PlatformNodeLocation, PlatformSession> endpointService = newServices
+                .getPlatformProtocolService().getEndpointServices().get(context.getCurrentAddressValue());
+
+        // put the new endpoint service in the original protocol services container
+        ProtocolService<PlatformNodeLocation, PlatformSession> platformService = monitorService.getProtocolServices()
+                .getPlatformProtocolService();
+        platformService.add(endpointService);
     }
 }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/PlatformAttributes.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/PlatformAttributes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,11 +27,11 @@ public interface PlatformAttributes {
 
     SimpleAttributeDefinition ENABLED = new SimpleAttributeDefinitionBuilder("enabled",
             ModelType.BOOLEAN)
-            .setAllowNull(true)
-            .setDefaultValue(new ModelNode(true))
-            .setAllowExpression(true)
-            .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
-            .build();
+                    .setAllowNull(true)
+                    .setDefaultValue(new ModelNode(true))
+                    .setAllowExpression(true)
+                    .addFlag(AttributeAccess.Flag.RESTART_NONE)
+                    .build();
 
     AttributeDefinition[] ATTRIBUTES = {
             ENABLED

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/PlatformDefinition.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/PlatformDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,10 +20,23 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
+import org.hawkular.agent.monitor.protocol.EndpointService;
+import org.hawkular.agent.monitor.protocol.ProtocolService;
+import org.hawkular.agent.monitor.protocol.ProtocolServices;
+import org.hawkular.agent.monitor.protocol.platform.PlatformNodeLocation;
+import org.hawkular.agent.monitor.protocol.platform.PlatformSession;
+import org.hawkular.agent.monitor.scheduler.SchedulerService;
+import org.hawkular.agent.monitor.service.MonitorService;
+import org.hawkular.agent.monitor.util.Util;
+import org.jboss.as.controller.AbstractWriteAttributeHandler;
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.PersistentResourceDefinition;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry.Flag;
+import org.jboss.dmr.ModelNode;
 
 public class PlatformDefinition extends PersistentResourceDefinition {
 
@@ -36,8 +49,8 @@ public class PlatformDefinition extends PersistentResourceDefinition {
                 SubsystemExtension.getResourceDescriptionResolver(PLATFORM),
                 PlatformAdd.INSTANCE,
                 PlatformRemove.INSTANCE,
-                Flag.RESTART_RESOURCE_SERVICES,
-                Flag.RESTART_RESOURCE_SERVICES);
+                Flag.RESTART_NONE,
+                Flag.RESTART_NONE);
     }
 
     @Override
@@ -50,4 +63,74 @@ public class PlatformDefinition extends PersistentResourceDefinition {
         return Arrays.asList(FileStoresDefinition.INSTANCE, MemoryDefinition.INSTANCE, ProcessorsDefinition.INSTANCE,
                 PowerSourcesDefinition.INSTANCE);
     }
+
+    @Override
+    public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
+        Util.registerOnlyRestartAttributes(resourceRegistration, getAttributes());
+
+        resourceRegistration.registerReadWriteAttribute(PlatformAttributes.ENABLED, null,
+                new MonitorServiceWriteAttributeHandler<Void>() {
+                    @Override
+                    protected boolean applyUpdateToRuntime(
+                            OperationContext context,
+                            ModelNode operation,
+                            String attributeName,
+                            ModelNode newValue,
+                            ModelNode currentValue,
+                            AbstractWriteAttributeHandler.HandbackHolder<Void> handbackHolder)
+                                    throws OperationFailedException {
+
+                        if (context.isBooting()) {
+                            return false;
+                        }
+
+                        boolean currBool = PlatformAttributes.ENABLED.resolveValue(context, currentValue).asBoolean();
+                        boolean newBool = PlatformAttributes.ENABLED.resolveValue(context, newValue).asBoolean();
+                        if (currBool == newBool) {
+                            return false; // don't know if this would ever happen, but if it does, nothing changed
+                        }
+
+                        MonitorService monitorService = getMonitorService(context);
+                        ProtocolService<PlatformNodeLocation, PlatformSession> platformService = monitorService
+                                .getProtocolServices().getPlatformProtocolService();
+                        String thisEndpointName = context.getCurrentAddressValue();
+
+                        if (newBool) {
+                            // add the endpoint so it begins to be monitored
+
+                            // first get our subsystem config
+                            MonitorServiceConfiguration config = Util.getMonitorServiceConfiguration(context);
+
+                            // create a new endpoint service
+                            ProtocolServices newServices = monitorService.createProtocolServicesBuilder()
+                                    .platformProtocolService(config.getPlatformConfiguration())
+                                    .build();
+                            EndpointService<PlatformNodeLocation, PlatformSession> endpointService = newServices
+                                    .getPlatformProtocolService().getEndpointServices().get(thisEndpointName);
+
+                            // put the new endpoint service in the original protocol services container
+                            platformService.add(endpointService);
+                        } else {
+                            // remove the endpoint so it is no longer monitored
+                            SchedulerService schedulerService = monitorService.getSchedulerService();
+                            platformService.remove(thisEndpointName, schedulerService);
+                        }
+
+                        return false;
+                    }
+
+                    @Override
+                    protected void revertUpdateToRuntime(
+                            OperationContext context,
+                            ModelNode operation,
+                            String attributeName,
+                            ModelNode originalValue,
+                            ModelNode newBadValue,
+                            Void handback)
+                                    throws OperationFailedException {
+                        // nothing to revert?
+                    }
+                });
+    }
+
 }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/PlatformRemove.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/PlatformRemove.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,12 +16,36 @@
  */
 package org.hawkular.agent.monitor.extension;
 
-import org.jboss.as.controller.AbstractRemoveStepHandler;
+import org.hawkular.agent.monitor.protocol.ProtocolService;
+import org.hawkular.agent.monitor.scheduler.SchedulerService;
+import org.hawkular.agent.monitor.service.MonitorService;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.dmr.ModelNode;
 
-public class PlatformRemove extends AbstractRemoveStepHandler {
+public class PlatformRemove extends MonitorServiceRemoveStepHandler {
 
     public static final PlatformRemove INSTANCE = new PlatformRemove();
 
     private PlatformRemove() {
+    }
+
+    @Override
+    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model)
+            throws OperationFailedException {
+
+        if (context.isBooting()) {
+            return;
+        }
+
+        MonitorService monitorService = getMonitorService(context);
+        if (monitorService == null) {
+            return; // the agent wasn't enabled, nothing to do
+        }
+
+        SchedulerService schedulerService = monitorService.getSchedulerService();
+        ProtocolService<?, ?> platformService = monitorService.getProtocolServices().getPlatformProtocolService();
+        String doomedEndpointName = context.getCurrentAddressValue();
+        platformService.remove(doomedEndpointName, schedulerService);
     }
 }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteDMRAdd.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteDMRAdd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,13 +16,52 @@
  */
 package org.hawkular.agent.monitor.extension;
 
-import org.jboss.as.controller.AbstractAddStepHandler;
+import org.hawkular.agent.monitor.log.AgentLoggers;
+import org.hawkular.agent.monitor.log.MsgLogger;
+import org.hawkular.agent.monitor.protocol.EndpointService;
+import org.hawkular.agent.monitor.protocol.ProtocolService;
+import org.hawkular.agent.monitor.protocol.ProtocolServices;
+import org.hawkular.agent.monitor.protocol.dmr.DMRNodeLocation;
+import org.hawkular.agent.monitor.protocol.dmr.DMRSession;
+import org.hawkular.agent.monitor.service.MonitorService;
+import org.hawkular.agent.monitor.util.Util;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.dmr.ModelNode;
 
-public class RemoteDMRAdd extends AbstractAddStepHandler {
+public class RemoteDMRAdd extends MonitorServiceAddStepHandler {
+    private static final MsgLogger log = AgentLoggers.getLogger(RemoteDMRAdd.class);
 
     public static final RemoteDMRAdd INSTANCE = new RemoteDMRAdd();
 
     private RemoteDMRAdd() {
         super(RemoteDMRAttributes.ATTRIBUTES);
+    }
+
+    @Override
+    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model)
+            throws OperationFailedException {
+
+        if (context.isBooting()) {
+            return;
+        }
+
+        MonitorService monitorService = getMonitorService(context);
+        if (monitorService == null) {
+            return; // the agent wasn't enabled, nothing to do
+        }
+
+        MonitorServiceConfiguration config = Util.getMonitorServiceConfiguration(context);
+
+        // create a new endpoint service
+        ProtocolServices newServices = monitorService.createProtocolServicesBuilder()
+                .dmrProtocolService(null, config.getDmrConfiguration()).build();
+        EndpointService<DMRNodeLocation, DMRSession> endpointService = newServices.getDmrProtocolService()
+                .getEndpointServices().get(context.getCurrentAddressValue());
+
+        // put the new endpoint service in the original protocol services container
+        ProtocolService<DMRNodeLocation, DMRSession> dmrService = monitorService.getProtocolServices()
+                .getDmrProtocolService();
+        dmrService.add(endpointService);
     }
 }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteDMRAttributes.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteDMRAttributes.java
@@ -32,7 +32,7 @@ public interface RemoteDMRAttributes {
             .setAllowNull(true)
             .setDefaultValue(new ModelNode(true))
             .setAllowExpression(true)
-            .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+            .addFlag(AttributeAccess.Flag.RESTART_NONE)
             .build();
 
     SimpleAttributeDefinition HOST = new SimpleAttributeDefinitionBuilder("host",

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteDMRDefinition.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteDMRDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,10 +19,23 @@ package org.hawkular.agent.monitor.extension;
 import java.util.Arrays;
 import java.util.Collection;
 
+import org.hawkular.agent.monitor.protocol.EndpointService;
+import org.hawkular.agent.monitor.protocol.ProtocolService;
+import org.hawkular.agent.monitor.protocol.ProtocolServices;
+import org.hawkular.agent.monitor.protocol.dmr.DMRNodeLocation;
+import org.hawkular.agent.monitor.protocol.dmr.DMRSession;
+import org.hawkular.agent.monitor.scheduler.SchedulerService;
+import org.hawkular.agent.monitor.service.MonitorService;
+import org.hawkular.agent.monitor.util.Util;
+import org.jboss.as.controller.AbstractWriteAttributeHandler;
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.PersistentResourceDefinition;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry.Flag;
+import org.jboss.dmr.ModelNode;
 
 public class RemoteDMRDefinition extends PersistentResourceDefinition {
 
@@ -36,12 +49,83 @@ public class RemoteDMRDefinition extends PersistentResourceDefinition {
                         REMOTE_DMR),
                 RemoteDMRAdd.INSTANCE,
                 RemoteDMRRemove.INSTANCE,
-                Flag.RESTART_RESOURCE_SERVICES,
-                Flag.RESTART_RESOURCE_SERVICES);
+                Flag.RESTART_NONE,
+                Flag.RESTART_NONE);
     }
 
     @Override
     public Collection<AttributeDefinition> getAttributes() {
         return Arrays.asList(RemoteDMRAttributes.ATTRIBUTES);
     }
+
+    @Override
+    public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
+        Util.registerOnlyRestartAttributes(resourceRegistration, getAttributes());
+
+        resourceRegistration.registerReadWriteAttribute(RemoteDMRAttributes.ENABLED, null,
+                new MonitorServiceWriteAttributeHandler<Void>() {
+                    @Override
+                    protected boolean applyUpdateToRuntime(
+                            OperationContext context,
+                            ModelNode operation,
+                            String attributeName,
+                            ModelNode newValue,
+                            ModelNode currentValue,
+                            AbstractWriteAttributeHandler.HandbackHolder<Void> handbackHolder)
+                                    throws OperationFailedException {
+
+                        if (context.isBooting()) {
+                            return false;
+                        }
+
+                        boolean currBool = RemoteDMRAttributes.ENABLED.resolveValue(context, currentValue).asBoolean();
+                        boolean newBool = RemoteDMRAttributes.ENABLED.resolveValue(context, newValue).asBoolean();
+                        if (currBool == newBool) {
+                            return false; // don't know if this would ever happen, but if it does, nothing changed
+                        }
+
+                        MonitorService monitorService = getMonitorService(context);
+                        ProtocolService<DMRNodeLocation, DMRSession> dmrService = monitorService.getProtocolServices()
+                                .getDmrProtocolService();
+                        String thisEndpointName = context.getCurrentAddressValue();
+
+                        if (newBool) {
+                            // add the endpoint so it begins to be monitored
+
+                            // first get our subsystem config
+                            MonitorServiceConfiguration config = Util.getMonitorServiceConfiguration(context);
+
+                            // create a new endpoint service
+                            ProtocolServices newServices = monitorService.createProtocolServicesBuilder()
+                                    .dmrProtocolService(monitorService.getLocalModelControllerClientFactory(),
+                                            config.getDmrConfiguration())
+                                    .build();
+                            EndpointService<DMRNodeLocation, DMRSession> endpointService = newServices
+                                    .getDmrProtocolService().getEndpointServices().get(thisEndpointName);
+
+                            // put the new endpoint service in the original protocol services container
+                            dmrService.add(endpointService);
+                        } else {
+                            // remove the endpoint so it is no longer monitored
+                            SchedulerService schedulerService = monitorService.getSchedulerService();
+                            dmrService.remove(thisEndpointName, schedulerService);
+                        }
+
+                        return false;
+                    }
+
+                    @Override
+                    protected void revertUpdateToRuntime(
+                            OperationContext context,
+                            ModelNode operation,
+                            String attributeName,
+                            ModelNode originalValue,
+                            ModelNode newBadValue,
+                            Void handback)
+                                    throws OperationFailedException {
+                        // nothing to revert?
+                    }
+                });
+    }
+
 }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteDMRRemove.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteDMRRemove.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,12 +16,36 @@
  */
 package org.hawkular.agent.monitor.extension;
 
-import org.jboss.as.controller.AbstractRemoveStepHandler;
+import org.hawkular.agent.monitor.protocol.ProtocolService;
+import org.hawkular.agent.monitor.scheduler.SchedulerService;
+import org.hawkular.agent.monitor.service.MonitorService;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.dmr.ModelNode;
 
-public class RemoteDMRRemove extends AbstractRemoveStepHandler {
+public class RemoteDMRRemove extends MonitorServiceRemoveStepHandler {
 
     public static final RemoteDMRRemove INSTANCE = new RemoteDMRRemove();
 
     private RemoteDMRRemove() {
+    }
+
+    @Override
+    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model)
+            throws OperationFailedException {
+
+        if (context.isBooting()) {
+            return;
+        }
+
+        MonitorService monitorService = getMonitorService(context);
+        if (monitorService == null) {
+            return; // the agent wasn't enabled, nothing to do
+        }
+
+        SchedulerService schedulerService = monitorService.getSchedulerService();
+        ProtocolService<?, ?> dmrService = monitorService.getProtocolServices().getDmrProtocolService();
+        String doomedEndpointName = context.getCurrentAddressValue();
+        dmrService.remove(doomedEndpointName, schedulerService);
     }
 }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteJMXAttributes.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteJMXAttributes.java
@@ -32,7 +32,7 @@ public interface RemoteJMXAttributes {
             .setAllowNull(true)
             .setDefaultValue(new ModelNode(true))
             .setAllowExpression(true)
-            .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+            .addFlag(AttributeAccess.Flag.RESTART_NONE)
             .build();
 
     SimpleAttributeDefinition URL = new SimpleAttributeDefinitionBuilder("url",

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteJMXDefinition.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteJMXDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,10 +19,23 @@ package org.hawkular.agent.monitor.extension;
 import java.util.Arrays;
 import java.util.Collection;
 
+import org.hawkular.agent.monitor.protocol.EndpointService;
+import org.hawkular.agent.monitor.protocol.ProtocolService;
+import org.hawkular.agent.monitor.protocol.ProtocolServices;
+import org.hawkular.agent.monitor.protocol.jmx.JMXNodeLocation;
+import org.hawkular.agent.monitor.protocol.jmx.JMXSession;
+import org.hawkular.agent.monitor.scheduler.SchedulerService;
+import org.hawkular.agent.monitor.service.MonitorService;
+import org.hawkular.agent.monitor.util.Util;
+import org.jboss.as.controller.AbstractWriteAttributeHandler;
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.PersistentResourceDefinition;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry.Flag;
+import org.jboss.dmr.ModelNode;
 
 public class RemoteJMXDefinition extends PersistentResourceDefinition {
 
@@ -36,12 +49,82 @@ public class RemoteJMXDefinition extends PersistentResourceDefinition {
                         REMOTE_JMX),
                 RemoteJMXAdd.INSTANCE,
                 RemoteJMXRemove.INSTANCE,
-                Flag.RESTART_RESOURCE_SERVICES,
-                Flag.RESTART_RESOURCE_SERVICES);
+                Flag.RESTART_NONE,
+                Flag.RESTART_NONE);
     }
 
     @Override
     public Collection<AttributeDefinition> getAttributes() {
         return Arrays.asList(RemoteJMXAttributes.ATTRIBUTES);
     }
+
+    @Override
+    public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
+        Util.registerOnlyRestartAttributes(resourceRegistration, getAttributes());
+
+        resourceRegistration.registerReadWriteAttribute(RemoteJMXAttributes.ENABLED, null,
+                new MonitorServiceWriteAttributeHandler<Void>() {
+                    @Override
+                    protected boolean applyUpdateToRuntime(
+                            OperationContext context,
+                            ModelNode operation,
+                            String attributeName,
+                            ModelNode newValue,
+                            ModelNode currentValue,
+                            AbstractWriteAttributeHandler.HandbackHolder<Void> handbackHolder)
+                                    throws OperationFailedException {
+
+                        if (context.isBooting()) {
+                            return false;
+                        }
+
+                        boolean currBool = RemoteJMXAttributes.ENABLED.resolveValue(context, currentValue).asBoolean();
+                        boolean newBool = RemoteJMXAttributes.ENABLED.resolveValue(context, newValue).asBoolean();
+                        if (currBool == newBool) {
+                            return false; // don't know if this would ever happen, but if it does, nothing changed
+                        }
+
+                        MonitorService monitorService = getMonitorService(context);
+                        ProtocolService<JMXNodeLocation, JMXSession> jmxService = monitorService.getProtocolServices()
+                                .getJmxProtocolService();
+                        String thisEndpointName = context.getCurrentAddressValue();
+
+                        if (newBool) {
+                            // add the endpoint so it begins to be monitored
+
+                            // first get our subsystem config
+                            MonitorServiceConfiguration config = Util.getMonitorServiceConfiguration(context);
+
+                            // create a new endpoint service
+                            ProtocolServices newServices = monitorService.createProtocolServicesBuilder()
+                                    .jmxProtocolService(config.getJmxConfiguration())
+                                    .build();
+                            EndpointService<JMXNodeLocation, JMXSession> endpointService = newServices
+                                    .getJmxProtocolService().getEndpointServices().get(thisEndpointName);
+
+                            // put the new endpoint service in the original protocol services container
+                            jmxService.add(endpointService);
+                        } else {
+                            // remove the endpoint so it is no longer monitored
+                            SchedulerService schedulerService = monitorService.getSchedulerService();
+                            jmxService.remove(thisEndpointName, schedulerService);
+                        }
+
+                        return false;
+                    }
+
+                    @Override
+                    protected void revertUpdateToRuntime(
+                            OperationContext context,
+                            ModelNode operation,
+                            String attributeName,
+                            ModelNode originalValue,
+                            ModelNode newBadValue,
+                            Void handback)
+                                    throws OperationFailedException {
+                        // nothing to revert?
+                    }
+                });
+    }
+
 }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteJMXRemove.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteJMXRemove.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,12 +16,36 @@
  */
 package org.hawkular.agent.monitor.extension;
 
-import org.jboss.as.controller.AbstractRemoveStepHandler;
+import org.hawkular.agent.monitor.protocol.ProtocolService;
+import org.hawkular.agent.monitor.scheduler.SchedulerService;
+import org.hawkular.agent.monitor.service.MonitorService;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.dmr.ModelNode;
 
-public class RemoteJMXRemove extends AbstractRemoveStepHandler {
+public class RemoteJMXRemove extends MonitorServiceRemoveStepHandler {
 
     public static final RemoteJMXRemove INSTANCE = new RemoteJMXRemove();
 
     private RemoteJMXRemove() {
+    }
+
+    @Override
+    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model)
+            throws OperationFailedException {
+
+        if (context.isBooting()) {
+            return;
+        }
+
+        MonitorService monitorService = getMonitorService(context);
+        if (monitorService == null) {
+            return; // the agent wasn't enabled, nothing to do
+        }
+
+        SchedulerService schedulerService = monitorService.getSchedulerService();
+        ProtocolService<?, ?> jmxService = monitorService.getProtocolServices().getJmxProtocolService();
+        String doomedEndpointName = context.getCurrentAddressValue();
+        jmxService.remove(doomedEndpointName, schedulerService);
     }
 }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemotePrometheusAttributes.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemotePrometheusAttributes.java
@@ -33,7 +33,7 @@ public interface RemotePrometheusAttributes {
                     .setAllowNull(true)
                     .setDefaultValue(new ModelNode(true))
                     .setAllowExpression(true)
-                    .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+                    .addFlag(AttributeAccess.Flag.RESTART_NONE)
                     .build();
 
     SimpleAttributeDefinition URL = new SimpleAttributeDefinitionBuilder("url",

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemotePrometheusDefinition.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemotePrometheusDefinition.java
@@ -19,13 +19,22 @@ package org.hawkular.agent.monitor.extension;
 import java.util.Arrays;
 import java.util.Collection;
 
+import org.hawkular.agent.monitor.dynamicprotocol.DynamicEndpointService;
+import org.hawkular.agent.monitor.dynamicprotocol.DynamicProtocolService;
+import org.hawkular.agent.monitor.dynamicprotocol.DynamicProtocolServices;
+import org.hawkular.agent.monitor.service.MonitorService;
+import org.hawkular.agent.monitor.util.Util;
+import org.jboss.as.controller.AbstractWriteAttributeHandler;
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.PersistentResourceDefinition;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry.Flag;
+import org.jboss.dmr.ModelNode;
 
 public class RemotePrometheusDefinition extends PersistentResourceDefinition {
-
     public static final RemotePrometheusDefinition INSTANCE = new RemotePrometheusDefinition();
 
     static final String REMOTE_PROMETHEUS = "remote-prometheus";
@@ -36,12 +45,84 @@ public class RemotePrometheusDefinition extends PersistentResourceDefinition {
                         REMOTE_PROMETHEUS),
                 RemotePrometheusAdd.INSTANCE,
                 RemotePrometheusRemove.INSTANCE,
-                Flag.RESTART_RESOURCE_SERVICES,
-                Flag.RESTART_RESOURCE_SERVICES);
+                Flag.RESTART_NONE,
+                Flag.RESTART_NONE);
     }
 
     @Override
     public Collection<AttributeDefinition> getAttributes() {
         return Arrays.asList(RemotePrometheusAttributes.ATTRIBUTES);
     }
+
+    @Override
+    public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
+        Util.registerOnlyRestartAttributes(resourceRegistration, getAttributes());
+
+        resourceRegistration.registerReadWriteAttribute(RemotePrometheusAttributes.ENABLED, null,
+                new MonitorServiceWriteAttributeHandler<Void>() {
+                    @Override
+                    protected boolean applyUpdateToRuntime(
+                            OperationContext context,
+                            ModelNode operation,
+                            String attributeName,
+                            ModelNode newValue,
+                            ModelNode currentValue,
+                            AbstractWriteAttributeHandler.HandbackHolder<Void> handbackHolder)
+                                    throws OperationFailedException {
+
+                        if (context.isBooting()) {
+                            return false;
+                        }
+
+                        boolean currBool = RemotePrometheusAttributes.ENABLED.resolveValue(context, currentValue)
+                                .asBoolean();
+                        boolean newBool = RemotePrometheusAttributes.ENABLED.resolveValue(context, newValue)
+                                .asBoolean();
+                        if (currBool == newBool) {
+                            return false; // don't know if this would ever happen, but if it does, nothing changed
+                        }
+
+                        MonitorService monitorService = getMonitorService(context);
+                        DynamicProtocolService promService = monitorService.getDynamicProtocolServices()
+                                .getPrometheusProtocolService();
+                        String thisEndpointName = context.getCurrentAddressValue();
+
+                        if (newBool) {
+                            // add the endpoint so it begins to be monitored
+
+                            // first get our subsystem config
+                            MonitorServiceConfiguration config = Util.getMonitorServiceConfiguration(context);
+
+                            // create a new endpoint service
+                            DynamicProtocolServices newServices = monitorService.createDynamicProtocolServicesBuilder()
+                                    .prometheusDynamicProtocolService(config.getPrometheusConfiguration(),
+                                            monitorService.getHawkularMonitorContext())
+                                    .build();
+                            DynamicEndpointService endpointService = newServices.getPrometheusProtocolService()
+                                    .getDynamicEndpointServices().get(thisEndpointName);
+
+                            // put the new endpoint service in the original protocol services container
+                            promService.add(endpointService);
+                        } else {
+                            // remove the endpoint so it is no longer monitored
+                            promService.remove(thisEndpointName);
+                        }
+
+                        return false;
+                    }
+
+                    @Override
+                    protected void revertUpdateToRuntime(
+                            OperationContext context,
+                            ModelNode operation,
+                            String attributeName,
+                            ModelNode originalValue,
+                            ModelNode newBadValue,
+                            Void handback)
+                                    throws OperationFailedException {
+                        // nothing to revert?
+                    }
+                });
+    }
+
 }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/SubsystemExtension.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/SubsystemExtension.java
@@ -27,7 +27,7 @@ import org.jboss.msc.service.ServiceName;
 
 public class SubsystemExtension implements Extension {
 
-    static final String SUBSYSTEM_NAME = "hawkular-wildfly-agent";
+    public static final String SUBSYSTEM_NAME = "hawkular-wildfly-agent";
     static final String NAMESPACE = "urn:org.hawkular.agent:agent:1.0";
     static final int MAJOR_VERSION = 1;
     static final int MINOR_VERSION = 0;

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/inventory/ResourceManager.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/inventory/ResourceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -346,7 +346,7 @@ public final class ResourceManager<L> {
 
             Set<Resource<L>> roots = getRootResources();
             if (roots.isEmpty()) {
-                throw new IllegalStateException("There are no root nodes; cannot traverse");
+                return Collections.emptyList();
             }
 
             // loop over each root resource and traverse their tree hierarchy breadth-first

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/log/MsgLogger.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/log/MsgLogger.java
@@ -320,4 +320,20 @@ public interface MsgLogger extends BasicLogger {
     @Message(id = 10069, value = "Cannot get tenant ID. Will retry in 60 seconds. Error=[%s]")
     void errorRetryTenantId(String errorMsg);
 
+    @LogMessage(level = Level.INFO)
+    @Message(id = 10070, value = "No longer monitoring the endpoint [%s]")
+    void infoRemovedDynamicEndpointService(String id);
+
+    @LogMessage(level = Level.INFO)
+    @Message(id = 10071, value = "No longer monitoring the endpoint [%s]")
+    void infoRemovedEndpointService(String id);
+
+    @LogMessage(level = Level.INFO)
+    @Message(id = 10072, value = "Now monitoring the new endpoint [%s]")
+    void infoAddedDynamicEndpointService(String string);
+
+    @LogMessage(level = Level.INFO)
+    @Message(id = 10073, value = "Now monitoring the new endpoint [%s]")
+    void infoAddedEndpointService(String string);
+
 }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/protocol/ProtocolService.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/protocol/ProtocolService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,15 +18,18 @@ package org.hawkular.agent.monitor.protocol;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.hawkular.agent.monitor.api.InventoryListener;
 import org.hawkular.agent.monitor.inventory.NodeLocation;
-import org.hawkular.agent.monitor.inventory.ResourceTypeManager;
+import org.hawkular.agent.monitor.inventory.Resource;
+import org.hawkular.agent.monitor.log.AgentLoggers;
+import org.hawkular.agent.monitor.log.MsgLogger;
+import org.hawkular.agent.monitor.scheduler.SchedulerService;
 
 /**
- * A collection of {@link EndpointService}s that all handle a single protocol and share a single
- * {@link ResourceTypeManager}.
+ * A collection of {@link EndpointService}s that all handle a single protocol.
  *
  * @author <a href="https://github.com/ppalaga">Peter Palaga</a>
  *
@@ -34,12 +37,13 @@ import org.hawkular.agent.monitor.inventory.ResourceTypeManager;
  * @param <S> the protocol specific {@link Session}
  */
 public class ProtocolService<L, S extends Session<L>> {
+    private static final MsgLogger log = AgentLoggers.getLogger(ProtocolService.class);
 
     public static class Builder<L, S extends Session<L>> {
         private Map<String, EndpointService<L, S>> endpointServices = new HashMap<>();
 
         public ProtocolService<L, S> build() {
-            return new ProtocolService<L, S>(Collections.unmodifiableMap(endpointServices));
+            return new ProtocolService<L, S>(Collections.synchronizedMap(endpointServices));
         }
 
         public Builder<L, S> endpointService(EndpointService<L, S> endpointService) {
@@ -57,38 +61,78 @@ public class ProtocolService<L, S extends Session<L>> {
         this.endpointServices = endpointServices;
     }
 
+    /**
+     * @return a shallow copy of all endpoint services
+     */
     public Map<String, EndpointService<L, S>> getEndpointServices() {
-        return endpointServices;
+        synchronized (endpointServices) {
+            return new HashMap<>(endpointServices);
+        }
     }
 
     public void discoverAll() {
-        for (EndpointService<L, S> service : endpointServices.values()) {
+        for (EndpointService<L, S> service : getEndpointServices().values()) {
             service.discoverAll();
         }
     }
 
     public void start() {
-        for (EndpointService<L, S> service : endpointServices.values()) {
+        for (EndpointService<L, S> service : getEndpointServices().values()) {
             service.start();
         }
     }
 
     public void stop() {
-        for (EndpointService<L, S> service : endpointServices.values()) {
+        for (EndpointService<L, S> service : getEndpointServices().values()) {
             service.stop();
         }
     }
 
     public void addInventoryListener(InventoryListener listener) {
-        for (EndpointService<L, S> service : endpointServices.values()) {
+        for (EndpointService<L, S> service : getEndpointServices().values()) {
             service.addInventoryListener(listener);
         }
     }
 
     public void removeInventoryListener(InventoryListener listener) {
-        for (EndpointService<L, S> service : endpointServices.values()) {
+        for (EndpointService<L, S> service : getEndpointServices().values()) {
             service.removeInventoryListener(listener);
         }
     }
 
+    /**
+     * This will add a new endpoint service to the list. Once added, the new service
+     * will immediately be started.
+     *
+     * @param newEndpointService the new service to add and start
+     */
+    public void add(EndpointService<L, S> newEndpointService) {
+        if (newEndpointService == null) {
+            throw new IllegalArgumentException("New endpoint service must not be null");
+        }
+
+        endpointServices.put(newEndpointService.getMonitoredEndpoint().getName(), newEndpointService);
+        newEndpointService.start();
+        log.infoAddedEndpointService(newEndpointService.toString());
+
+        newEndpointService.discoverAll();
+    }
+
+    /**
+     * This will stop the given endpoint service and remove it from the list of endpoint services.
+     *
+     * @param name identifies the endpoint service to remove
+     * @param scheduler the scheduler that is currently collecting metrics for this service
+     */
+    public void remove(String name, SchedulerService scheduler) {
+        EndpointService<L, S> service = endpointServices.remove(name);
+        if (service != null) {
+            service.stop();
+
+            List<Resource<L>> allResources = service.getResourceManager().getResourcesBreadthFirst();
+            scheduler.unschedule(service, allResources);
+
+            log.infoRemovedEndpointService(service.toString());
+        }
+    }
 }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/protocol/ProtocolServices.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/protocol/ProtocolServices.java
@@ -88,7 +88,7 @@ public class ProtocolServices {
         }
 
         public Builder dmrProtocolService(
-                ModelControllerClientFactory localModelControllerClientFactory,
+                ModelControllerClientFactory localModelControllerClientFactory, // may be null; only needed for local
                 ProtocolConfiguration<DMRNodeLocation> protocolConfig) {
 
             ProtocolService.Builder<DMRNodeLocation, DMRSession> builder = ProtocolService.builder();
@@ -163,8 +163,7 @@ public class ProtocolServices {
             return this;
         }
 
-        public Builder platformProtocolService(
-                ProtocolConfiguration<PlatformNodeLocation> protocolConfig) {
+        public Builder platformProtocolService(ProtocolConfiguration<PlatformNodeLocation> protocolConfig) {
 
             ProtocolService.Builder<PlatformNodeLocation, PlatformSession> builder = ProtocolService
                     .builder();
@@ -225,17 +224,6 @@ public class ProtocolServices {
         this.services = Collections.unmodifiableList(Arrays.asList(dmrProtocolService, jmxProtocolService,
                 platformProtocolService));
         this.autoDiscoveryScanPeriodSecs = autoDiscoveryScanPeriodSecs;
-    }
-
-    @SuppressWarnings("unchecked")
-    public <L, S extends Session<L>> EndpointService<L, S> getEndpointService(String endpointName) {
-        for (ProtocolService<?, ?> service : services) {
-            EndpointService<?, ?> result = service.getEndpointServices().get(endpointName);
-            if (result != null) {
-                return (EndpointService<L, S>) result;
-            }
-        }
-        return null;
     }
 
     public void start() {

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/scheduler/MeasurementScheduler.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/scheduler/MeasurementScheduler.java
@@ -152,7 +152,7 @@ public abstract class MeasurementScheduler<L, T extends MeasurementType<L>, D ex
      * @param endpointService defines where the resources are
      * @param resources the resources whose metric collections/avail checks are to be added to the scheduler
      */
-    public void schedule(SamplingService<L> endpointService, List<Resource<L>> resources) {
+    public void schedule(SamplingService<L> endpointService, Collection<Resource<L>> resources) {
         status.assertRunning(getClass(), "schedule()");
 
         List<ScheduledMeasurementInstance<L, T>> schedules = new ArrayList<>();
@@ -172,7 +172,7 @@ public abstract class MeasurementScheduler<L, T extends MeasurementType<L>, D ex
      * @param endpointService defines where the resources are
      * @param resources the resources whose metric collections/avail checks are to be removed from the scheduler
      */
-    public void unschedule(SamplingService<L> endpointService, List<Resource<L>> resources) {
+    public void unschedule(SamplingService<L> endpointService, Collection<Resource<L>> resources) {
         status.assertRunning(getClass(), "unschedule()");
 
         ScheduledCollectionsQueue<L, T> queue = getScheduledCollectionsQueue(endpointService);

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/scheduler/SchedulerService.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/scheduler/SchedulerService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,7 @@
  */
 package org.hawkular.agent.monitor.scheduler;
 
+import java.util.Collection;
 import java.util.List;
 
 import org.hawkular.agent.monitor.api.InventoryEvent;
@@ -120,8 +121,11 @@ public class SchedulerService implements InventoryListener {
         log.debugf("Unscheduling jobs for [%d] obsolete resources for endpoint [%s]",
                 resources.size(), service.getMonitoredEndpoint());
 
+        unschedule(service, resources);
+    }
+
+    public <L> void unschedule(SamplingService<L> service, Collection<Resource<L>> resources) {
         ((MeasurementScheduler) metricScheduler).unschedule(service, resources);
         ((MeasurementScheduler) availScheduler).unschedule(service, resources);
     }
-
 }

--- a/hawkular-wildfly-agent/src/test/java/org/hawkular/agent/monitor/inventory/ResourceManagerTest.java
+++ b/hawkular-wildfly-agent/src/test/java/org/hawkular/agent/monitor/inventory/ResourceManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,11 +34,7 @@ public class ResourceManagerTest {
         ResourceManager<DMRNodeLocation> rm = new ResourceManager<>();
         Assert.assertNull(rm.getResource(new ID("foo")));
         Assert.assertTrue(rm.getRootResources().isEmpty());
-        try {
-            rm.getResourcesBreadthFirst();
-            Assert.fail("Should have failed since we don't have any root resources");
-        } catch (IllegalStateException expected) {
-        }
+        Assert.assertTrue(rm.getResourcesBreadthFirst().isEmpty());
     }
 
     @Test


### PR DESCRIPTION
This allows someone to add/remove and enable/disable remote endpoints (remote-dmr/jmx/prometheus) and the local wildfly endpoint (local-dmr).

All other configuration settings will require a restart of the agent subsystem to take effect.
