### PR TITLE
this "deploy" operation should not be here. There is no "Deploy" DMR …

### DIFF
--- a/hawkular-wildfly-agent-feature-pack/src/main/resources/subsystem-templates/hawkular-wildfly-agent.xml
+++ b/hawkular-wildfly-agent-feature-pack/src/main/resources/subsystem-templates/hawkular-wildfly-agent.xml
@@ -606,7 +606,6 @@
         <operation-dmr name="Resume"   operationName="resume" />
         <operation-dmr name="Shutdown" operationName="shutdown" /> <!-- shutdown and restart -->
         <operation-dmr name="Suspend"  operationName="suspend" />
-        <operation-dmr name="Deploy"   operationName="deploy"   />
 
       </resource-type-dmr>
     </resource-type-set-dmr>


### PR DESCRIPTION
There is no "Deploy" DMR  operation that ExecuteOperationRequest can process.

We already have DeployApplicationRequest that the agent can invoke via the Websocket command interface, but these <operation> metadata is not related to the websocket commands like that.

These DMR operations are only invoked directly over the WildFly management interface via the ExecuteOperationRequest. And there is no "deploy" DMR operation on the root resource in WildFly.
