### PR TITLE
put embedded cassandra into our own itest server feature pack.

### DIFF
--- a/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-cmdgw-itest/pom.xml
+++ b/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-cmdgw-itest/pom.xml
@@ -342,6 +342,7 @@
                     <javaOpt>-Dhawkular.log.nest=${hawkular.log.nest}</javaOpt>
                     <javaOpt>-Dhawkular.log.datastax.driver=${hawkular.log.datastax.driver}</javaOpt>
                     <javaOpt>-Dhawkular.log.cassandra=${hawkular.log.cassandra}</javaOpt>
+                    <javaOpt>-Dhawkular.backend=embedded_cassandra</javaOpt>
                     <javaOpt>${debug.wildfly.argLine}</javaOpt>
                   </javaOpts>
                   <add-user>

--- a/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-domain-itest/pom.xml
+++ b/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-domain-itest/pom.xml
@@ -351,6 +351,7 @@
                     <javaOpt>-Dhawkular.log.nest=${hawkular.log.nest}</javaOpt>
                     <javaOpt>-Dhawkular.log.datastax.driver=${hawkular.log.datastax.driver}</javaOpt>
                     <javaOpt>-Dhawkular.log.cassandra=${hawkular.log.cassandra}</javaOpt>
+                    <javaOpt>-Dhawkular.backend=embedded_cassandra</javaOpt>
                     <javaOpt>${debug.hawkular.argLine}</javaOpt>
                   </javaOpts>
                   <add-user>

--- a/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-installer-itest/pom.xml
+++ b/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-installer-itest/pom.xml
@@ -296,6 +296,7 @@
                     <javaOpt>-Dhawkular.log.nest=${hawkular.log.nest}</javaOpt>
                     <javaOpt>-Dhawkular.log.datastax.driver=${hawkular.log.datastax.driver}</javaOpt>
                     <javaOpt>-Dhawkular.log.cassandra=${hawkular.log.cassandra}</javaOpt>
+                    <javaOpt>-Dhawkular.backend=embedded_cassandra</javaOpt>
                     <javaOpt>${debug.hawkular.argLine}</javaOpt>
                   </javaOpts>
                   <add-user>

--- a/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-itest-feature-pack/feature-pack-build.xml
+++ b/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-itest-feature-pack/feature-pack-build.xml
@@ -24,13 +24,14 @@
   </dependencies>
 
   <config>
-    <standalone template="configuration/standalone/hawkular-nest-template.xml" subsystems="configuration/standalone/hawkular-wildfly-agent-itest-subsystems.xml" output-file="standalone/configuration/standalone.xml" />
+    <standalone template="configuration/standalone/template.xml" subsystems="configuration/standalone/hawkular-wildfly-agent-itest-subsystems.xml" output-file="standalone/configuration/standalone.xml" />
   </config>
 
   <copy-artifacts>
     <copy-artifact artifact="org.hawkular.inventory:hawkular-inventory-dist" to-location="modules/system/layers/hawkular/org/hawkular/nest/main/deployments/hawkular-inventory-dist.war" />
     <copy-artifact artifact="org.hawkular.metrics:hawkular-metrics-component" to-location="modules/system/layers/hawkular/org/hawkular/nest/main/deployments/hawkular-metrics-component.war" />
     <copy-artifact artifact="org.hawkular.agent:hawkular-wildfly-agent-example-jndi" to-location="modules/system/layers/hawkular/org/hawkular/nest/main/deployments/hawkular-wildfly-agent-example-jndi.war" />
+    <copy-artifact artifact="org.hawkular.commons:hawkular-commons-embedded-cassandra-war" to-location="modules/system/layers/hawkular/org/hawkular/nest/main/deployments/hawkular-commons-embedded-cassandra-war.war" />
   </copy-artifacts>
 
   <file-permissions>

--- a/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-itest-feature-pack/pom.xml
+++ b/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-itest-feature-pack/pom.xml
@@ -41,6 +41,13 @@
     </dependency>
 
     <dependency>
+      <groupId>org.hawkular.commons</groupId>
+      <artifactId>hawkular-commons-embedded-cassandra-war</artifactId>
+      <type>war</type>
+      <version>${version.org.hawkular.commons}</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.hawkular.agent</groupId>
       <artifactId>hawkular-wildfly-agent-example-jndi</artifactId>
       <version>${project.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <version.io.prometheus.client>0.0.2</version.io.prometheus.client>
     <version.org.hamcrest>1.3</version.org.hamcrest>
 
-    <version.org.hawkular.commons>0.7.3.Final</version.org.hawkular.commons>
+    <version.org.hawkular.commons>0.7.4.Final</version.org.hawkular.commons>
     <version.org.hawkular.inventory>0.16.0.Final</version.org.hawkular.inventory>
     <version.org.hawkular.metrics>0.16.0.Final</version.org.hawkular.metrics>
 


### PR DESCRIPTION
now that hawkular-services no longer has embedded cassandra, we need to put embedded cassandra into our own itest server feature pack.
