### PR TITLE
getCanonicalHostName sometimes gives us what we don't want

### DIFF
--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/service/MonitorService.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/service/MonitorService.java
@@ -170,7 +170,7 @@ public class MonitorService implements Service<MonitorService> {
                         } else {
                             socketBinding = httpSocketBindingValue.getValue();
                         }
-                        address = socketBinding.getAddress().getCanonicalHostName();
+                        address = socketBinding.getAddress().getHostName();
                         if (address.equals("0.0.0.0") || address.equals("::/128")) {
                             address = InetAddress.getLocalHost().getCanonicalHostName();
                         }
@@ -178,7 +178,7 @@ public class MonitorService implements Service<MonitorService> {
                     } else {
                         OutboundSocketBinding serverBinding = serverOutboundSocketBindingValue
                                 .getValue();
-                        address = serverBinding.getResolvedDestinationAddress().getCanonicalHostName();
+                        address = serverBinding.getResolvedDestinationAddress().getHostName();
                         port = serverBinding.getDestinationPort();
                     }
                     String protocol = (bootStorageAdapter.isUseSSL()) ? "https" : "http";


### PR DESCRIPTION
(i.e. resolves to a load balancer in a cloud environment)

so just use getHostName. If course, if the user gives us an IP address and it resolves to the wrong hostname, we have the reverse problem.
