### PR TITLE
HWKAGENT-100 Add agent availability ping

### DIFF
--- a/hawkular-swarm-agents/hawkular-swarm-agent-dists/hawkular-swarm-agent-dist/src/main/resources/hawkular-swarm-agent-config.xml
+++ b/hawkular-swarm-agents/hawkular-swarm-agent-dists/hawkular-swarm-agent-dist/src/main/resources/hawkular-swarm-agent-config.xml
@@ -1036,7 +1036,7 @@
 
       <managed-servers>
         <remote-dmr enabled="${hawkular.dmr.enabled:true}"
-                    name="Wildfly"
+                    name="WildFly"
                     host="${hawkular.dmr.host:127.0.0.1}"
                     port="${hawkular.dmr.port:9990}"
                     username="${hawkular.dmr.username:admin}"

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/MonitorServiceConfiguration.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/MonitorServiceConfiguration.java
@@ -220,26 +220,28 @@ public class MonitorServiceConfiguration {
 
         private final boolean subsystemEnabled;
         private final String apiJndi;
-        private final int autoDiscoveryScanPeriodSecs;
+        private final int autoDiscoveryScanPeriodSeconds;
         private final int numDmrSchedulerThreads;
         private final int metricDispatcherBufferSize;
         private final int metricDispatcherMaxBatchSize;
         private final int availDispatcherBufferSize;
         private final int availDispatcherMaxBatchSize;
+        private final int pingDispatcherPeriodSeconds;
 
-        public GlobalConfiguration(boolean subsystemEnabled, String apiJndi, int autoDiscoveryScanPeriodSecs,
+        public GlobalConfiguration(boolean subsystemEnabled, String apiJndi, int autoDiscoveryScanPeriodSeconds,
                 int numDmrSchedulerThreads,
                 int metricDispatcherBufferSize, int metricDispatcherMaxBatchSize, int availDispatcherBufferSize,
-                int availDispatcherMaxBatchSize) {
+                int availDispatcherMaxBatchSize, int pingDispatcherPeriodSeconds) {
             super();
             this.subsystemEnabled = subsystemEnabled;
             this.apiJndi = apiJndi;
-            this.autoDiscoveryScanPeriodSecs = autoDiscoveryScanPeriodSecs;
+            this.autoDiscoveryScanPeriodSeconds = autoDiscoveryScanPeriodSeconds;
             this.numDmrSchedulerThreads = numDmrSchedulerThreads;
             this.metricDispatcherBufferSize = metricDispatcherBufferSize;
             this.metricDispatcherMaxBatchSize = metricDispatcherMaxBatchSize;
             this.availDispatcherBufferSize = availDispatcherBufferSize;
             this.availDispatcherMaxBatchSize = availDispatcherMaxBatchSize;
+            this.pingDispatcherPeriodSeconds = pingDispatcherPeriodSeconds;
         }
 
     }
@@ -515,8 +517,8 @@ public class MonitorServiceConfiguration {
         return globalConfiguration.apiJndi;
     }
 
-    public int getAutoDiscoveryScanPeriodSecs() {
-        return globalConfiguration.autoDiscoveryScanPeriodSecs;
+    public int getAutoDiscoveryScanPeriodSeconds() {
+        return globalConfiguration.autoDiscoveryScanPeriodSeconds;
     }
 
     public int getNumDmrSchedulerThreads() {
@@ -537,6 +539,10 @@ public class MonitorServiceConfiguration {
 
     public int getAvailDispatcherMaxBatchSize() {
         return globalConfiguration.availDispatcherMaxBatchSize;
+    }
+
+    public int getPingDispatcherPeriodSeconds() {
+        return globalConfiguration.pingDispatcherPeriodSeconds;
     }
 
     public MonitorServiceConfiguration cloneWith(StorageAdapterConfiguration newStorageAdapter) {

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/MonitorServiceConfigurationBuilder.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/MonitorServiceConfigurationBuilder.java
@@ -860,20 +860,20 @@ public class MonitorServiceConfigurationBuilder {
             throws OperationFailedException {
         boolean subsystemEnabled = getBoolean(config, context, SubsystemAttributes.ENABLED);
         String apiJndi = getString(config, context, SubsystemAttributes.API_JNDI);
-        int autoDiscoveryScanPeriodSecs = getInt(config, context, SubsystemAttributes.AUTO_DISCOVERY_SCAN_PERIOD_SECS);
+        int autoDiscoveryScanPeriodSecs = getInt(config, context,
+                SubsystemAttributes.AUTO_DISCOVERY_SCAN_PERIOD_SECONDS);
         int numDmrSchedulerThreads = getInt(config, context, SubsystemAttributes.NUM_DMR_SCHEDULER_THREADS);
         int metricDispatcherBufferSize = getInt(config, context, SubsystemAttributes.METRIC_DISPATCHER_BUFFER_SIZE);
         int metricDispatcherMaxBatchSize = getInt(config, context,
                 SubsystemAttributes.METRIC_DISPATCHER_MAX_BATCH_SIZE);
         int availDispatcherBufferSize = getInt(config, context, SubsystemAttributes.AVAIL_DISPATCHER_BUFFER_SIZE);
         int availDispatcherMaxBatchSize = getInt(config, context, SubsystemAttributes.AVAIL_DISPATCHER_MAX_BATCH_SIZE);
+        int pingDispatcherPeriodSeconds = getInt(config, context, SubsystemAttributes.PING_DISPATCHER_PERIOD_SECONDS);
 
         return new GlobalConfiguration(subsystemEnabled, apiJndi, autoDiscoveryScanPeriodSecs,
-                numDmrSchedulerThreads,
-                metricDispatcherBufferSize, metricDispatcherMaxBatchSize, availDispatcherBufferSize,
-                availDispatcherMaxBatchSize);
+                numDmrSchedulerThreads, metricDispatcherBufferSize, metricDispatcherMaxBatchSize,
+                availDispatcherBufferSize, availDispatcherMaxBatchSize, pingDispatcherPeriodSeconds);
     }
-
     private static void determineResourceTypeSetDmr(ModelNode config,
             OperationContext context,
             TypeSets.Builder<DMRNodeLocation> typeSetsBuilder)

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/SubsystemAttributes.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/SubsystemAttributes.java
@@ -94,7 +94,7 @@ public interface SubsystemAttributes {
                     .build();
 
     SimpleAttributeDefinition PING_DISPATCHER_PERIOD_SECONDS = new SimpleAttributeDefinitionBuilder(
-            "ping-dispatcher-period-secs", ModelType.INT)
+            "ping-period-secs", ModelType.INT)
                     .setAllowNull(true)
                     .setDefaultValue(new ModelNode(SchedulerConfiguration.DEFAULT_PING_DISPATCHER_PERIOD_SECONDS))
                     .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/SubsystemAttributes.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/SubsystemAttributes.java
@@ -45,7 +45,7 @@ public interface SubsystemAttributes {
                     .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
                     .build();
 
-    SimpleAttributeDefinition AUTO_DISCOVERY_SCAN_PERIOD_SECS = new SimpleAttributeDefinitionBuilder(
+    SimpleAttributeDefinition AUTO_DISCOVERY_SCAN_PERIOD_SECONDS = new SimpleAttributeDefinitionBuilder(
             "auto-discovery-scan-period-secs", ModelType.INT)
                     .setAllowNull(true)
                     .setDefaultValue(new ModelNode(ProtocolServices.DEFAULT_AUTO_DISCOVERY_SCAN_PERIOD_SECS))
@@ -93,14 +93,22 @@ public interface SubsystemAttributes {
                     .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
                     .build();
 
+    SimpleAttributeDefinition PING_DISPATCHER_PERIOD_SECONDS = new SimpleAttributeDefinitionBuilder(
+            "ping-dispatcher-period-secs", ModelType.INT)
+                    .setAllowNull(true)
+                    .setDefaultValue(new ModelNode(SchedulerConfiguration.DEFAULT_PING_DISPATCHER_PERIOD_SECONDS))
+                    .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+                    .build();
+
     AttributeDefinition[] ATTRIBUTES = {
             ENABLED,
             API_JNDI,
-            AUTO_DISCOVERY_SCAN_PERIOD_SECS,
+            AUTO_DISCOVERY_SCAN_PERIOD_SECONDS,
             NUM_DMR_SCHEDULER_THREADS,
             METRIC_DISPATCHER_BUFFER_SIZE,
             METRIC_DISPATCHER_MAX_BATCH_SIZE,
             AVAIL_DISPATCHER_BUFFER_SIZE,
-            AVAIL_DISPATCHER_MAX_BATCH_SIZE
+            AVAIL_DISPATCHER_MAX_BATCH_SIZE,
+            PING_DISPATCHER_PERIOD_SECONDS
     };
 }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/scheduler/SchedulerConfiguration.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/scheduler/SchedulerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,8 @@
  */
 package org.hawkular.agent.monitor.scheduler;
 
+import java.util.Set;
+
 import org.hawkular.agent.monitor.extension.MonitorServiceConfiguration;
 
 public class SchedulerConfiguration {
@@ -24,6 +26,7 @@ public class SchedulerConfiguration {
     public static final int DEFAULT_METRIC_DISPATCHER_MAX_BATCH_SIZE = 100;
     public static final int DEFAULT_AVAIL_DISPATCHER_BUFFER_SIZE = 500;
     public static final int DEFAULT_AVAIL_DISPATCHER_MAX_BATCH_SIZE = 50;
+    public static final int DEFAULT_PING_DISPATCHER_PERIOD_SECONDS = 60;
 
     private int metricDispatcherBufferSize = DEFAULT_METRIC_DISPATCHER_BUFFER_SIZE;
     private int metricDispatcherMaxBatchSize = DEFAULT_METRIC_DISPATCHER_MAX_BATCH_SIZE;
@@ -31,9 +34,13 @@ public class SchedulerConfiguration {
     private int availDispatcherBufferSize = DEFAULT_AVAIL_DISPATCHER_BUFFER_SIZE;
     private int availDispatcherMaxBatchSize = DEFAULT_AVAIL_DISPATCHER_MAX_BATCH_SIZE;
 
+    private int pingDispatcherPeriodSeconds = DEFAULT_PING_DISPATCHER_PERIOD_SECONDS;
 
     private MonitorServiceConfiguration.StorageAdapterConfiguration storageAdapterConfig;
     private MonitorServiceConfiguration.DiagnosticsConfiguration diagnosticsConfig;
+
+    private String pingDispatcherFeedId;
+    private Set<String> pingDispatcherTenantIds;
 
     public int getMetricDispatcherBufferSize() {
         return metricDispatcherBufferSize;
@@ -67,6 +74,30 @@ public class SchedulerConfiguration {
         this.availDispatcherMaxBatchSize = availDispatcherMaxBatchSize;
     }
 
+    public int getPingDispatcherPeriodSeconds() {
+        return pingDispatcherPeriodSeconds;
+    }
+
+    public void setPingDispatcherPeriodSeconds(int pingDispatcherPeriodSeconds) {
+        this.pingDispatcherPeriodSeconds = pingDispatcherPeriodSeconds;
+    }
+
+    public String getPingDispatcherFeedId() {
+        return pingDispatcherFeedId;
+    }
+
+    public void setPingDispatcherFeedId(String pingDispatcherFeedId) {
+        this.pingDispatcherFeedId = pingDispatcherFeedId;
+    }
+
+    public Set<String> getPingDispatcherTenantIds() {
+        return pingDispatcherTenantIds;
+    }
+
+    public void setPingDispatcherTenantIds(Set<String> pingDispatcherTenantIds) {
+        this.pingDispatcherTenantIds = pingDispatcherTenantIds;
+    }
+
     public MonitorServiceConfiguration.StorageAdapterConfiguration getStorageAdapterConfig() {
         return this.storageAdapterConfig;
     }
@@ -82,5 +113,5 @@ public class SchedulerConfiguration {
     public void setDiagnosticsConfig(MonitorServiceConfiguration.DiagnosticsConfiguration config) {
         this.diagnosticsConfig = config;
     }
-}
 
+}

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/scheduler/SchedulerConfiguration.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/scheduler/SchedulerConfiguration.java
@@ -39,8 +39,8 @@ public class SchedulerConfiguration {
     private MonitorServiceConfiguration.StorageAdapterConfiguration storageAdapterConfig;
     private MonitorServiceConfiguration.DiagnosticsConfiguration diagnosticsConfig;
 
-    private String pingDispatcherFeedId;
-    private Set<String> pingDispatcherTenantIds;
+    private String feedId;
+    private Set<String> tenantIds;
 
     public int getMetricDispatcherBufferSize() {
         return metricDispatcherBufferSize;
@@ -82,20 +82,20 @@ public class SchedulerConfiguration {
         this.pingDispatcherPeriodSeconds = pingDispatcherPeriodSeconds;
     }
 
-    public String getPingDispatcherFeedId() {
-        return pingDispatcherFeedId;
+    public String getFeedId() {
+        return feedId;
     }
 
-    public void setPingDispatcherFeedId(String pingDispatcherFeedId) {
-        this.pingDispatcherFeedId = pingDispatcherFeedId;
+    public void setFeedId(String feedId) {
+        this.feedId = feedId;
     }
 
-    public Set<String> getPingDispatcherTenantIds() {
-        return pingDispatcherTenantIds;
+    public Set<String> getTenantIds() {
+        return tenantIds;
     }
 
-    public void setPingDispatcherTenantIds(Set<String> pingDispatcherTenantIds) {
-        this.pingDispatcherTenantIds = pingDispatcherTenantIds;
+    public void setTenantIds(Set<String> tenantIds) {
+        this.tenantIds = tenantIds;
     }
 
     public MonitorServiceConfiguration.StorageAdapterConfiguration getStorageAdapterConfig() {

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/scheduler/SchedulerService.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/scheduler/SchedulerService.java
@@ -18,6 +18,9 @@ package org.hawkular.agent.monitor.scheduler;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 import org.hawkular.agent.monitor.api.InventoryEvent;
 import org.hawkular.agent.monitor.api.InventoryListener;
@@ -33,6 +36,7 @@ import org.hawkular.agent.monitor.storage.AvailBufferedStorageDispatcher;
 import org.hawkular.agent.monitor.storage.AvailDataPoint;
 import org.hawkular.agent.monitor.storage.MetricBufferedStorageDispatcher;
 import org.hawkular.agent.monitor.storage.MetricDataPoint;
+import org.hawkular.agent.monitor.storage.PingStorageDispatcher;
 import org.hawkular.agent.monitor.storage.StorageAdapter;
 
 /**
@@ -45,8 +49,12 @@ public class SchedulerService implements InventoryListener {
     private final Diagnostics diagnostics;
     private final MeasurementScheduler<Object, MetricType<Object>, MetricDataPoint> metricScheduler;
     private final MeasurementScheduler<Object, AvailType<Object>, AvailDataPoint> availScheduler;
+    private final ScheduledThreadPoolExecutor pingScheduler;
     private final MetricBufferedStorageDispatcher metricStorage;
     private final AvailBufferedStorageDispatcher availStorage;
+    private final PingStorageDispatcher pingStorage;
+
+    private ScheduledFuture<?> pingJob;
 
     protected volatile ServiceStatus status = ServiceStatus.INITIAL;
 
@@ -58,7 +66,7 @@ public class SchedulerService implements InventoryListener {
         // metrics for our own internals
         this.diagnostics = diagnostics;
 
-        // create the schedulers - we use two: one for metric collections and one for avail checks
+        // create the schedulers - we use three: one for metric collections, one for avail checks and one for feed pings
         this.metricStorage = new MetricBufferedStorageDispatcher(configuration, storageAdapter, diagnostics);
         this.metricScheduler = MeasurementScheduler.forMetrics("Hawkular-WildFly-Agent-Scheduler-Metrics",
                 metricStorage);
@@ -66,6 +74,9 @@ public class SchedulerService implements InventoryListener {
         this.availStorage = new AvailBufferedStorageDispatcher(configuration, storageAdapter, diagnostics);
         this.availScheduler = MeasurementScheduler.forAvails("Hawkular-WildFly-Agent-Scheduler-Avail",
                 availStorage);
+
+        this.pingStorage = new PingStorageDispatcher(configuration, storageAdapter, diagnostics);
+        this.pingScheduler = new ScheduledThreadPoolExecutor(1);
     }
 
     public void start() {
@@ -73,6 +84,12 @@ public class SchedulerService implements InventoryListener {
         status = ServiceStatus.STARTING;
 
         log.infoStartingScheduler();
+
+        // start showing the agent as running
+        int pingPeriod = this.pingStorage.getConfig().getPingDispatcherPeriodSeconds();
+        if (pingPeriod > 0) {
+            this.pingJob = this.pingScheduler.scheduleAtFixedRate(this.pingStorage, 0L, pingPeriod, TimeUnit.SECONDS);
+        }
 
         // start the collections
         this.metricStorage.start();
@@ -97,6 +114,11 @@ public class SchedulerService implements InventoryListener {
         // stop the schedulers
         this.metricScheduler.stop();
         this.availScheduler.stop();
+
+        // stop the agent availability ping
+        if (null != this.pingJob) {
+            this.pingJob.cancel(true);
+        }
 
         status = ServiceStatus.STOPPED;
     }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/scheduler/SchedulerService.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/scheduler/SchedulerService.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
 import org.hawkular.agent.monitor.api.InventoryEvent;
@@ -38,6 +39,7 @@ import org.hawkular.agent.monitor.storage.MetricBufferedStorageDispatcher;
 import org.hawkular.agent.monitor.storage.MetricDataPoint;
 import org.hawkular.agent.monitor.storage.PingStorageDispatcher;
 import org.hawkular.agent.monitor.storage.StorageAdapter;
+import org.hawkular.agent.monitor.util.ThreadFactoryGenerator;
 
 /**
  * The core service that schedules tasks and stores the data resulting from those tasks to its storage adapter.
@@ -76,7 +78,8 @@ public class SchedulerService implements InventoryListener {
                 availStorage);
 
         this.pingStorage = new PingStorageDispatcher(configuration, storageAdapter, diagnostics);
-        this.pingScheduler = new ScheduledThreadPoolExecutor(1);
+        ThreadFactory threadFactory = ThreadFactoryGenerator.generateFactory(true, "Hawkular-WildFly-Scheduler-Ping");
+        this.pingScheduler = new ScheduledThreadPoolExecutor(1, threadFactory);
     }
 
     public void start() {

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/storage/PingStorageDispatcher.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/storage/PingStorageDispatcher.java
@@ -42,7 +42,7 @@ public class PingStorageDispatcher implements Runnable {
         this.config = config;
         this.storageAdapter = storageAdapter;
         this.diagnostics = diagnostics;
-        this.metricId = "hawkular-feed-availability-" + this.config.getPingDispatcherFeedId();
+        this.metricId = "hawkular-feed-availability-" + this.config.getFeedId();
     }
 
     public SchedulerConfiguration getConfig() {
@@ -61,7 +61,7 @@ public class PingStorageDispatcher implements Runnable {
     public void run() {
         long now = System.currentTimeMillis();
 
-        Set<AvailDataPoint> pings = this.config.getPingDispatcherTenantIds().stream()
+        Set<AvailDataPoint> pings = this.config.getTenantIds().stream()
                 .map(t -> new AvailDataPoint(metricId, now, UP, t)).collect(Collectors.toSet());
 
         log.tracef("Sending agent availability pings: %s", pings);

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/storage/PingStorageDispatcher.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/storage/PingStorageDispatcher.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.agent.monitor.storage;
+
+import static org.hawkular.agent.monitor.api.Avail.UP;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.hawkular.agent.monitor.diagnostics.Diagnostics;
+import org.hawkular.agent.monitor.log.AgentLoggers;
+import org.hawkular.agent.monitor.log.MsgLogger;
+import org.hawkular.agent.monitor.scheduler.SchedulerConfiguration;
+
+/**
+ * Buffers availability check data and eventually stores them in a storage adapter.
+ */
+public class PingStorageDispatcher implements Runnable {
+    private static final MsgLogger log = AgentLoggers.getLogger(PingStorageDispatcher.class);
+
+    private final SchedulerConfiguration config;
+    private final StorageAdapter storageAdapter;
+    private final Diagnostics diagnostics; // TODO: Any diagnostics for this?
+    private final String metricId;
+
+    public PingStorageDispatcher(SchedulerConfiguration config, StorageAdapter storageAdapter,
+            Diagnostics diagnostics) {
+        this.config = config;
+        this.storageAdapter = storageAdapter;
+        this.diagnostics = diagnostics;
+        this.metricId = "hawkular-feed-availability-" + this.config.getPingDispatcherFeedId();
+    }
+
+    public SchedulerConfiguration getConfig() {
+        return config;
+    }
+
+    public StorageAdapter getStorageAdapter() {
+        return storageAdapter;
+    }
+
+    public Diagnostics getDiagnostics() {
+        return diagnostics;
+    }
+
+    @Override
+    public void run() {
+        long now = System.currentTimeMillis();
+
+        Set<AvailDataPoint> pings = this.config.getPingDispatcherTenantIds().stream()
+                .map(t -> new AvailDataPoint(metricId, now, UP, t)).collect(Collectors.toSet());
+
+        log.tracef("Sending agent availability pings: %s", pings);
+
+        // dispatch
+        storageAdapter.storeAvails(pings, 0);
+    }
+
+}

--- a/hawkular-wildfly-agent/src/main/resources/org/hawkular/agent/monitor/extension/LocalDescriptions.properties
+++ b/hawkular-wildfly-agent/src/main/resources/org/hawkular/agent/monitor/extension/LocalDescriptions.properties
@@ -28,6 +28,7 @@ hawkular-wildfly-agent.metric-dispatcher-buffer-size=Size of the buffer that wil
 hawkular-wildfly-agent.metric-dispatcher-max-batch-size=Maximum number of metrics that will be sent to the backend storage at any one time.
 hawkular-wildfly-agent.avail-dispatcher-buffer-size=Size of the buffer that will hold all availability check results that are waiting to be sent to backend storage.
 hawkular-wildfly-agent.avail-dispatcher-max-batch-size=Maximum number of availability check results that will be sent to the backend storage at any one time.
+hawkular-wildfly-agent.ping-dispatcher-period-secs=Time between agent availability pings. If <= 0 the agent will not send availability pings.
 hawkular-wildfly-agent.start=Start the Hawkular WildFly Agent service
 hawkular-wildfly-agent.start.restart=If true, will stop the Hawkular WildFly Agent service if it is currently running, and then will restart it
 hawkular-wildfly-agent.stop=Stop the Hawkular WildFly Agent service

--- a/hawkular-wildfly-agent/src/main/resources/org/hawkular/agent/monitor/extension/LocalDescriptions.properties
+++ b/hawkular-wildfly-agent/src/main/resources/org/hawkular/agent/monitor/extension/LocalDescriptions.properties
@@ -28,7 +28,7 @@ hawkular-wildfly-agent.metric-dispatcher-buffer-size=Size of the buffer that wil
 hawkular-wildfly-agent.metric-dispatcher-max-batch-size=Maximum number of metrics that will be sent to the backend storage at any one time.
 hawkular-wildfly-agent.avail-dispatcher-buffer-size=Size of the buffer that will hold all availability check results that are waiting to be sent to backend storage.
 hawkular-wildfly-agent.avail-dispatcher-max-batch-size=Maximum number of availability check results that will be sent to the backend storage at any one time.
-hawkular-wildfly-agent.ping-dispatcher-period-secs=Time between agent availability pings. If <= 0 the agent will not send availability pings.
+hawkular-wildfly-agent.ping-period-secs=Time between agent pings (in the form of an UP availability for the agent itself). If <= 0 the agent will not send ping availability.
 hawkular-wildfly-agent.start=Start the Hawkular WildFly Agent service
 hawkular-wildfly-agent.start.restart=If true, will stop the Hawkular WildFly Agent service if it is currently running, and then will restart it
 hawkular-wildfly-agent.stop=Stop the Hawkular WildFly Agent service

--- a/hawkular-wildfly-agent/src/main/resources/schema/hawkular-agent-monitor-subsystem.xsd
+++ b/hawkular-wildfly-agent/src/main/resources/schema/hawkular-agent-monitor-subsystem.xsd
@@ -47,7 +47,7 @@
     <xs:attribute name="metric-dispatcher-max-batch-size" type="xs:int"/>
     <xs:attribute name="avail-dispatcher-buffer-size"     type="xs:int"/>
     <xs:attribute name="avail-dispatcher-max-batch-size"  type="xs:int"/>
-    <xs:attribute name="ping-dispatcher-period-secs"      type="xs:int"/>
+    <xs:attribute name="ping-period-secs"                 type="xs:int"/>
   </xs:complexType>
 
   <!-- storage adapter configuration -->

--- a/hawkular-wildfly-agent/src/main/resources/schema/hawkular-agent-monitor-subsystem.xsd
+++ b/hawkular-wildfly-agent/src/main/resources/schema/hawkular-agent-monitor-subsystem.xsd
@@ -47,6 +47,7 @@
     <xs:attribute name="metric-dispatcher-max-batch-size" type="xs:int"/>
     <xs:attribute name="avail-dispatcher-buffer-size"     type="xs:int"/>
     <xs:attribute name="avail-dispatcher-max-batch-size"  type="xs:int"/>
+    <xs:attribute name="ping-dispatcher-period-secs"      type="xs:int"/>
   </xs:complexType>
 
   <!-- storage adapter configuration -->

--- a/hawkular-wildfly-agent/src/test/resources/org/hawkular/agent/monitor/extension/subsystem-xsd-full.xml
+++ b/hawkular-wildfly-agent/src/test/resources/org/hawkular/agent/monitor/extension/subsystem-xsd-full.xml
@@ -24,7 +24,8 @@
            metric-dispatcher-buffer-size="201"
            metric-dispatcher-max-batch-size="51"
            avail-dispatcher-buffer-size="101"
-           avail-dispatcher-max-batch-size="26">
+           avail-dispatcher-max-batch-size="26"
+           ping-dispatcher-period-secs="31">
 
   <diagnostics enabled="true"
                interval="1"

--- a/hawkular-wildfly-agent/src/test/resources/org/hawkular/agent/monitor/extension/subsystem-xsd-full.xml
+++ b/hawkular-wildfly-agent/src/test/resources/org/hawkular/agent/monitor/extension/subsystem-xsd-full.xml
@@ -25,7 +25,7 @@
            metric-dispatcher-max-batch-size="51"
            avail-dispatcher-buffer-size="101"
            avail-dispatcher-max-batch-size="26"
-           ping-dispatcher-period-secs="31">
+           ping-period-secs="31">
 
   <diagnostics enabled="true"
                interval="1"

--- a/hawkular-wildfly-agent/src/test/resources/org/hawkular/agent/monitor/extension/subsystem.xml
+++ b/hawkular-wildfly-agent/src/test/resources/org/hawkular/agent/monitor/extension/subsystem.xml
@@ -23,7 +23,7 @@
            metric-dispatcher-max-batch-size="51"
            avail-dispatcher-buffer-size="101"
            avail-dispatcher-max-batch-size="26"
-           ping-dispatcher-period-secs="31">
+           ping-period-secs="31">
 
   <diagnostics enabled="false"
                interval="1"

--- a/hawkular-wildfly-agent/src/test/resources/org/hawkular/agent/monitor/extension/subsystem.xml
+++ b/hawkular-wildfly-agent/src/test/resources/org/hawkular/agent/monitor/extension/subsystem.xml
@@ -22,7 +22,8 @@
            metric-dispatcher-buffer-size="201"
            metric-dispatcher-max-batch-size="51"
            avail-dispatcher-buffer-size="101"
-           avail-dispatcher-max-batch-size="26">
+           avail-dispatcher-max-batch-size="26"
+           ping-dispatcher-period-secs="31">
 
   <diagnostics enabled="false"
                interval="1"


### PR DESCRIPTION
The agent now sends an availability metric for each of its registered feeds.
The server (in hawkular mode) uses this to determine if the agent is or is
not reporting, and will "backfill" the agent's monitored resources as needed.
- ping-dispatcher-period-secs is a new subsystem attribute setting the
  ping frequency.  It defaults to 60s.
- note, no longer write feedId to a file, instead just re-register feeds to
  ensure all feeds are registered and pinging.

@jmazzitelli Please Review, this is probably close but I could easily have missed something given my new-ness to the code.
