### PR TITLE
HWKAGENT-407 mark avail down if can't connect to endpoint

### DIFF
--- a/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-cmdgw-itest/src/test/java/org/hawkular/agent/ws/test/DatasourceCommandITest.java
+++ b/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-cmdgw-itest/src/test/java/org/hawkular/agent/ws/test/DatasourceCommandITest.java
@@ -16,8 +16,7 @@
  */
 package org.hawkular.agent.ws.test;
 
-import java.net.URLEncoder;
-
+import org.hawkular.agent.monitor.util.Util;
 import org.hawkular.cmdgw.ws.test.TestWebSocketClient;
 import org.hawkular.inventory.paths.CanonicalPath;
 import org.jboss.as.controller.client.ModelControllerClient;
@@ -160,7 +159,7 @@ public class DatasourceCommandITest extends AbstractCommandITest {
         ModelNode dsAddress = datasourceAddess(datasourceName, false);
 
         String dsPath = wfPath.toString().replaceFirst("\\~+$", "")
-                + URLEncoder.encode("~/subsystem=datasources/data-source=" + datasourceName, "UTF-8");
+                + Util.urlEncode("~/subsystem=datasources/data-source=" + datasourceName);
 
         try (ModelControllerClient mcc = newHawkularModelControllerClient()) {
             assertNodeEquals(mcc, dsAddress, getClass(), dsFileNameAfterAdd);
@@ -212,7 +211,7 @@ public class DatasourceCommandITest extends AbstractCommandITest {
         ModelNode dsAddress = datasourceAddess(xaDatasourceName, true);
 
         String dsPath = wfPath.toString().replaceFirst("\\~+$", "")
-                + URLEncoder.encode("~/subsystem=datasources/xa-data-source=" + xaDatasourceName, "UTF-8");
+                + Util.urlEncode("~/subsystem=datasources/xa-data-source=" + xaDatasourceName);
 
         try (ModelControllerClient mcc = newHawkularModelControllerClient()) {
             assertNodeEquals(mcc, dsAddress, getClass(), xaDsFileNameAfterAdd);
@@ -265,7 +264,7 @@ public class DatasourceCommandITest extends AbstractCommandITest {
         ModelNode dsAddress = datasourceAddess(datasourceName, false);
 
         String removePath = wfPath.toString().replaceFirst("\\~+$", "")
-                + URLEncoder.encode("~/subsystem=datasources/data-source=" + datasourceName, "UTF-8");
+                + Util.urlEncode("~/subsystem=datasources/data-source=" + datasourceName);
 
         try (ModelControllerClient mcc = newHawkularModelControllerClient()) {
             assertResourceExists(mcc, dsAddress, true);
@@ -312,7 +311,7 @@ public class DatasourceCommandITest extends AbstractCommandITest {
         ModelNode dsAddress = datasourceAddess(xaDatasourceName, true);
 
         String removePath = wfPath.toString().replaceFirst("\\~+$", "")
-                + URLEncoder.encode("~/subsystem=datasources/xa-data-source=" + xaDatasourceName, "UTF-8");
+                + Util.urlEncode("~/subsystem=datasources/xa-data-source=" + xaDatasourceName);
 
         try (ModelControllerClient mcc = newHawkularModelControllerClient()) {
             assertResourceExists(mcc, dsAddress, true);

--- a/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-cmdgw-itest/src/test/java/org/hawkular/agent/ws/test/JdbcDriverCommandITest.java
+++ b/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-cmdgw-itest/src/test/java/org/hawkular/agent/ws/test/JdbcDriverCommandITest.java
@@ -18,8 +18,8 @@ package org.hawkular.agent.ws.test;
 
 import java.io.File;
 import java.net.URL;
-import java.net.URLEncoder;
 
+import org.hawkular.agent.monitor.util.Util;
 import org.hawkular.cmdgw.ws.test.TestWebSocketClient;
 import org.hawkular.cmdgw.ws.test.TestWebSocketClient.MessageAnswer;
 import org.hawkular.inventory.paths.CanonicalPath;
@@ -95,7 +95,7 @@ public class JdbcDriverCommandITest extends AbstractCommandITest {
         final ModelNode driverAddress = driverAddress();
 
         String removePath = wfPath.toString().replaceFirst("\\~+$", "")
-                + URLEncoder.encode("~/subsystem=datasources/jdbc-driver=" + driverName, "UTF-8");
+                + Util.urlEncode("~/subsystem=datasources/jdbc-driver=" + driverName);
 
         try (ModelControllerClient mcc = newHawkularModelControllerClient()) {
             ModelNode datasourcesPath = new ModelNode().add(ModelDescriptionConstants.SUBSYSTEM, "datasources");

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/api/SamplingService.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/api/SamplingService.java
@@ -44,6 +44,7 @@ public interface SamplingService<L> {
 
     /**
      * Checks the availabilities defined by {@code instances} and reports them back to the given {@code consumer}.
+     * If the relevant Endpoint is unreachable all instances are reported as {@code Avail.DOWN}.
      *
      * @param instances the availabilities to check
      * @param consumer the consumer to send the results to

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/util/Util.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/util/Util.java
@@ -117,9 +117,10 @@ public class Util {
     }
 
     /**
-     * Encodes the given string so it can be placed inside a URL.
+     * Encodes the given string so it can be placed inside a URL. This should not be the query part of the URL, for
+     * that use {@link #urlEncodeQuery(String)}.
      *
-     * @param str string to encode
+     * @param str non-query string to encode
      * @return encoded string that can be placed inside a URL
      */
     public static String urlEncode(String str) {
@@ -127,6 +128,22 @@ public class Util {
             String encodeForForm = URLEncoder.encode(str, "UTF-8");
             String encodeForUrl = encodeForForm.replace("+", "%20");
             return encodeForUrl;
+        } catch (UnsupportedEncodingException e) {
+            throw new IllegalStateException("JVM does not support UTF-8");
+        }
+    }
+
+    /**
+     * Encodes the given string so it can be placed inside a URL. This should oly be used for
+     * the query part of the URL, for other parts, like path, use {@link #urlEncode(String)}.
+     *
+     * @param str non-query string to encode
+     * @return encoded string that can be placed inside a URL
+     */
+    public static String urlEncodeQuery(String str) {
+        try {
+            String encodeForForm = URLEncoder.encode(str, "UTF-8");
+            return encodeForForm;
         } catch (UnsupportedEncodingException e) {
             throw new IllegalStateException("JVM does not support UTF-8");
         }


### PR DESCRIPTION
HWKAGENT-407  when unable to connect to the endpoint, set avails to down
- for remote monitoring this should solve the issue, if you can't connect
  to the endpoint we should assume it's down, and that it's associated
  resources are down.
- for local/embedded dmr this shouldn't happen, because if the server
  goes down so will the agent
