### PR TITLE
do not include resoure types as root types if the configuration is bad

### DIFF
--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/inventory/ResourceTypeManager.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/inventory/ResourceTypeManager.java
@@ -106,7 +106,11 @@ public final class ResourceTypeManager<L> {
         Set<ResourceType<L>> allTypes = resourceTypesGraph.vertexSet();
         for (ResourceType<L> type : allTypes) {
             if (index.predecessorsOf(type).isEmpty()) {
-                roots.add(type);
+                if (type.getParents().isEmpty()) {
+                    roots.add(type);
+                } else {
+                    log.errorInvalidRootResourceType(type.getID().getIDString(), type.getParents());
+                }
             }
         }
         return Collections.unmodifiableSet(roots);

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/log/MsgLogger.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/log/MsgLogger.java
@@ -16,12 +16,14 @@
  */
 package org.hawkular.agent.monitor.log;
 
+import java.util.Collection;
 import java.util.List;
 
 import javax.management.MalformedObjectNameException;
 
 import org.hawkular.agent.monitor.extension.MonitorServiceConfiguration.StorageReportTo;
 import org.hawkular.agent.monitor.inventory.MonitoredEndpoint;
+import org.hawkular.agent.monitor.inventory.Name;
 import org.hawkular.agent.monitor.protocol.EndpointService;
 import org.hawkular.agent.monitor.protocol.ProtocolException;
 import org.jboss.logging.BasicLogger;
@@ -334,5 +336,10 @@ public interface MsgLogger extends BasicLogger {
     @LogMessage(level = Level.INFO)
     @Message(id = 10073, value = "Now monitoring the new endpoint [%s]")
     void infoAddedEndpointService(String string);
+
+    @LogMessage(level = Level.ERROR)
+    @Message(id = 10074, value = "The resource type [%s] is missing a parent. "
+            + "Make sure at least one of these resource types are defined and enabled: %s")
+    void errorInvalidRootResourceType(String idString, Collection<Name> parents);
 
 }


### PR DESCRIPTION
You will see errors logs when this happens now, and the type won't be considered a root type:

13:53:24,501 ERROR [org.hawkular.agent.monitor.inventory.ResourceTypeManager](Hawkular WildFly Agent Full Discovery Scan-1) HAWKMONITOR010074: The resource type [Datasource] is missing a parent. Make sure at least one of these resource types are defined and enabled: [WildFly Server, Domain WildFly Server]
