### PR TITLE
remove arquillian so all itests use the same test framework

### DIFF
--- a/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-cmdgw-itest/pom.xml
+++ b/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-cmdgw-itest/pom.xml
@@ -35,25 +35,6 @@
     <hawkular.test.staging.dir>${project.build.directory}/staging</hawkular.test.staging.dir>
   </properties>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.jboss.arquillian</groupId>
-        <artifactId>arquillian-bom</artifactId>
-        <version>${version.org.jboss.arquillian}</version>
-        <scope>import</scope>
-        <type>pom</type>
-      </dependency>
-
-      <dependency>
-        <groupId>org.wildfly.arquillian</groupId>
-        <artifactId>wildfly-arquillian-container-managed</artifactId>
-        <version>${version.org.wildfly.arquillian}</version>
-      </dependency>
-
-    </dependencies>
-  </dependencyManagement>
-
   <dependencies>
     <dependency>
       <groupId>com.squareup.okhttp</groupId>
@@ -78,6 +59,13 @@
       <artifactId>hawkular-wildfly-agent-itest-feature-pack</artifactId>
       <version>${project.version}</version>
       <type>zip</type>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hawkular.agent</groupId>
+      <artifactId>hawkular-wildfly-agent-itest-util</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
@@ -121,20 +109,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jboss.arquillian.testng</groupId>
-      <artifactId>arquillian-testng-container</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.wildfly.arquillian</groupId>
-      <artifactId>wildfly-arquillian-container-managed</artifactId>
       <scope>test</scope>
     </dependency>
 
@@ -176,8 +152,8 @@
       <id>itest</id>
       <properties>
         <surefire.testng.verbose>3</surefire.testng.verbose>
-        <hawkular.agent.itest.includes>**/*ITest.class</hawkular.agent.itest.includes>
 
+        <hawkular.agent.itest.includes>**/*ITest.class</hawkular.agent.itest.includes>
         <hawkular.agent.itest.run.dir>${project.build.directory}/${project.artifactId}-${project.version}</hawkular.agent.itest.run.dir>
 
         <hawkular.agent.itest.mgmt.user>itest-admin</hawkular.agent.itest.mgmt.user>
@@ -283,66 +259,6 @@
             </dependencies>
           </plugin>
 
-          <!-- Add various users to the itest distro -->
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>exec-maven-plugin</artifactId>
-            <executions>
-
-              <execution>
-                <id>create-management-itest-user</id>
-                <phase>process-classes</phase>
-                <goals>
-                  <goal>exec</goal>
-                </goals>
-                <configuration>
-                  <executable>java</executable>
-                  <environmentVariables>
-                    <JBOSS_HOME>${project.build.directory}/${project.build.finalName}</JBOSS_HOME>
-                  </environmentVariables>
-                  <arguments>
-                    <argument>-jar</argument>
-                    <argument>${project.build.directory}/${project.build.finalName}/jboss-modules.jar</argument>
-                    <argument>-mp</argument>
-                    <argument>${project.build.directory}/${project.build.finalName}/modules</argument>
-                    <argument>org.jboss.as.domain-add-user</argument>
-                    <argument>--user</argument>
-                    <argument>${hawkular.agent.itest.mgmt.user}</argument>
-                    <argument>--password</argument>
-                    <argument>${hawkular.agent.itest.mgmt.password}</argument>
-                  </arguments>
-                </configuration>
-              </execution>
-              <execution>
-                <id>create-rest-itest-user</id>
-                <phase>process-classes</phase>
-                <goals>
-                  <goal>exec</goal>
-                </goals>
-                <configuration>
-                  <executable>java</executable>
-                  <environmentVariables>
-                    <JBOSS_HOME>${project.build.directory}/${project.build.finalName}</JBOSS_HOME>
-                  </environmentVariables>
-                  <arguments>
-                    <argument>-jar</argument>
-                    <argument>${project.build.directory}/${project.build.finalName}/jboss-modules.jar</argument>
-                    <argument>-mp</argument>
-                    <argument>${project.build.directory}/${project.build.finalName}/modules</argument>
-                    <argument>org.jboss.as.domain-add-user</argument>
-                    <argument>-a</argument>
-                    <argument>--user</argument>
-                    <argument>${hawkular.itest.rest.user}</argument>
-                    <argument>--password</argument>
-                    <argument>${hawkular.itest.rest.password}</argument>
-                    <argument>--group</argument>
-                    <argument>read-write,read-only</argument>
-                  </arguments>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-
           <!-- To run a subset of tests, specify the test class paths explicitly. For example:
                -Dhawkular.agent.itest.includes=**/MyITest.class,**/EchoCommandITest.class -Pitest
           -->
@@ -350,34 +266,13 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
             <configuration>
-              <dependenciesToScan>
-                <dependency>org.hawkular.commons:hawkular-command-gateway-itest</dependency>
-              </dependenciesToScan>
               <includes>
                 <include>${hawkular.agent.itest.includes}</include>
               </includes>
               <systemPropertyVariables>
-                <jboss.home>${project.build.directory}/${project.build.finalName}</jboss.home>
-                <jboss.options>-Xmx1024m -XX:MaxPermSize=1024m
-                    -Djava.net.preferIPv4Stack=true
-                    -Djboss.bind.address=${hawkular.bind.address}
-                    -Djboss.socket.binding.port-offset=${hawkular.port.offset}
-                    -Dhawkular.agent.enabled=${hawkular.agent.enabled}
-                    -Dhawkular.rest.user=${hawkular.itest.rest.user}
-                    -Dhawkular.rest.password=${hawkular.itest.rest.password}
-                    -Dhawkular.rest.tenantId=${hawkular.itest.rest.tenantId}
-                    -Dhawkular.log.root=${hawkular.log.root}
-                    -Dhawkular.log.console=${hawkular.log.console}
-                    -Dhawkular.log.bus=${hawkular.log.bus}
-                    -Dhawkular.log.cmdgw=${hawkular.log.cmdgw}
-                    -Dhawkular.log.inventory=${hawkular.log.inventory}
-                    -Dorg.hawkular.inventory.rest.requests=${org.hawkular.inventory.rest.requests}
-                    -Dhawkular.log.metrics=${hawkular.log.metrics}
-                    -Dhawkular.log.nest=${hawkular.log.nest}
-                    -Dhawkular.log.datastax.driver=${hawkular.log.datastax.driver}
-                    -Dhawkular.log.cassandra=${hawkular.log.cassandra}
-                    ${debug.wildfly.argLine}
-                </jboss.options>
+
+                <hawkular.bind.address>${hawkular.bind.address}</hawkular.bind.address>
+                <hawkular.port.offset>${hawkular.port.offset}</hawkular.port.offset>
 
                 <hawkular.agent.itest.mgmt.user>${hawkular.agent.itest.mgmt.user}</hawkular.agent.itest.mgmt.user>
                 <hawkular.agent.itest.mgmt.password>${hawkular.agent.itest.mgmt.password}</hawkular.agent.itest.mgmt.password>
@@ -385,9 +280,6 @@
                 <hawkular.itest.rest.tenantId>${hawkular.itest.rest.tenantId}</hawkular.itest.rest.tenantId>
                 <hawkular.itest.rest.user>${hawkular.itest.rest.user}</hawkular.itest.rest.user>
                 <hawkular.itest.rest.password>${hawkular.itest.rest.password}</hawkular.itest.rest.password>
-
-                <hawkular.bind.address>${hawkular.bind.address}</hawkular.bind.address>
-                <hawkular.port.offset>${hawkular.port.offset}</hawkular.port.offset>
 
                 <!-- we put application in here so our test can deploy it -->
                 <hawkular.test.staging.dir>${hawkular.test.staging.dir}</hawkular.test.staging.dir>
@@ -418,6 +310,84 @@
                   <goal>integration-test</goal>
                   <goal>verify</goal>
                 </goals>
+              </execution>
+            </executions>
+          </plugin>
+
+          <!-- Start WildFly from the folder where the provisioning plugin has prepared it -->
+          <plugin>
+            <groupId>org.wildfly.plugins</groupId>
+            <artifactId>wildfly-maven-plugin</artifactId>
+            <configuration>
+              <skip>${skipTests}</skip>
+              <startupTimeout>360</startupTimeout>
+            </configuration>
+            <executions>
+              <execution>
+                <id>start-hawkular</id>
+                <phase>process-test-classes</phase>
+                <goals>
+                  <goal>start</goal>
+                </goals>
+                <configuration>
+                  <jboss-home>${project.build.directory}/${project.build.finalName}</jboss-home>
+                  <port>${hawkular.management.port}</port>
+                  <javaOpts>
+                    <javaOpt>-Xmx1024m</javaOpt>
+                    <javaOpt>-XX:MaxPermSize=1024m</javaOpt>
+                    <javaOpt>-Djava.net.preferIPv4Stack=true</javaOpt>
+                    <javaOpt>-Djboss.bind.address=${hawkular.bind.address}</javaOpt>
+                    <javaOpt>-Djboss.modules.system.pkgs=org.jboss.byteman</javaOpt>
+                    <javaOpt>-Djava.awt.headless=true</javaOpt>
+                    <javaOpt>-Djboss.socket.binding.port-offset=${hawkular.port.offset}</javaOpt>
+                    <javaOpt>-Dhawkular.agent.enabled=${hawkular.agent.enabled}</javaOpt>
+                    <javaOpt>-Dhawkular.rest.user=${hawkular.itest.rest.user}</javaOpt>
+                    <javaOpt>-Dhawkular.rest.password=${hawkular.itest.rest.password}</javaOpt>
+                    <javaOpt>-Dhawkular.rest.tenantId=${hawkular.itest.rest.tenantId}</javaOpt>
+                    <javaOpt>-Dhawkular.log.root=${hawkular.log.root}</javaOpt>
+                    <javaOpt>-Dhawkular.log.console=${hawkular.log.console}</javaOpt>
+                    <javaOpt>-Dhawkular.log.agent=${hawkular.log.agent}</javaOpt>
+                    <javaOpt>-Dhawkular.log.bus=${hawkular.log.bus}</javaOpt>
+                    <javaOpt>-Dhawkular.log.cmdgw=${hawkular.log.cmdgw}</javaOpt>
+                    <javaOpt>-Dhawkular.log.inventory=${hawkular.log.inventory}</javaOpt>
+                    <javaOpt>-Dhawkular.log.inventory.rest.requests=${hawkular.log.inventory.rest.requests}</javaOpt>
+                    <javaOpt>-Dhawkular.log.metrics=${hawkular.log.metrics}</javaOpt>
+                    <javaOpt>-Dhawkular.log.nest=${hawkular.log.nest}</javaOpt>
+                    <javaOpt>-Dhawkular.log.datastax.driver=${hawkular.log.datastax.driver}</javaOpt>
+                    <javaOpt>-Dhawkular.log.cassandra=${hawkular.log.cassandra}</javaOpt>
+                    <javaOpt>${debug.wildfly.argLine}</javaOpt>
+                  </javaOpts>
+                  <add-user>
+                    <users>
+                      <user>
+                        <username>${hawkular.agent.itest.mgmt.user}</username>
+                        <password>${hawkular.agent.itest.mgmt.password}</password>
+                        <application-user>false</application-user>
+                      </user>
+                      <user>
+                        <username>${hawkular.itest.rest.user}</username>
+                        <password>${hawkular.itest.rest.password}</password>
+                        <application-user>true</application-user>
+                        <groups>
+                          <group>read-write</group>
+                          <group>read-only</group>
+                        </groups>
+                      </user>
+                    </users>
+                  </add-user>
+                </configuration>
+              </execution>
+
+              <execution>
+                <id>stop-hawkular</id>
+                <phase>post-integration-test</phase>
+                <goals>
+                  <goal>shutdown</goal>
+                </goals>
+                <configuration>
+                  <jboss-home>${project.build.directory}/${project.build.finalName}</jboss-home>
+                  <port>${hawkular.management.port}</port>
+                </configuration>
               </execution>
             </executions>
           </plugin>

--- a/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-cmdgw-itest/src/test/java/org/hawkular/agent/test/HawkularWildFlyAgentContextITest.java
+++ b/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-cmdgw-itest/src/test/java/org/hawkular/agent/test/HawkularWildFlyAgentContextITest.java
@@ -19,7 +19,6 @@ package org.hawkular.agent.test;
 import org.hawkular.agent.monitor.api.HawkularWildFlyAgentContext;
 import org.hawkular.agent.ws.test.AbstractCommandITest;
 import org.hawkular.agent.ws.test.DatasourceCommandITest;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.testng.annotations.Test;
 
 /**
@@ -29,7 +28,6 @@ import org.testng.annotations.Test;
 public class HawkularWildFlyAgentContextITest extends AbstractCommandITest {
     public static final String GROUP = "HawkularWildFlyAgentContextITest";
 
-    @RunAsClient
     @Test(groups = { GROUP }, dependsOnGroups = { DatasourceCommandITest.GROUP })
     public void testAgentFromJNDI() throws Throwable {
         waitForAccountsAndInventory();

--- a/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-cmdgw-itest/src/test/java/org/hawkular/agent/ws/test/AbstractCommandITest.java
+++ b/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-cmdgw-itest/src/test/java/org/hawkular/agent/ws/test/AbstractCommandITest.java
@@ -53,7 +53,6 @@ import org.hawkular.dmrclient.JBossASClient;
 import org.hawkular.inventory.api.model.Resource;
 import org.hawkular.inventory.json.InventoryJacksonConfig;
 import org.hawkular.inventory.paths.CanonicalPath;
-import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.client.helpers.Operations;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
@@ -79,7 +78,7 @@ import com.squareup.okhttp.ResponseBody;
 /**
  * @author <a href="https://github.com/ppalaga">Peter Palaga</a>
  */
-public abstract class AbstractCommandITest extends Arquillian {
+public abstract class AbstractCommandITest {
 
     private static volatile boolean accountsAndInventoryReady = false;
 

--- a/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-cmdgw-itest/src/test/java/org/hawkular/agent/ws/test/DatasourceCommandITest.java
+++ b/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-cmdgw-itest/src/test/java/org/hawkular/agent/ws/test/DatasourceCommandITest.java
@@ -20,7 +20,6 @@ import java.net.URLEncoder;
 
 import org.hawkular.cmdgw.ws.test.TestWebSocketClient;
 import org.hawkular.inventory.paths.CanonicalPath;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.dmr.ModelNode;
@@ -62,7 +61,6 @@ public class DatasourceCommandITest extends AbstractCommandITest {
     }
 
 
-    @RunAsClient
     @Test(groups = { GROUP }, dependsOnGroups = { JdbcDriverCommandITest.GROUP })
     public void testAddDatasource() throws Throwable {
         waitForAccountsAndInventory();
@@ -111,7 +109,6 @@ public class DatasourceCommandITest extends AbstractCommandITest {
         }
     }
 
-    @RunAsClient
     @Test(groups = { GROUP }, dependsOnGroups = { JdbcDriverCommandITest.GROUP })
     public void testAddXaDatasource() throws Throwable {
         waitForAccountsAndInventory();
@@ -155,7 +152,6 @@ public class DatasourceCommandITest extends AbstractCommandITest {
         }
     }
 
-    @RunAsClient
     @Test(groups = { GROUP }, dependsOnMethods = { "testAddDatasource" })
     public void testUpdateDatasource() throws Throwable {
         waitForAccountsAndInventory();
@@ -208,7 +204,6 @@ public class DatasourceCommandITest extends AbstractCommandITest {
         }
     }
 
-    @RunAsClient
     @Test(groups = { GROUP }, dependsOnMethods = { "testAddXaDatasource" })
     public void testUpdateXaDatasource() throws Throwable {
         waitForAccountsAndInventory();
@@ -262,7 +257,6 @@ public class DatasourceCommandITest extends AbstractCommandITest {
         }
     }
 
-    @RunAsClient
     @Test(groups = { GROUP }, dependsOnMethods = { "testUpdateDatasource" })
     public void testRemoveDatasource() throws Throwable {
         waitForAccountsAndInventory();
@@ -310,7 +304,6 @@ public class DatasourceCommandITest extends AbstractCommandITest {
         }
     }
 
-    @RunAsClient
     @Test(groups = { GROUP }, dependsOnMethods = { "testUpdateXaDatasource" })
     public void testRemoveXaDatasource() throws Throwable {
         waitForAccountsAndInventory();

--- a/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-cmdgw-itest/src/test/java/org/hawkular/agent/ws/test/DeployApplicationITest.java
+++ b/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-cmdgw-itest/src/test/java/org/hawkular/agent/ws/test/DeployApplicationITest.java
@@ -22,14 +22,12 @@ import org.hawkular.cmdgw.ws.test.TestWebSocketClient;
 import org.hawkular.cmdgw.ws.test.TestWebSocketClient.MessageAnswer;
 import org.hawkular.inventory.api.model.Resource;
 import org.hawkular.inventory.paths.CanonicalPath;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.junit.Assert;
 import org.testng.annotations.Test;
 
 public class DeployApplicationITest extends AbstractCommandITest {
     public static final String GROUP = "DeployApplicationITest";
 
-    @RunAsClient
     @Test(groups = { GROUP }, dependsOnGroups = { ExecuteOperationCommandITest.GROUP })
     public void testAddDeployment() throws Throwable {
         waitForAccountsAndInventory();
@@ -61,7 +59,6 @@ public class DeployApplicationITest extends AbstractCommandITest {
         }
     }
 
-    @RunAsClient
     @Test(groups = { GROUP }, dependsOnMethods = { "testAddDeployment" })
     public void testReloadDeployment() throws Throwable {
         waitForAccountsAndInventory();
@@ -94,7 +91,6 @@ public class DeployApplicationITest extends AbstractCommandITest {
         }
     }
 
-    @RunAsClient
     @Test(groups = { GROUP }, dependsOnMethods = { "testReloadDeployment" })
     public void testUndeployDeployment() throws Throwable {
         waitForAccountsAndInventory();
@@ -127,7 +123,6 @@ public class DeployApplicationITest extends AbstractCommandITest {
         }
     }
 
-    @RunAsClient
     @Test(groups = { GROUP }, dependsOnMethods = { "testUndeployDeployment" })
     public void testRemoveDeployment() throws Throwable {
         waitForAccountsAndInventory();

--- a/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-cmdgw-itest/src/test/java/org/hawkular/agent/ws/test/ExecuteOperationCommandITest.java
+++ b/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-cmdgw-itest/src/test/java/org/hawkular/agent/ws/test/ExecuteOperationCommandITest.java
@@ -16,11 +16,9 @@
  */
 package org.hawkular.agent.ws.test;
 
-import org.hawkular.cmdgw.ws.test.EchoCommandITest;
 import org.hawkular.cmdgw.ws.test.TestWebSocketClient;
 import org.hawkular.inventory.api.model.Resource;
 import org.hawkular.inventory.paths.CanonicalPath;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.dmr.ModelNode;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -31,8 +29,7 @@ import org.testng.annotations.Test;
 public class ExecuteOperationCommandITest extends AbstractCommandITest {
     public static final String GROUP = "ExecuteOperationCommandITest";
 
-    @RunAsClient
-    @Test(groups = { GROUP }, dependsOnGroups = { EchoCommandITest.GROUP })
+    @Test(groups = { GROUP })
     public void testExecuteAgentDiscoveryScan() throws Throwable {
         waitForAccountsAndInventory();
 

--- a/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-cmdgw-itest/src/test/java/org/hawkular/agent/ws/test/ExportJdrCommandITest.java
+++ b/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-cmdgw-itest/src/test/java/org/hawkular/agent/ws/test/ExportJdrCommandITest.java
@@ -18,7 +18,6 @@ package org.hawkular.agent.ws.test;
 
 import org.hawkular.cmdgw.ws.test.TestWebSocketClient;
 import org.hawkular.inventory.paths.CanonicalPath;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.testng.annotations.Test;
 
@@ -28,7 +27,6 @@ import org.testng.annotations.Test;
 public class ExportJdrCommandITest extends AbstractCommandITest {
     public static final String GROUP = "ExportJdrCommandITest";
 
-    @RunAsClient
     @Test(groups = { GROUP }, dependsOnGroups = { DeployApplicationITest.GROUP })
     public void exportJdrCommand() throws Throwable {
         waitForAccountsAndInventory();

--- a/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-cmdgw-itest/src/test/java/org/hawkular/agent/ws/test/JdbcDriverCommandITest.java
+++ b/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-cmdgw-itest/src/test/java/org/hawkular/agent/ws/test/JdbcDriverCommandITest.java
@@ -23,7 +23,6 @@ import java.net.URLEncoder;
 import org.hawkular.cmdgw.ws.test.TestWebSocketClient;
 import org.hawkular.cmdgw.ws.test.TestWebSocketClient.MessageAnswer;
 import org.hawkular.inventory.paths.CanonicalPath;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.dmr.ModelNode;
@@ -42,7 +41,6 @@ public class JdbcDriverCommandITest extends AbstractCommandITest {
         return new ModelNode().add(ModelDescriptionConstants.SUBSYSTEM, "datasources").add("jdbc-driver", driverName);
     }
 
-    @RunAsClient
     @Test(groups = { GROUP }, dependsOnGroups = { ExportJdrCommandITest.GROUP })
     public void testAddJdbcDriver() throws Throwable {
         waitForAccountsAndInventory();
@@ -89,7 +87,6 @@ public class JdbcDriverCommandITest extends AbstractCommandITest {
         }
     }
 
-    @RunAsClient
     @Test(groups = { GROUP }, dependsOnMethods = { "testAddJdbcDriver" })
     public void testRemoveJdbcDriver() throws Throwable {
         waitForAccountsAndInventory();

--- a/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-cmdgw-itest/src/test/java/org/hawkular/agent/ws/test/StatisticsControlCommandITest.java
+++ b/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-cmdgw-itest/src/test/java/org/hawkular/agent/ws/test/StatisticsControlCommandITest.java
@@ -20,7 +20,6 @@ import org.hawkular.agent.test.HawkularWildFlyAgentContextITest;
 import org.hawkular.cmdgw.ws.test.TestWebSocketClient;
 import org.hawkular.dmrclient.Address;
 import org.hawkular.inventory.paths.CanonicalPath;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.junit.AfterClass;
 import org.testng.annotations.Test;
@@ -34,7 +33,6 @@ public class StatisticsControlCommandITest extends AbstractCommandITest {
         // reload();
     }
 
-    @RunAsClient
     @Test(groups = { GROUP }, dependsOnGroups = { HawkularWildFlyAgentContextITest.GROUP })
     public void testEnableStatistics() throws Throwable {
         waitForAccountsAndInventory();
@@ -108,7 +106,6 @@ public class StatisticsControlCommandITest extends AbstractCommandITest {
         testReadOnlyStatistics(true);
     }
 
-    @RunAsClient
     @Test(groups = { GROUP }, dependsOnMethods = { "testEnableStatistics" })
     public void testDisableStatistics() throws Throwable {
         waitForAccountsAndInventory();
@@ -236,7 +233,6 @@ public class StatisticsControlCommandITest extends AbstractCommandITest {
         }
     }
 
-    @RunAsClient
     @Test(groups = { GROUP }, dependsOnMethods = { "testDisableStatistics" })
     public void testEnableStatisticsSubset() throws Throwable {
         waitForAccountsAndInventory();

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <version.io.prometheus.client>0.0.2</version.io.prometheus.client>
     <version.org.hamcrest>1.3</version.org.hamcrest>
 
-    <version.org.hawkular.commons>0.7.2.Final</version.org.hawkular.commons>
+    <version.org.hawkular.commons>0.7.3.Final-SRC-revision-e97d4e34527c4c0a3ca235f4262fe3eb32c3ebed</version.org.hawkular.commons>
     <version.org.hawkular.inventory>0.16.0.Final</version.org.hawkular.inventory>
     <version.org.hawkular.metrics>0.16.0.Final</version.org.hawkular.metrics>
 
@@ -71,9 +71,6 @@
     <version.org.jgrapht>0.9.1</version.org.jgrapht>
     <version.org.jolokia>1.3.2</version.org.jolokia>
     <version.org.keycloak>1.8.1.Final</version.org.keycloak>
-
-    <version.org.jboss.arquillian>1.1.11.Final</version.org.jboss.arquillian>
-    <version.org.wildfly.arquillian>2.0.0.Alpha1</version.org.wildfly.arquillian>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
we can now create common utility classes/methods across all agent itest modules.

This first requires https://github.com/hawkular/hawkular-commons/pull/69 to be merged. We then must bump up the pom changed in this PR to use the srcdep version, or released version, of that new commons.
