### PR TITLE
HWKAGENT-79  metric tags

### DIFF
--- a/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-example-jndi/src/main/java/org/hawkular/agent/example/MyAppSamplingService.java
+++ b/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-example-jndi/src/main/java/org/hawkular/agent/example/MyAppSamplingService.java
@@ -46,7 +46,7 @@ public class MyAppSamplingService implements SamplingService<MyAppNodeLocation> 
             // this is our endpoint that Hawkular uses to collect metrics and availabilities for our managed resources
             ConnectionData connectionData = new ConnectionData(new URI("myapp:local-uri"), null, null);
             EndpointConfiguration config = new EndpointConfiguration("My App Endpoint", true, Collections.emptyList(),
-                    connectionData, null, null, null, null);
+                    connectionData, null, null, null, null, null);
             this.endpoint = MonitoredEndpoint.of(config, null);
         } catch (Exception e) {
             throw new IllegalStateException("Cannot create sampling service", e);

--- a/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-example-jndi/src/main/java/org/hawkular/agent/example/MyAppSamplingService.java
+++ b/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-example-jndi/src/main/java/org/hawkular/agent/example/MyAppSamplingService.java
@@ -19,6 +19,7 @@ package org.hawkular.agent.example;
 import java.net.URI;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 
 import org.hawkular.agent.monitor.api.SamplingService;
 import org.hawkular.agent.monitor.extension.MonitorServiceConfiguration.EndpointConfiguration;
@@ -46,11 +47,16 @@ public class MyAppSamplingService implements SamplingService<MyAppNodeLocation> 
             // this is our endpoint that Hawkular uses to collect metrics and availabilities for our managed resources
             ConnectionData connectionData = new ConnectionData(new URI("myapp:local-uri"), null, null);
             EndpointConfiguration config = new EndpointConfiguration("My App Endpoint", true, Collections.emptyList(),
-                    connectionData, null, null, null, null, null);
+                    connectionData, null, null, null, null, null, null);
             this.endpoint = MonitoredEndpoint.of(config, null);
         } catch (Exception e) {
             throw new IllegalStateException("Cannot create sampling service", e);
         }
+    }
+
+    @Override
+    public Map<String, String> generateAssociatedMetricTags(MeasurementInstance<MyAppNodeLocation, ?> instance) {
+        return Collections.emptyMap();
     }
 
     @Override
@@ -73,5 +79,4 @@ public class MyAppSamplingService implements SamplingService<MyAppNodeLocation> 
         // TODO collect availabilities
         log.warnf("Need to check availabilities for these: %s", instances);
     }
-
 }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/api/MetricStorage.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/api/MetricStorage.java
@@ -32,4 +32,20 @@ public interface MetricStorage {
      * @param waitMillis the amount of milliseconds to wait for the store to complete before returning (0==no wait)
      */
     void store(MetricDataPayloadBuilder payloadBuilder, long waitMillis);
+
+    /**
+     * @return a builder object suitable for wrapping metric tags in a proper payload
+     * message format to be sent to the storage backend.
+     */
+    MetricTagPayloadBuilder createMetricTagPayloadBuilder();
+
+    /**
+     * Stores the metric tags found in the given builder.
+     * This is an asynchronous call. But if a <code>waitMillis</code> is provided, it indicates the caller is willing
+     * to wait up to that amount of milliseconds for the store to complete before returning.
+     *
+     * @param payloadBuilder contains the metric tags to store
+     * @param waitMillis the amount of milliseconds to wait for the store to complete before returning (0==no wait)
+     */
+    void store(MetricTagPayloadBuilder payloadBuilder, long waitMillis);
 }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/api/MetricTagPayloadBuilder.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/api/MetricTagPayloadBuilder.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.agent.monitor.api;
+
+import java.util.Map;
+
+import org.hawkular.metrics.client.common.MetricType;
+
+public interface MetricTagPayloadBuilder {
+
+    /**
+     * Add a tag to a metric type. When all metric tags are added, call
+     * {@link #toPayload()} to get the payload message that can be used to
+     * send to the storage backend via the storage adapter.
+     *
+     * @param key identifies the metric
+     * @param name the name of the tag
+     * @param value the value of the tag
+     * @param metricType the type of metric
+     */
+    void addTag(String key, String name, String value, MetricType metricType);
+
+    /**
+     * Due to the way Hawkular Metrics REST API works, you can only add tags for a single metric.
+     * So this method actually has the potential to return mulitple payloads - one for each metric that is
+     * getting assigned tags. The key to the map is the relative path to the REST API that identifies
+     * the metric whose tags are being added. For example, if a gauge metric of id "foo" is getting
+     * tags, its key in the map will be "gauges/foo". The values of the map are the JSON encodings
+     * of all the tags for the metric.
+     *
+     * @return the payloads in a format suitable for the storage adapter.
+     */
+    Map<String, String> toPayload();
+
+    /**
+     * @return the number of tags that were {@link #addTag(String, String, String, MetricType) added} to payload
+     */
+    int getNumberTags();
+
+    /**
+     * If the metric tags are to be stored with a special tenant ID, this sets that tenant ID.
+     * If null is passed in, or if this method is not called, the agent's tenant ID is used.
+     *
+     * @param tenantId the tenant ID to associate the metric tags with. May be null.
+     */
+    void setTenantId(String tenantId);
+
+    /**
+     * @return the tenant ID to be associated with the metrics. If null, the agent's tenant ID is used.
+     */
+    String getTenantId();
+}

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/api/SamplingService.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/api/SamplingService.java
@@ -17,6 +17,7 @@
 package org.hawkular.agent.monitor.api;
 
 import java.util.Collection;
+import java.util.Map;
 
 import org.hawkular.agent.monitor.extension.MonitorServiceConfiguration.AbstractEndpointConfiguration;
 import org.hawkular.agent.monitor.extension.MonitorServiceConfiguration.EndpointConfiguration;
@@ -42,6 +43,19 @@ public interface SamplingService<L> {
      * @return the endpoint this service is able to sample
      */
     MonitoredEndpoint<EndpointConfiguration> getMonitoredEndpoint();
+
+    /**
+     * Given a measurement instance, this will generate the tags to be added to the
+     * associated Hawkular Metrics metric definition.
+     *
+     * The service can use the metric tags provided by the user via
+     * {@link MonitoredEndpoint#getEndpointConfiguration() the endpoint configuration} which contains
+     * {@link AbstractEndpointConfiguration#getMetricTags() the metric tags}.
+     *
+     * @param instance the measurement instance whose tags are to be generated
+     * @return the measurement tags to be added to the metric definition
+     */
+    Map<String, String> generateAssociatedMetricTags(MeasurementInstance<L, ?> instance);
 
     /**
      * Given a measurement instance, this will generate the key to be used when

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/api/SamplingService.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/api/SamplingService.java
@@ -46,8 +46,7 @@ public interface SamplingService<L> {
     /**
      * Given a measurement instance, this will generate the key to be used when
      * storing that measurement instance's collected data to storage. In the Hawkular Metrics
-     * REST API, this key is known as the "metric id" hence why this method is called
-     * <code>generateMetricId</code>.
+     * REST API, this key is known as the "metric id".
      *
      * The service can generate a default one or can use the metric ID template provided by the user
      * via {@link MonitoredEndpoint#getEndpointConfiguration() the endpoint configuration} which contains a
@@ -58,8 +57,10 @@ public interface SamplingService<L> {
      *
      * @param instance the measurement instance whose key is to be generated
      * @return the measurement key to be used to identify measured data for the given instance
+     * @see MeasurementInstance#getAssociatedMetricId(String)
+     * @see MeasurementInstance#setAssociatedMetricId(String)
      */
-    default String generateMetricId(MeasurementInstance<L, ?> instance) {
+    default String generateAssociatedMetricId(MeasurementInstance<L, ?> instance) {
         return instance.getID().getIDString();
     }
 

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/api/SamplingService.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/api/SamplingService.java
@@ -18,6 +18,7 @@ package org.hawkular.agent.monitor.api;
 
 import java.util.Collection;
 
+import org.hawkular.agent.monitor.extension.MonitorServiceConfiguration.AbstractEndpointConfiguration;
 import org.hawkular.agent.monitor.extension.MonitorServiceConfiguration.EndpointConfiguration;
 import org.hawkular.agent.monitor.inventory.AvailType;
 import org.hawkular.agent.monitor.inventory.MeasurementInstance;
@@ -41,6 +42,26 @@ public interface SamplingService<L> {
      * @return the endpoint this service is able to sample
      */
     MonitoredEndpoint<EndpointConfiguration> getMonitoredEndpoint();
+
+    /**
+     * Given a measurement instance, this will generate the key to be used when
+     * storing that measurement instance's collected data to storage. In the Hawkular Metrics
+     * REST API, this key is known as the "metric id" hence why this method is called
+     * <code>generateMetricId</code>.
+     *
+     * The service can generate a default one or can use the metric ID template provided by the user
+     * via {@link MonitoredEndpoint#getEndpointConfiguration() the endpoint configuration} which contains a
+     * {@link AbstractEndpointConfiguration#getMetricIdTemplate() metric ID template}.
+     *
+     * If this method is not implemented, the default behavior is to return the ID of
+     * the measurement instance itself.
+     *
+     * @param instance the measurement instance whose key is to be generated
+     * @return the measurement key to be used to identify measured data for the given instance
+     */
+    default String generateMetricId(MeasurementInstance<L, ?> instance) {
+        return instance.getID().getIDString();
+    }
 
     /**
      * Checks the availabilities defined by {@code instances} and reports them back to the given {@code consumer}.

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/dynamicprotocol/prometheus/PrometheusDynamicEndpointService.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/dynamicprotocol/prometheus/PrometheusDynamicEndpointService.java
@@ -227,13 +227,21 @@ public class PrometheusDynamicEndpointService extends DynamicEndpointService {
         }
 
         private String generateKey(Metric metric) {
-            // TODO figure out a good key
             StringBuilder key = new StringBuilder();
 
-            key.append(getFeedId()).append("_");
-            key.append(metric.getName()).append("_");
-            if (!metric.getLabels().isEmpty()) {
-                key.append(buildLabelListString(metric.getLabels(), null, null)).append("_");
+            DynamicEndpointConfiguration config = getMonitoredEndpoint().getEndpointConfiguration();
+            String metricIdTemplate = config.getMetricIdTemplate();
+            if (metricIdTemplate == null || metricIdTemplate.isEmpty()) {
+                key.append(getFeedId()).append("_");
+                key.append(metric.getName()).append("_");
+                if (!metric.getLabels().isEmpty()) {
+                    key.append(buildLabelListString(metric.getLabels(), null, null)).append("_");
+                }
+            } else {
+                key.append(metricIdTemplate
+                        .replaceAll("%FeedId", getFeedId())
+                        .replaceAll("%ManagedServerName", config.getName())
+                        .replaceAll("%MetricName", metric.getName()));
             }
 
             return key.toString();

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalDMRAttributes.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalDMRAttributes.java
@@ -58,10 +58,18 @@ public interface LocalDMRAttributes {
                     .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
                     .build();
 
+    SimpleAttributeDefinition METRIC_ID_TEMPLATE = new SimpleAttributeDefinitionBuilder("metric-id-template",
+            ModelType.STRING)
+                    .setAllowNull(true)
+                    .setAllowExpression(true)
+                    .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+                    .build();
+
     AttributeDefinition[] ATTRIBUTES = {
             ENABLED,
             SET_AVAIL_ON_SHUTDOWN,
             RESOURCE_TYPE_SETS,
-            TENANT_ID
+            TENANT_ID,
+            METRIC_ID_TEMPLATE
     };
 }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalDMRAttributes.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalDMRAttributes.java
@@ -65,11 +65,19 @@ public interface LocalDMRAttributes {
                     .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
                     .build();
 
+    SimpleAttributeDefinition METRIC_TAGS = new SimpleAttributeDefinitionBuilder("metric-tags",
+            ModelType.STRING)
+                    .setAllowNull(true)
+                    .setAllowExpression(true)
+                    .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+                    .build();
+
     AttributeDefinition[] ATTRIBUTES = {
             ENABLED,
             SET_AVAIL_ON_SHUTDOWN,
             RESOURCE_TYPE_SETS,
             TENANT_ID,
-            METRIC_ID_TEMPLATE
+            METRIC_ID_TEMPLATE,
+            METRIC_TAGS
     };
 }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/MonitorServiceConfiguration.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/MonitorServiceConfiguration.java
@@ -363,10 +363,11 @@ public class MonitorServiceConfiguration {
         private final String securityRealm;
         private final String tenantId;
         private final String metricIdTemplate;
+        private final Map<String, String> metricTags;
         private final Map<String, ? extends Object> customData;
 
         public AbstractEndpointConfiguration(String name, boolean enabled, ConnectionData connectionData,
-                String securityRealm, String tenantId, String metricIdTemplate,
+                String securityRealm, String tenantId, String metricIdTemplate, Map<String, String> metricTags,
                 Map<String, ? extends Object> customData) {
             super();
             this.name = name;
@@ -375,6 +376,7 @@ public class MonitorServiceConfiguration {
             this.securityRealm = securityRealm;
             this.tenantId = tenantId;
             this.metricIdTemplate = metricIdTemplate;
+            this.metricTags = metricTags;
             this.customData = (customData != null) ? Collections.unmodifiableMap(customData) : Collections.emptyMap();
         }
 
@@ -410,6 +412,16 @@ public class MonitorServiceConfiguration {
         }
 
         /**
+         * @return if not null this is name/value pairs of tags to be associated with metrics that are
+         *         collected from resources associated with this managed server. These tags are tokenized,
+         *         meanining they can have substrings such as "%ManagedServerName" in them which are meant to
+         *         be replaced at runtime with the values of the tokens.
+         */
+        public Map<String, String> getMetricTags() {
+            return metricTags;
+        }
+
+        /**
          * @return custom information related to an endpoint. The endpoint service should know the value types.
          */
         public Map<String, ? extends Object> getCustomData() {
@@ -427,8 +439,8 @@ public class MonitorServiceConfiguration {
 
         public EndpointConfiguration(String name, boolean enabled, Collection<Name> resourceTypeSets,
                 ConnectionData connectionData, String securityRealm, Avail setAvailOnShutdown, String tenantId,
-                String metricIdTemplate, Map<String, ? extends Object> customData) {
-            super(name, enabled, connectionData, securityRealm, tenantId, metricIdTemplate, customData);
+                String metricIdTemplate, Map<String, String> metricTags, Map<String, ? extends Object> customData) {
+            super(name, enabled, connectionData, securityRealm, tenantId, metricIdTemplate, metricTags, customData);
             this.resourceTypeSets = resourceTypeSets;
             this.setAvailOnShutdown = setAvailOnShutdown;
         }
@@ -462,8 +474,9 @@ public class MonitorServiceConfiguration {
 
         public DynamicEndpointConfiguration(String name, boolean enabled,
                 Collection<Name> metricSets, ConnectionData connectionData, String securityRealm, int interval,
-                TimeUnit timeUnits, String tenantId, String metricIdTemplate, Map<String, Object> customData) {
-            super(name, enabled, connectionData, securityRealm, tenantId, metricIdTemplate, customData);
+                TimeUnit timeUnits, String tenantId, String metricIdTemplate, Map<String, String> metricTags,
+                Map<String, Object> customData) {
+            super(name, enabled, connectionData, securityRealm, tenantId, metricIdTemplate, metricTags, customData);
             this.metricSets = metricSets;
             this.interval = interval;
             this.timeUnits = timeUnits;

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/MonitorServiceConfiguration.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/MonitorServiceConfiguration.java
@@ -362,16 +362,19 @@ public class MonitorServiceConfiguration {
         private final ConnectionData connectionData;
         private final String securityRealm;
         private final String tenantId;
+        private final String metricIdTemplate;
         private final Map<String, ? extends Object> customData;
 
         public AbstractEndpointConfiguration(String name, boolean enabled, ConnectionData connectionData,
-                String securityRealm, String tenantId, Map<String, ? extends Object> customData) {
+                String securityRealm, String tenantId, String metricIdTemplate,
+                Map<String, ? extends Object> customData) {
             super();
             this.name = name;
             this.enabled = enabled;
             this.connectionData = connectionData;
             this.securityRealm = securityRealm;
             this.tenantId = tenantId;
+            this.metricIdTemplate = metricIdTemplate;
             this.customData = (customData != null) ? Collections.unmodifiableMap(customData) : Collections.emptyMap();
         }
 
@@ -400,6 +403,13 @@ public class MonitorServiceConfiguration {
         }
 
         /**
+         * @return if not null this is the template to use to create all metric IDs for this managed server.
+         */
+        public String getMetricIdTemplate() {
+            return metricIdTemplate;
+        }
+
+        /**
          * @return custom information related to an endpoint. The endpoint service should know the value types.
          */
         public Map<String, ? extends Object> getCustomData() {
@@ -417,8 +427,8 @@ public class MonitorServiceConfiguration {
 
         public EndpointConfiguration(String name, boolean enabled, Collection<Name> resourceTypeSets,
                 ConnectionData connectionData, String securityRealm, Avail setAvailOnShutdown, String tenantId,
-                Map<String, ? extends Object> customData) {
-            super(name, enabled, connectionData, securityRealm, tenantId, customData);
+                String metricIdTemplate, Map<String, ? extends Object> customData) {
+            super(name, enabled, connectionData, securityRealm, tenantId, metricIdTemplate, customData);
             this.resourceTypeSets = resourceTypeSets;
             this.setAvailOnShutdown = setAvailOnShutdown;
         }
@@ -452,8 +462,8 @@ public class MonitorServiceConfiguration {
 
         public DynamicEndpointConfiguration(String name, boolean enabled,
                 Collection<Name> metricSets, ConnectionData connectionData, String securityRealm, int interval,
-                TimeUnit timeUnits, String tenantId, Map<String, Object> customData) {
-            super(name, enabled, connectionData, securityRealm, tenantId, customData);
+                TimeUnit timeUnits, String tenantId, String metricIdTemplate, Map<String, Object> customData) {
+            super(name, enabled, connectionData, securityRealm, tenantId, metricIdTemplate, customData);
             this.metricSets = metricSets;
             this.interval = interval;
             this.timeUnits = timeUnits;

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/MonitorServiceConfigurationBuilder.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/MonitorServiceConfigurationBuilder.java
@@ -126,7 +126,7 @@ public class MonitorServiceConfigurationBuilder {
         if (!platformTypeSets.isDisabledOrEmpty()) {
             String machineId = determinePlatformMachineId(config, context);
             EndpointConfiguration endpoint = new EndpointConfiguration("platform", true, null, null, null, Avail.DOWN,
-                    null, Collections.singletonMap(Constants.MACHINE_ID.getNameString(), machineId));
+                    null, null, Collections.singletonMap(Constants.MACHINE_ID.getNameString(), machineId));
             platformConfigBuilder.endpoint(endpoint);
         }
 
@@ -146,7 +146,7 @@ public class MonitorServiceConfigurationBuilder {
             OperationContext context,
             org.hawkular.agent.monitor.inventory.TypeSets.Builder<DMRNodeLocation>//
             typeSetsBuilder)
-                    throws OperationFailedException {
+            throws OperationFailedException {
 
         boolean enabled = false;
 
@@ -159,15 +159,16 @@ public class MonitorServiceConfigurationBuilder {
                 }
                 ModelNode metricSetValueNode = metricSetProperty.getValue();
 
-                TypeSetBuilder<MetricType<DMRNodeLocation>> typeSetBuilder =
-                        TypeSet.<MetricType<DMRNodeLocation>> builder()
-                                .name(new Name(metricSetName))
-                                .enabled(getBoolean(metricSetValueNode, context, DMRMetricSetAttributes.ENABLED));
+                TypeSetBuilder<MetricType<DMRNodeLocation>> typeSetBuilder = TypeSet
+                        .<MetricType<DMRNodeLocation>> builder()
+                        .name(new Name(metricSetName))
+                        .enabled(getBoolean(metricSetValueNode, context, DMRMetricSetAttributes.ENABLED));
 
                 if (metricSetValueNode.hasDefined(DMRMetricDefinition.METRIC)) {
                     List<Property> metricsList = metricSetValueNode.get(DMRMetricDefinition.METRIC).asPropertyList();
                     for (Property metricProperty : metricsList) {
-                        String metricName = metricSetName + "~" + metricProperty.getName();
+                        String metricId = metricSetName + "~" + metricProperty.getName();
+                        String metricName = metricProperty.getName();
                         ModelNode metricValueNode = metricProperty.getValue();
                         String attributeString = getString(metricValueNode, context, DMRMetricAttributes.ATTRIBUTE);
                         PathAddress pathAddress = getPath(metricValueNode, context, DMRMetricAttributes.PATH);
@@ -177,7 +178,7 @@ public class MonitorServiceConfigurationBuilder {
                                 new DMRNodeLocation(pathAddress, re, id),
                                 attributeString);
                         MetricType<DMRNodeLocation> metric = new MetricType<>(
-                                ID.NULL_ID,
+                                new ID(metricId),
                                 new Name(metricName),
                                 location,
                                 new Interval(getInt(metricValueNode, context, DMRMetricAttributes.INTERVAL),
@@ -228,7 +229,7 @@ public class MonitorServiceConfigurationBuilder {
     private static void determineAvailSetDmr(ModelNode config,
             OperationContext context,
             TypeSets.Builder<DMRNodeLocation> typeSetsBuilder)
-                    throws OperationFailedException {
+            throws OperationFailedException {
         boolean enabled = false;
 
         if (config.hasDefined(DMRAvailSetDefinition.AVAIL_SET)) {
@@ -239,10 +240,10 @@ public class MonitorServiceConfigurationBuilder {
                     log.warnCommaInName(availSetName);
                 }
                 ModelNode availSetValueNode = availSetProperty.getValue();
-                TypeSetBuilder<AvailType<DMRNodeLocation>> typeSetBuilder =
-                        TypeSet.<AvailType<DMRNodeLocation>> builder()
-                                .name(new Name(availSetName))
-                                .enabled(getBoolean(availSetValueNode, context, DMRAvailSetAttributes.ENABLED));
+                TypeSetBuilder<AvailType<DMRNodeLocation>> typeSetBuilder = TypeSet
+                        .<AvailType<DMRNodeLocation>> builder()
+                        .name(new Name(availSetName))
+                        .enabled(getBoolean(availSetValueNode, context, DMRAvailSetAttributes.ENABLED));
 
                 if (availSetValueNode.hasDefined(DMRAvailDefinition.AVAIL)) {
                     List<Property> availsList = availSetValueNode.get(DMRAvailDefinition.AVAIL).asPropertyList();
@@ -279,7 +280,7 @@ public class MonitorServiceConfigurationBuilder {
     private static void determineMetricSetJmx(ModelNode config,
             OperationContext context,
             TypeSets.Builder<JMXNodeLocation> typeSetsBuilder)
-                    throws OperationFailedException {
+            throws OperationFailedException {
 
         boolean enabled = false;
 
@@ -291,14 +292,15 @@ public class MonitorServiceConfigurationBuilder {
                     log.warnCommaInName(metricSetName);
                 }
                 ModelNode metricSetValueNode = metricSetProperty.getValue();
-                TypeSetBuilder<MetricType<JMXNodeLocation>> typeSetBuilder =
-                        TypeSet.<MetricType<JMXNodeLocation>> builder()
-                                .name(new Name(metricSetName))
-                                .enabled(getBoolean(metricSetValueNode, context, JMXMetricSetAttributes.ENABLED));
+                TypeSetBuilder<MetricType<JMXNodeLocation>> typeSetBuilder = TypeSet
+                        .<MetricType<JMXNodeLocation>> builder()
+                        .name(new Name(metricSetName))
+                        .enabled(getBoolean(metricSetValueNode, context, JMXMetricSetAttributes.ENABLED));
                 if (metricSetValueNode.hasDefined(JMXMetricDefinition.METRIC)) {
                     List<Property> metricsList = metricSetValueNode.get(JMXMetricDefinition.METRIC).asPropertyList();
                     for (Property metricProperty : metricsList) {
-                        String metricName = metricSetName + "~" + metricProperty.getName();
+                        String metricId = metricSetName + "~" + metricProperty.getName();
+                        String metricName = metricProperty.getName();
 
                         ModelNode metricValueNode = metricProperty.getValue();
                         String objectName = getString(metricValueNode, context, JMXMetricAttributes.OBJECT_NAME);
@@ -307,7 +309,8 @@ public class MonitorServiceConfigurationBuilder {
                                     new JMXNodeLocation(objectName),
                                     getString(metricValueNode, context, JMXMetricAttributes.ATTRIBUTE));
 
-                            MetricType<JMXNodeLocation> metric = new MetricType<JMXNodeLocation>(ID.NULL_ID,
+                            MetricType<JMXNodeLocation> metric = new MetricType<JMXNodeLocation>(
+                                    new ID(metricId),
                                     new Name(metricName),
                                     location,
                                     new Interval(getInt(metricValueNode, context, JMXMetricAttributes.INTERVAL),
@@ -334,7 +337,7 @@ public class MonitorServiceConfigurationBuilder {
     private static void determineAvailSetJmx(ModelNode config,
             OperationContext context,
             TypeSets.Builder<JMXNodeLocation> typeSetsBuilder)
-                    throws OperationFailedException {
+            throws OperationFailedException {
 
         boolean enabled = false;
 
@@ -346,10 +349,10 @@ public class MonitorServiceConfigurationBuilder {
                     log.warnCommaInName(availSetName);
                 }
                 ModelNode availSetValueNode = availSetProperty.getValue();
-                TypeSetBuilder<AvailType<JMXNodeLocation>> typeSetBuilder =
-                        TypeSet.<AvailType<JMXNodeLocation>> builder() //
-                                .name(new Name(availSetName)) //
-                                .enabled(getBoolean(availSetValueNode, context, JMXAvailSetAttributes.ENABLED));
+                TypeSetBuilder<AvailType<JMXNodeLocation>> typeSetBuilder = TypeSet
+                        .<AvailType<JMXNodeLocation>> builder() //
+                        .name(new Name(availSetName)) //
+                        .enabled(getBoolean(availSetValueNode, context, JMXAvailSetAttributes.ENABLED));
                 if (availSetValueNode.hasDefined(JMXAvailDefinition.AVAIL)) {
                     List<Property> availsList = availSetValueNode.get(JMXAvailDefinition.AVAIL).asPropertyList();
                     for (Property availProperty : availsList) {
@@ -387,7 +390,7 @@ public class MonitorServiceConfigurationBuilder {
     private static void determineMetricSetPrometheus(ModelNode config,
             OperationContext context,
             Map<Name, NameSet> namedMetricSets)
-                    throws OperationFailedException {
+            throws OperationFailedException {
 
         boolean enabled = false;
 
@@ -834,7 +837,7 @@ public class MonitorServiceConfigurationBuilder {
 
     private static StorageAdapterConfiguration determineStorageAdapterConfig(ModelNode config,
             OperationContext context)
-                    throws OperationFailedException {
+            throws OperationFailedException {
 
         if (!config.hasDefined(StorageDefinition.STORAGE_ADAPTER)) {
             throw new IllegalArgumentException("Missing storage adapter configuration: " + config.toJSONString(true));
@@ -914,10 +917,11 @@ public class MonitorServiceConfigurationBuilder {
                 numDmrSchedulerThreads, metricDispatcherBufferSize, metricDispatcherMaxBatchSize,
                 availDispatcherBufferSize, availDispatcherMaxBatchSize, pingDispatcherPeriodSeconds);
     }
+
     private static void determineResourceTypeSetDmr(ModelNode config,
             OperationContext context,
             TypeSets.Builder<DMRNodeLocation> typeSetsBuilder)
-                    throws OperationFailedException {
+            throws OperationFailedException {
         boolean enabled = false;
 
         if (config.hasDefined(DMRResourceTypeSetDefinition.RESOURCE_TYPE_SET)) {
@@ -926,11 +930,11 @@ public class MonitorServiceConfigurationBuilder {
             for (Property resourceTypeSetProperty : resourceTypeSetsList) {
                 String resourceTypeSetName = resourceTypeSetProperty.getName();
                 ModelNode resourceTypeSetValueNode = resourceTypeSetProperty.getValue();
-                TypeSetBuilder<ResourceType<DMRNodeLocation>> typeSetBuilder =
-                        TypeSet.<ResourceType<DMRNodeLocation>> builder()
-                                .name(new Name(resourceTypeSetName))
-                                .enabled(getBoolean(resourceTypeSetValueNode, context,
-                                        DMRResourceTypeSetAttributes.ENABLED));
+                TypeSetBuilder<ResourceType<DMRNodeLocation>> typeSetBuilder = TypeSet
+                        .<ResourceType<DMRNodeLocation>> builder()
+                        .name(new Name(resourceTypeSetName))
+                        .enabled(getBoolean(resourceTypeSetValueNode, context,
+                                DMRResourceTypeSetAttributes.ENABLED));
                 if (resourceTypeSetName.indexOf(',') > -1) {
                     log.warnCommaInName(resourceTypeSetName);
                 }
@@ -995,8 +999,7 @@ public class MonitorServiceConfigurationBuilder {
                                 boolean id = getBoolean(configValueNode, context,
                                         DMRResourceConfigAttributes.INCLUDE_DEFAULTS);
 
-                                ResourceConfigurationPropertyType<DMRNodeLocation> configType =
-                                new ResourceConfigurationPropertyType<>(
+                                ResourceConfigurationPropertyType<DMRNodeLocation> configType = new ResourceConfigurationPropertyType<>(
                                         ID.NULL_ID, new Name(configName),
                                         new AttributeLocation<DMRNodeLocation>(
                                                 new DMRNodeLocation(pathAddress, re, id),
@@ -1029,7 +1032,7 @@ public class MonitorServiceConfigurationBuilder {
 
     private static void determineResourceTypeSetJmx(ModelNode config,
             OperationContext context, TypeSets.Builder<JMXNodeLocation> typeSetsBuilder)
-                    throws OperationFailedException {
+            throws OperationFailedException {
         boolean enabled = false;
 
         if (config.hasDefined(JMXResourceTypeSetDefinition.RESOURCE_TYPE_SET)) {
@@ -1038,11 +1041,11 @@ public class MonitorServiceConfigurationBuilder {
             for (Property resourceTypeSetProperty : resourceTypeSetsList) {
                 String resourceTypeSetName = resourceTypeSetProperty.getName();
                 ModelNode resourceTypeSetValueNode = resourceTypeSetProperty.getValue();
-                TypeSetBuilder<ResourceType<JMXNodeLocation>> typeSetBuilder =
-                        TypeSet.<ResourceType<JMXNodeLocation>> builder()
-                                .name(new Name(resourceTypeSetName))
-                                .enabled(getBoolean(resourceTypeSetValueNode, context,
-                                        JMXResourceTypeSetAttributes.ENABLED));
+                TypeSetBuilder<ResourceType<JMXNodeLocation>> typeSetBuilder = TypeSet
+                        .<ResourceType<JMXNodeLocation>> builder()
+                        .name(new Name(resourceTypeSetName))
+                        .enabled(getBoolean(resourceTypeSetValueNode, context,
+                                JMXResourceTypeSetAttributes.ENABLED));
                 if (resourceTypeSetName.indexOf(',') > -1) {
                     log.warnCommaInName(resourceTypeSetName);
                 }
@@ -1057,15 +1060,14 @@ public class MonitorServiceConfigurationBuilder {
                         String objectName = getObjectName(resourceTypeValueNode, context,
                                 JMXResourceTypeAttributes.OBJECT_NAME);
                         try {
-                            Builder<?, JMXNodeLocation> resourceTypeBuilder =
-                                    ResourceType.<JMXNodeLocation> builder()
-                                            .id(ID.NULL_ID)
-                                            .name(new Name(resourceTypeName))
-                                            .location(new JMXNodeLocation(objectName))
-                                            .resourceNameTemplate(getString(resourceTypeValueNode, context,
-                                                    JMXResourceTypeAttributes.RESOURCE_NAME_TEMPLATE))
-                                            .parents(getNameListFromString(resourceTypeValueNode, context,
-                                                    JMXResourceTypeAttributes.PARENTS));
+                            Builder<?, JMXNodeLocation> resourceTypeBuilder = ResourceType.<JMXNodeLocation> builder()
+                                    .id(ID.NULL_ID)
+                                    .name(new Name(resourceTypeName))
+                                    .location(new JMXNodeLocation(objectName))
+                                    .resourceNameTemplate(getString(resourceTypeValueNode, context,
+                                            JMXResourceTypeAttributes.RESOURCE_NAME_TEMPLATE))
+                                    .parents(getNameListFromString(resourceTypeValueNode, context,
+                                            JMXResourceTypeAttributes.PARENTS));
 
                             List<Name> metricSets = getNameListFromString(resourceTypeValueNode, context,
                                     JMXResourceTypeAttributes.METRIC_SETS);
@@ -1106,11 +1108,10 @@ public class MonitorServiceConfigurationBuilder {
                                             JMXResourceConfigAttributes.OBJECT_NAME);
                                     String attr = getString(configValueNode, context,
                                             JMXResourceConfigAttributes.ATTRIBUTE);
-                                    AttributeLocation<JMXNodeLocation> attribLoc =
-                                            new AttributeLocation<JMXNodeLocation>(new JMXNodeLocation(on), attr);
-                                    ResourceConfigurationPropertyType<JMXNodeLocation> configType =
-                                            new ResourceConfigurationPropertyType<>(
-                                                    ID.NULL_ID, new Name(configName), attribLoc);
+                                    AttributeLocation<JMXNodeLocation> attribLoc = new AttributeLocation<JMXNodeLocation>(
+                                            new JMXNodeLocation(on), attr);
+                                    ResourceConfigurationPropertyType<JMXNodeLocation> configType = new ResourceConfigurationPropertyType<>(
+                                            ID.NULL_ID, new Name(configName), attribLoc);
                                     resourceTypeBuilder.resourceConfigurationPropertyType(configType);
 
                                 }
@@ -1172,6 +1173,8 @@ public class MonitorServiceConfigurationBuilder {
                     List<Name> resourceTypeSets = getNameListFromString(remoteDMRValueNode, context,
                             RemoteDMRAttributes.RESOURCE_TYPE_SETS);
                     String tenantId = getString(remoteDMRValueNode, context, RemoteDMRAttributes.TENANT_ID);
+                    String metricIdTemplate = getString(remoteDMRValueNode, context,
+                            RemoteDMRAttributes.METRIC_ID_TEMPLATE);
 
                     if (useSsl && securityRealm == null) {
                         log.debugf("Using SSL with no security realm - will rely on the JVM truststore: " + name);
@@ -1180,7 +1183,7 @@ public class MonitorServiceConfigurationBuilder {
                     String protocol = useSsl ? "https-remoting" : "http-remoting";
                     ConnectionData connectionData = new ConnectionData(protocol, host, port, username, password);
                     EndpointConfiguration endpoint = new EndpointConfiguration(name, enabled, resourceTypeSets,
-                            connectionData, securityRealm, setAvailOnShutdown, tenantId, null);
+                            connectionData, securityRealm, setAvailOnShutdown, tenantId, metricIdTemplate, null);
 
                     dmrConfigBuilder.endpoint(endpoint);
                 }
@@ -1204,9 +1207,10 @@ public class MonitorServiceConfigurationBuilder {
                 List<Name> resourceTypeSets = getNameListFromString(localDMRValueNode, context,
                         LocalDMRAttributes.RESOURCE_TYPE_SETS);
                 String tenantId = getString(localDMRValueNode, context, LocalDMRAttributes.TENANT_ID);
+                String metricIdTemplate = getString(localDMRValueNode, context, LocalDMRAttributes.METRIC_ID_TEMPLATE);
 
                 EndpointConfiguration endpoint = new EndpointConfiguration(name, enabled, resourceTypeSets, null, null,
-                        setAvailOnShutdown, tenantId, null);
+                        setAvailOnShutdown, tenantId, metricIdTemplate, null);
                 dmrConfigBuilder.endpoint(endpoint);
             }
 
@@ -1230,6 +1234,8 @@ public class MonitorServiceConfigurationBuilder {
                     List<Name> resourceTypeSets = getNameListFromString(remoteJMXValueNode, context,
                             RemoteJMXAttributes.RESOURCE_TYPE_SETS);
                     String tenantId = getString(remoteJMXValueNode, context, RemoteJMXAttributes.TENANT_ID);
+                    String metricIdTemplate = getString(remoteJMXValueNode, context,
+                            RemoteDMRAttributes.METRIC_ID_TEMPLATE);
 
                     // make sure the URL is at least syntactically valid
                     URI url;
@@ -1245,7 +1251,7 @@ public class MonitorServiceConfigurationBuilder {
 
                     ConnectionData connectionData = new ConnectionData(url, username, password);
                     EndpointConfiguration endpoint = new EndpointConfiguration(name, enabled, resourceTypeSets,
-                            connectionData, securityRealm, setAvailOnShutdown, tenantId, null);
+                            connectionData, securityRealm, setAvailOnShutdown, tenantId, metricIdTemplate, null);
 
                     jmxConfigBuilder.endpoint(endpoint);
                 }
@@ -1273,6 +1279,8 @@ public class MonitorServiceConfigurationBuilder {
                             RemotePrometheusAttributes.TIME_UNITS);
                     TimeUnit timeUnits = TimeUnit.valueOf(timeUnitsStr.toUpperCase());
                     String tenandId = getString(remotePromValueNode, context, RemotePrometheusAttributes.TENANT_ID);
+                    String metricIdTemplate = getString(remotePromValueNode, context,
+                            RemotePrometheusAttributes.METRIC_ID_TEMPLATE);
 
                     // make sure the URL is at least syntactically valid
                     URI url;
@@ -1288,7 +1296,8 @@ public class MonitorServiceConfigurationBuilder {
 
                     ConnectionData connectionData = new ConnectionData(url, username, password);
                     DynamicEndpointConfiguration endpoint = new DynamicEndpointConfiguration(name, enabled,
-                            metricSets, connectionData, securityRealm, interval, timeUnits, tenandId, null);
+                            metricSets, connectionData, securityRealm, interval, timeUnits, tenandId, metricIdTemplate,
+                            null);
 
                     prometheusConfigBuilder.endpoint(endpoint);
                 }
@@ -1328,7 +1337,7 @@ public class MonitorServiceConfigurationBuilder {
 
     private static String getObjectName(ModelNode modelNode, OperationContext context,
             SimpleAttributeDefinition attrib)
-                    throws OperationFailedException {
+            throws OperationFailedException {
         String value = getString(modelNode, context, attrib);
         if (value != null && !value.isEmpty()) {
             // just make sure it follows valid object name syntax rules

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/MonitorServiceConfigurationBuilder.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/MonitorServiceConfigurationBuilder.java
@@ -126,7 +126,7 @@ public class MonitorServiceConfigurationBuilder {
         if (!platformTypeSets.isDisabledOrEmpty()) {
             String machineId = determinePlatformMachineId(config, context);
             EndpointConfiguration endpoint = new EndpointConfiguration("platform", true, null, null, null, Avail.DOWN,
-                    null, null, Collections.singletonMap(Constants.MACHINE_ID.getNameString(), machineId));
+                    null, null, null, Collections.singletonMap(Constants.MACHINE_ID.getNameString(), machineId));
             platformConfigBuilder.endpoint(endpoint);
         }
 
@@ -1175,6 +1175,8 @@ public class MonitorServiceConfigurationBuilder {
                     String tenantId = getString(remoteDMRValueNode, context, RemoteDMRAttributes.TENANT_ID);
                     String metricIdTemplate = getString(remoteDMRValueNode, context,
                             RemoteDMRAttributes.METRIC_ID_TEMPLATE);
+                    Map<String, String> metricTags = getMapFromString(remoteDMRValueNode, context,
+                            RemoteDMRAttributes.METRIC_TAGS);
 
                     if (useSsl && securityRealm == null) {
                         log.debugf("Using SSL with no security realm - will rely on the JVM truststore: " + name);
@@ -1183,7 +1185,8 @@ public class MonitorServiceConfigurationBuilder {
                     String protocol = useSsl ? "https-remoting" : "http-remoting";
                     ConnectionData connectionData = new ConnectionData(protocol, host, port, username, password);
                     EndpointConfiguration endpoint = new EndpointConfiguration(name, enabled, resourceTypeSets,
-                            connectionData, securityRealm, setAvailOnShutdown, tenantId, metricIdTemplate, null);
+                            connectionData, securityRealm, setAvailOnShutdown, tenantId, metricIdTemplate, metricTags,
+                            null);
 
                     dmrConfigBuilder.endpoint(endpoint);
                 }
@@ -1208,9 +1211,11 @@ public class MonitorServiceConfigurationBuilder {
                         LocalDMRAttributes.RESOURCE_TYPE_SETS);
                 String tenantId = getString(localDMRValueNode, context, LocalDMRAttributes.TENANT_ID);
                 String metricIdTemplate = getString(localDMRValueNode, context, LocalDMRAttributes.METRIC_ID_TEMPLATE);
+                Map<String, String> metricTags = getMapFromString(localDMRValueNode, context,
+                        LocalDMRAttributes.METRIC_TAGS);
 
                 EndpointConfiguration endpoint = new EndpointConfiguration(name, enabled, resourceTypeSets, null, null,
-                        setAvailOnShutdown, tenantId, metricIdTemplate, null);
+                        setAvailOnShutdown, tenantId, metricIdTemplate, metricTags, null);
                 dmrConfigBuilder.endpoint(endpoint);
             }
 
@@ -1236,6 +1241,8 @@ public class MonitorServiceConfigurationBuilder {
                     String tenantId = getString(remoteJMXValueNode, context, RemoteJMXAttributes.TENANT_ID);
                     String metricIdTemplate = getString(remoteJMXValueNode, context,
                             RemoteDMRAttributes.METRIC_ID_TEMPLATE);
+                    Map<String, String> metricTags = getMapFromString(remoteJMXValueNode, context,
+                            RemoteDMRAttributes.METRIC_TAGS);
 
                     // make sure the URL is at least syntactically valid
                     URI url;
@@ -1251,7 +1258,8 @@ public class MonitorServiceConfigurationBuilder {
 
                     ConnectionData connectionData = new ConnectionData(url, username, password);
                     EndpointConfiguration endpoint = new EndpointConfiguration(name, enabled, resourceTypeSets,
-                            connectionData, securityRealm, setAvailOnShutdown, tenantId, metricIdTemplate, null);
+                            connectionData, securityRealm, setAvailOnShutdown, tenantId, metricIdTemplate, metricTags,
+                            null);
 
                     jmxConfigBuilder.endpoint(endpoint);
                 }
@@ -1281,6 +1289,8 @@ public class MonitorServiceConfigurationBuilder {
                     String tenandId = getString(remotePromValueNode, context, RemotePrometheusAttributes.TENANT_ID);
                     String metricIdTemplate = getString(remotePromValueNode, context,
                             RemotePrometheusAttributes.METRIC_ID_TEMPLATE);
+                    Map<String, String> metricTags = getMapFromString(remotePromValueNode, context,
+                            RemotePrometheusAttributes.METRIC_TAGS);
 
                     // make sure the URL is at least syntactically valid
                     URI url;
@@ -1297,7 +1307,7 @@ public class MonitorServiceConfigurationBuilder {
                     ConnectionData connectionData = new ConnectionData(url, username, password);
                     DynamicEndpointConfiguration endpoint = new DynamicEndpointConfiguration(name, enabled,
                             metricSets, connectionData, securityRealm, interval, timeUnits, tenandId, metricIdTemplate,
-                            null);
+                            metricTags, null);
 
                     prometheusConfigBuilder.endpoint(endpoint);
                 }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteDMRAttributes.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteDMRAttributes.java
@@ -106,6 +106,13 @@ public interface RemoteDMRAttributes {
                     .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
                     .build();
 
+    SimpleAttributeDefinition METRIC_TAGS = new SimpleAttributeDefinitionBuilder("metric-tags",
+            ModelType.STRING)
+                    .setAllowNull(true)
+                    .setAllowExpression(true)
+                    .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+                    .build();
+
     AttributeDefinition[] ATTRIBUTES = {
             ENABLED,
             HOST,
@@ -117,6 +124,7 @@ public interface RemoteDMRAttributes {
             SET_AVAIL_ON_SHUTDOWN,
             RESOURCE_TYPE_SETS,
             TENANT_ID,
-            METRIC_ID_TEMPLATE
+            METRIC_ID_TEMPLATE,
+            METRIC_TAGS
     };
 }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteDMRAttributes.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteDMRAttributes.java
@@ -99,6 +99,13 @@ public interface RemoteDMRAttributes {
                     .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
                     .build();
 
+    SimpleAttributeDefinition METRIC_ID_TEMPLATE = new SimpleAttributeDefinitionBuilder("metric-id-template",
+            ModelType.STRING)
+                    .setAllowNull(true)
+                    .setAllowExpression(true)
+                    .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+                    .build();
+
     AttributeDefinition[] ATTRIBUTES = {
             ENABLED,
             HOST,
@@ -109,6 +116,7 @@ public interface RemoteDMRAttributes {
             SECURITY_REALM,
             SET_AVAIL_ON_SHUTDOWN,
             RESOURCE_TYPE_SETS,
-            TENANT_ID
+            TENANT_ID,
+            METRIC_ID_TEMPLATE
     };
 }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteJMXAttributes.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteJMXAttributes.java
@@ -92,6 +92,13 @@ public interface RemoteJMXAttributes {
                     .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
                     .build();
 
+    SimpleAttributeDefinition METRIC_TAGS = new SimpleAttributeDefinitionBuilder("metric-tags",
+            ModelType.STRING)
+                    .setAllowNull(true)
+                    .setAllowExpression(true)
+                    .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+                    .build();
+
     AttributeDefinition[] ATTRIBUTES = {
             ENABLED,
             URL,
@@ -101,6 +108,7 @@ public interface RemoteJMXAttributes {
             SET_AVAIL_ON_SHUTDOWN,
             RESOURCE_TYPE_SETS,
             TENANT_ID,
-            METRIC_ID_TEMPLATE
+            METRIC_ID_TEMPLATE,
+            METRIC_TAGS
     };
 }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteJMXAttributes.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteJMXAttributes.java
@@ -85,6 +85,13 @@ public interface RemoteJMXAttributes {
                     .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
                     .build();
 
+    SimpleAttributeDefinition METRIC_ID_TEMPLATE = new SimpleAttributeDefinitionBuilder("metric-id-template",
+            ModelType.STRING)
+                    .setAllowNull(true)
+                    .setAllowExpression(true)
+                    .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+                    .build();
+
     AttributeDefinition[] ATTRIBUTES = {
             ENABLED,
             URL,
@@ -93,6 +100,7 @@ public interface RemoteJMXAttributes {
             SECURITY_REALM,
             SET_AVAIL_ON_SHUTDOWN,
             RESOURCE_TYPE_SETS,
-            TENANT_ID
+            TENANT_ID,
+            METRIC_ID_TEMPLATE
     };
 }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemotePrometheusAttributes.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemotePrometheusAttributes.java
@@ -96,6 +96,13 @@ public interface RemotePrometheusAttributes {
                     .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
                     .build();
 
+    SimpleAttributeDefinition METRIC_ID_TEMPLATE = new SimpleAttributeDefinitionBuilder("metric-id-template",
+            ModelType.STRING)
+                    .setAllowNull(true)
+                    .setAllowExpression(true)
+                    .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+                    .build();
+
     AttributeDefinition[] ATTRIBUTES = {
             ENABLED,
             URL,
@@ -105,6 +112,7 @@ public interface RemotePrometheusAttributes {
             METRIC_SETS,
             INTERVAL,
             TIME_UNITS,
-            TENANT_ID
+            TENANT_ID,
+            METRIC_ID_TEMPLATE
     };
 }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemotePrometheusAttributes.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemotePrometheusAttributes.java
@@ -103,6 +103,13 @@ public interface RemotePrometheusAttributes {
                     .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
                     .build();
 
+    SimpleAttributeDefinition METRIC_TAGS = new SimpleAttributeDefinitionBuilder("metric-tags",
+            ModelType.STRING)
+                    .setAllowNull(true)
+                    .setAllowExpression(true)
+                    .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+                    .build();
+
     AttributeDefinition[] ATTRIBUTES = {
             ENABLED,
             URL,
@@ -113,6 +120,7 @@ public interface RemotePrometheusAttributes {
             INTERVAL,
             TIME_UNITS,
             TENANT_ID,
-            METRIC_ID_TEMPLATE
+            METRIC_ID_TEMPLATE,
+            METRIC_TAGS
     };
 }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/inventory/Instance.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/inventory/Instance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,17 +18,33 @@ package org.hawkular.agent.monitor.inventory;
 
 /**
  * An abstract supertype for {@link MeasurementInstance} and {@link ResourceConfigurationPropertyInstance}.
+ * Instances can be associated with a specific resource - see {@link #setResource(Resource)}. Once assigned
+ * a resource, an instance is owned by that resource for the instance's lifetime. You can use
+ * the copy constructor to create a copy of an instance and reassign that new instance to a new resource.
  *
  * @author <a href="https://github.com/ppalaga">Peter Palaga</a>
  */
-public abstract class Instance<L, T extends AttributeLocationProvider<L>> //
-        extends AttributeLocationProvider<L> {
+public abstract class Instance<L, T extends AttributeLocationProvider<L>> extends AttributeLocationProvider<L> {
 
     private final T type;
+    private Resource<L> resource;
 
-    public Instance(ID id, Name name, AttributeLocation<L> attributeLocation, T type) {
+    protected Instance(ID id, Name name, AttributeLocation<L> attributeLocation, T type) {
         super(id, name, attributeLocation);
         this.type = type;
+    }
+
+    /**
+     * Copy constructor with the added feature of allowing the new copy to be "disowned" from any
+     * resource that the original instance was owned by. This allows one to create a copy of an instance
+     * and reassign it to a different owner resource.
+     * @param original the object to copy
+     * @param disown if true, the new copy will not have an owning {@link #getResource() resource}.
+     *               if false, the new instance will be owned by the same resource that owns the original.
+     */
+    protected Instance(Instance<L, T> original, boolean disown) {
+        this(original.getID(), original.getName(), original.getAttributeLocation(), original.type);
+        this.resource = (disown) ? null : original.resource;
     }
 
     /**
@@ -36,6 +52,27 @@ public abstract class Instance<L, T extends AttributeLocationProvider<L>> //
      */
     public T getType() {
         return type;
+    }
+
+    /**
+     * @param resource assigns this instance to the given resource which means
+     *                 the resource is now to be considered the "owner" of this instance.
+     */
+    public void setResource(Resource<L> resource) {
+        if (this.resource != null) {
+            throw new IllegalStateException(
+                    String.format("Instance [%s] is already assigned to [%s]. Cannot reassign to [%s]",
+                            this, this.resource, resource));
+        }
+        this.resource = resource;
+    }
+
+    /**
+     * @return the resource that owns this instance, if one has been assigned
+     * @see Instance#assignToResource(Resource)
+     */
+    public Resource<L> getResource() {
+        return resource;
     }
 
 }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/inventory/InventoryIdUtil.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/inventory/InventoryIdUtil.java
@@ -86,7 +86,7 @@ public class InventoryIdUtil {
      * @return the ID
      */
     public static ID generateMetricInstanceId(String feedId, ID resourceId, MetricType<?> metricType) {
-        ID id = new ID(String.format("MI~R~[%s/%s]~MT~%s", feedId, resourceId, metricType.getName()));
+        ID id = new ID(String.format("MI~R~[%s/%s]~MT~%s", feedId, resourceId, metricType.getID()));
         return id;
     }
 
@@ -99,7 +99,7 @@ public class InventoryIdUtil {
      * @return the ID
      */
     public static ID generateAvailInstanceId(String feedId, ID resourceId, AvailType<?> availType) {
-        ID id = new ID(String.format("AI~R~[%s/%s]~AT~%s", feedId, resourceId, availType.getName()));
+        ID id = new ID(String.format("AI~R~[%s/%s]~AT~%s", feedId, resourceId, availType.getID()));
         return id;
     }
 }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/inventory/MeasurementInstance.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/inventory/MeasurementInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,11 +24,25 @@ package org.hawkular.agent.monitor.inventory;
  * @param <L> the type of the protocol specific location typically a subclass of {@link NodeLocation}
  * @param <T> the measurement type
  */
-public final class MeasurementInstance<L, T extends MeasurementType<L>> //
-        extends Instance<L, T> {
+public final class MeasurementInstance<L, T extends MeasurementType<L>> extends Instance<L, T> {
+
+    /**
+     * If this property exists in {@link #getProperties()} then this is the metric ID that represents
+     * the data for this measurement instance as it is found in Hawkular Metrics storage. If this
+     * property doesn't exist, you can assume the metric ID is the same as the ID of this measurement instance.
+     */
+    public static final String METRIC_ID_PROPERTY = "metric-id";
 
     public MeasurementInstance(ID id, Name name, AttributeLocation<L> attributeLocation, T type) {
         super(id, name, attributeLocation, type);
     }
 
+    // copy-constructor
+    public MeasurementInstance(MeasurementInstance<L, T> copy, boolean disown) {
+        super(copy, disown);
+
+        if (copy.getProperties().containsKey(METRIC_ID_PROPERTY)) {
+            this.addProperty(METRIC_ID_PROPERTY, copy.getProperties().get(METRIC_ID_PROPERTY));
+        }
+    }
 }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/inventory/MeasurementInstance.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/inventory/MeasurementInstance.java
@@ -17,7 +17,7 @@
 package org.hawkular.agent.monitor.inventory;
 
 /**
- * A measurement instance.
+ * A measurement instance that can be used to represent either numeric metric data or availability data.
  *
  * @author <a href="https://github.com/ppalaga">Peter Palaga</a>
  *
@@ -31,7 +31,7 @@ public final class MeasurementInstance<L, T extends MeasurementType<L>> extends 
      * the data for this measurement instance as it is found in Hawkular Metrics storage. If this
      * property doesn't exist, you can assume the metric ID is the same as the ID of this measurement instance.
      */
-    public static final String METRIC_ID_PROPERTY = "metric-id";
+    private static final String METRIC_ID_PROPERTY = "metric-id";
 
     public MeasurementInstance(ID id, Name name, AttributeLocation<L> attributeLocation, T type) {
         super(id, name, attributeLocation, type);
@@ -43,6 +43,48 @@ public final class MeasurementInstance<L, T extends MeasurementType<L>> extends 
 
         if (copy.getProperties().containsKey(METRIC_ID_PROPERTY)) {
             this.addProperty(METRIC_ID_PROPERTY, copy.getProperties().get(METRIC_ID_PROPERTY));
+        }
+    }
+
+    /**
+     * This returns this instance's associated metric ID. A metric ID is that ID which is used
+     * to store the metric data associated with this measurement instance into Hawkular Metrics.
+     *
+     * There is an explicit rule that all clients must follow - if a measurement instance has a
+     * property called {@value #METRIC_ID_PROPERTY} then that ID must be used when storing
+     * and retrieving metric data associated with this measurement instance. If there is no such
+     * property, then the implicit rule takes effect, and that is the metric ID to be used will
+     * be the same as the {@link #getID() id} of this measurement instance.
+     *
+     * This method follows those rules - if there is such a property, its value is returned;
+     * otherwise this instance's ID string is returned.
+     *
+     * @return the metric ID that should be used to read/write metric data from/to Hawkular Metrics
+     */
+    public String getAssociatedMetricId() {
+        Object property = getProperties().get(METRIC_ID_PROPERTY);
+        if (property != null) {
+            return property.toString();
+        } else {
+            return getID().getIDString();
+        }
+    }
+
+    /**
+     * This tells this instance what its metric ID should be. A metric ID is that ID which is used
+     * to store the metric data associated with this measurement instance into Hawkular Metrics.
+     * See {@link #getAssociatedMetricId()} for more details.
+     *
+     * @param metricId the metric ID to be associated with this measurement instance. If this is
+     *                 null or empty, the metric ID will be assumed to be the same as this instance's ID.
+     */
+    public void setAssociatedMetricId(String metricId) {
+        // Note that if the metric ID is the same as this instance's ID, then the implicit rule is in force,
+        // so there is no need to actually add the metric ID property.
+        if (metricId == null || metricId.isEmpty() || metricId.equals(getID().getIDString())) {
+            removeProperty(METRIC_ID_PROPERTY);
+        } else {
+            addProperty(METRIC_ID_PROPERTY, metricId);
         }
     }
 }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/inventory/ResourceConfigurationPropertyInstance.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/inventory/ResourceConfigurationPropertyInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,8 +21,7 @@ package org.hawkular.agent.monitor.inventory;
  *
  * @param <L> the type of the protocol specific location, typically a subclass of {@link NodeLocation}
  */
-public final class ResourceConfigurationPropertyInstance<L>
-        extends Instance<L, ResourceConfigurationPropertyType<L>> {
+public final class ResourceConfigurationPropertyInstance<L> extends Instance<L, ResourceConfigurationPropertyType<L>> {
 
     private final String value;
 
@@ -30,6 +29,12 @@ public final class ResourceConfigurationPropertyInstance<L>
             ResourceConfigurationPropertyType<L> type, String value) {
         super(id, name, attributeLocation, type);
         this.value = value;
+    }
+
+    // copy-constructor
+    public ResourceConfigurationPropertyInstance(ResourceConfigurationPropertyInstance<L> original, boolean disown) {
+        super(original, disown);
+        this.value = original.value;
     }
 
     public String getValue() {

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/log/MsgLogger.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/log/MsgLogger.java
@@ -349,4 +349,7 @@ public interface MsgLogger extends BasicLogger {
     @Message(id = 10076, value = "Cannot register feed under tenant ID [%s] for new managed server [%s]: %s")
     void warnCannotRegisterFeedForNewManagedServer(String tenantId, String managedServerName, String error);
 
+    @LogMessage(level = Level.ERROR)
+    @Message(id = 10077, value = "Failed to store metric tags: %s")
+    void errorFailedToStoreMetricTags(@Cause Throwable t, String data);
 }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/protocol/Discovery.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/protocol/Discovery.java
@@ -98,15 +98,12 @@ public final class Discovery<L> {
                 // build the resource now - we might need it to generate metric IDs
                 Resource<L> resource = builder.build();
 
-                // now that the resource is built (and measurement instances assigned to it) we can generate metric IDs
+                // The resource is built (and measurement instances assigned to it) so we can generate metric IDs.
                 for (MeasurementInstance<L, MetricType<L>> instance : resource.getMetrics()) {
-                    instance.addProperty(MeasurementInstance.METRIC_ID_PROPERTY,
-                            samplingService.generateMetricId(instance));
+                    instance.setAssociatedMetricId(samplingService.generateAssociatedMetricId(instance));
                 }
-
                 for (MeasurementInstance<L, AvailType<L>> instance : resource.getAvails()) {
-                    instance.addProperty(MeasurementInstance.METRIC_ID_PROPERTY,
-                            samplingService.generateMetricId(instance));
+                    instance.setAssociatedMetricId(samplingService.generateAssociatedMetricId(instance));
                 }
 
                 log.debugf("Discovered resource [%s]", resource);

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/protocol/Discovery.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/protocol/Discovery.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import org.hawkular.agent.monitor.api.SamplingService;
 import org.hawkular.agent.monitor.inventory.AttributeLocation;
 import org.hawkular.agent.monitor.inventory.AvailType;
 import org.hawkular.agent.monitor.inventory.ID;
@@ -56,12 +57,14 @@ public final class Discovery<L> {
      * @param parent look under this resource to find its children (if null, this looks for root resources)
      * @param childType only find children of this type
      * @param session session used to query the managed endpoint
+     * @param samplingService the service that collects measurements - this is used here just to generate metric IDs
      * @param resourceConsumer if not null, will be a listener that gets notified when resources are discovered
      */
     public <N> void discoverChildren(
             Resource<L> parent,
             ResourceType<L> childType,
             Session<L> session,
+            SamplingService<L> samplingService,
             Consumer<Resource<L>> resourceConsumer) {
 
         try {
@@ -92,8 +95,23 @@ public final class Discovery<L> {
                 // populate the metrics/avails based on the resource's type
                 addMetricAndAvailInstances(id, childType, location, entry.getValue(), builder, session);
 
+                // build the resource now - we might need it to generate metric IDs
                 Resource<L> resource = builder.build();
+
+                // now that the resource is built (and measurement instances assigned to it) we can generate metric IDs
+                for (MeasurementInstance<L, MetricType<L>> instance : resource.getMetrics()) {
+                    instance.addProperty(MeasurementInstance.METRIC_ID_PROPERTY,
+                            samplingService.generateMetricId(instance));
+                }
+
+                for (MeasurementInstance<L, AvailType<L>> instance : resource.getAvails()) {
+                    instance.addProperty(MeasurementInstance.METRIC_ID_PROPERTY,
+                            samplingService.generateMetricId(instance));
+                }
+
                 log.debugf("Discovered resource [%s]", resource);
+
+                // tell our consumer about our new resource
                 if (resourceConsumer != null) {
                     resourceConsumer.accept(resource);
                 }
@@ -102,7 +120,7 @@ public final class Discovery<L> {
                 Set<ResourceType<L>> childTypes = session.getResourceTypeManager()
                         .getChildren(childType);
                 for (ResourceType<L> nextLevelChildType : childTypes) {
-                    discoverChildren(resource, nextLevelChildType, session, resourceConsumer);
+                    discoverChildren(resource, nextLevelChildType, session, samplingService, resourceConsumer);
                 }
 
             }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/protocol/EndpointService.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/protocol/EndpointService.java
@@ -322,7 +322,7 @@ public abstract class EndpointService<L, S extends Session<L>> implements Sampli
                     avail = Avail.DOWN;
                 }
                 long ts = System.currentTimeMillis();
-                String key = getMetricId(instance);
+                String key = instance.getAssociatedMetricId();
                 AvailDataPoint dataPoint = new AvailDataPoint(key, ts, avail,
                         getMonitoredEndpoint().getEndpointConfiguration().getTenantId());
                 consumer.accept(dataPoint);
@@ -365,7 +365,7 @@ public abstract class EndpointService<L, S extends Session<L>> implements Sampli
                     value = toDouble(o);
                 }
                 long ts = System.currentTimeMillis();
-                String key = getMetricId(instance);
+                String key = instance.getAssociatedMetricId();
                 MetricDataPoint dataPoint = new MetricDataPoint(key, ts, value, instance.getType().getMetricType(),
                         getMonitoredEndpoint().getEndpointConfiguration().getTenantId());
                 consumer.accept(dataPoint);
@@ -377,7 +377,7 @@ public abstract class EndpointService<L, S extends Session<L>> implements Sampli
     }
 
     @Override
-    public String generateMetricId(MeasurementInstance<L, ?> instance) {
+    public String generateAssociatedMetricId(MeasurementInstance<L, ?> instance) {
         String generatedKey;
         EndpointConfiguration config = getMonitoredEndpoint().getEndpointConfiguration();
         String metricIdTemplate = config.getMetricIdTemplate();
@@ -460,14 +460,6 @@ public abstract class EndpointService<L, S extends Session<L>> implements Sampli
             return false;
         }
         return true;
-    }
-
-    private String getMetricId(MeasurementInstance<L, ?> instance) {
-        if (instance.getProperties().containsKey(MeasurementInstance.METRIC_ID_PROPERTY)) {
-            return instance.getProperties().get(MeasurementInstance.METRIC_ID_PROPERTY).toString();
-        } else {
-            return instance.getID().getIDString();
-        }
     }
 
     private double toDouble(Object valueObject) {

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/service/MonitorService.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/service/MonitorService.java
@@ -771,7 +771,7 @@ public class MonitorService implements Service<MonitorService> {
                     List<MeasurementInstance<?, AvailType<?>>> avails = availsToChange.get(endpointService);
                     for (MeasurementInstance avail : avails) {
                         AvailDataPoint availDataPoint = new AvailDataPoint(
-                                endpointService.generateMeasurementKey(avail),
+                                endpointService.generateMetricId(avail),
                                 now,
                                 setAvailOnShutdown,
                                 config.getTenantId());

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/service/MonitorService.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/service/MonitorService.java
@@ -771,7 +771,7 @@ public class MonitorService implements Service<MonitorService> {
                     List<MeasurementInstance<?, AvailType<?>>> avails = availsToChange.get(endpointService);
                     for (MeasurementInstance avail : avails) {
                         AvailDataPoint availDataPoint = new AvailDataPoint(
-                                endpointService.generateMetricId(avail),
+                                avail.getAssociatedMetricId(),
                                 now,
                                 setAvailOnShutdown,
                                 config.getTenantId());

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/storage/MetricStorageProxy.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/storage/MetricStorageProxy.java
@@ -18,6 +18,7 @@ package org.hawkular.agent.monitor.storage;
 
 import org.hawkular.agent.monitor.api.MetricDataPayloadBuilder;
 import org.hawkular.agent.monitor.api.MetricStorage;
+import org.hawkular.agent.monitor.api.MetricTagPayloadBuilder;
 import org.hawkular.agent.monitor.extension.MonitorServiceConfiguration.StorageAdapterConfiguration;
 
 /**
@@ -44,6 +45,22 @@ public class MetricStorageProxy implements MetricStorage {
 
     @Override
     public void store(MetricDataPayloadBuilder payloadBuilder, long waitMillis) {
+        if (storageAdapter == null) {
+            throw new IllegalStateException("Storage infrastructure is not ready yet");
+        }
+        storageAdapter.store(payloadBuilder, waitMillis);
+    }
+
+    @Override
+    public MetricTagPayloadBuilder createMetricTagPayloadBuilder() {
+        if (storageAdapter == null) {
+            throw new IllegalStateException("Storage infrastructure is not ready yet");
+        }
+        return storageAdapter.createMetricTagPayloadBuilder();
+    }
+
+    @Override
+    public void store(MetricTagPayloadBuilder payloadBuilder, long waitMillis) {
         if (storageAdapter == null) {
             throw new IllegalStateException("Storage infrastructure is not ready yet");
         }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/storage/MetricTagPayloadBuilderImpl.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/storage/MetricTagPayloadBuilderImpl.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.agent.monitor.storage;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.hawkular.agent.monitor.api.MetricTagPayloadBuilder;
+import org.hawkular.agent.monitor.util.Util;
+import org.hawkular.metrics.client.common.MetricType;
+
+/**
+ * Allows one to build up payload requests to send to metric storage to add tags.
+ * After all tags are added to this builder, you can get the payloads in
+ * JSON format via {@link #toPayload()}.
+ */
+public class MetricTagPayloadBuilderImpl implements MetricTagPayloadBuilder {
+
+    // key is metric ID, value is map of name/value pairs (the actual tags)
+    private Map<String, Map<String, String>> allGauges = new HashMap<>();
+    private Map<String, Map<String, String>> allCounters = new HashMap<>();
+
+    // a running count of the number of tags that have been added
+    private int count = 0;
+
+    // if not null, this is the tenant ID to associate all the metrics with (null means used the agent tenant ID)
+    private String tenantId = null;
+
+    @Override
+    public void addTag(String key, String name, String value, MetricType metricType) {
+        Map<String, Map<String, String>> map;
+
+        switch (metricType) {
+            case GAUGE: {
+                map = allGauges;
+                break;
+            }
+            case COUNTER: {
+                map = allCounters;
+                break;
+            }
+            // case AVAILABILITY: {
+            //     map = allAvails;
+            //     break;
+            // }
+            default: {
+                throw new IllegalArgumentException("Unsupported metric type: " + metricType);
+            }
+        }
+
+        Map<String, String> allTagsForMetric = map.get(key);
+        if (allTagsForMetric == null) {
+            // we haven't seen this metric ID before, create a new map of tags
+            allTagsForMetric = new TreeMap<String, String>(); // use tree map to sort the tags
+            map.put(key, allTagsForMetric);
+        }
+        allTagsForMetric.put(name, value);
+        count++;
+    }
+
+    @Override
+    public Map<String, String> toPayload() {
+        Map<String, Map<String, String>> withMapObject = new HashMap<>();
+
+        for (Map.Entry<String, Map<String, String>> gaugeEntry : allGauges.entrySet()) {
+            withMapObject.put("gauges/" + Util.urlEncode(gaugeEntry.getKey()), gaugeEntry.getValue());
+        }
+        for (Map.Entry<String, Map<String, String>> counterEntry : allCounters.entrySet()) {
+            withMapObject.put("counters/" + Util.urlEncode(counterEntry.getKey()), counterEntry.getValue());
+        }
+
+        // now convert all the maps of tags to json
+        Map<String, String> withJson = new HashMap<>(withMapObject.size());
+        for (Map.Entry<String, Map<String, String>> entry : withMapObject.entrySet()) {
+            withJson.put(entry.getKey(), Util.toJson(entry.getValue()));
+        }
+
+        return withJson;
+    }
+
+    @Override
+    public int getNumberTags() {
+        return count;
+    }
+
+    @Override
+    public void setTenantId(String tenantId) {
+        this.tenantId = tenantId;
+    }
+
+    @Override
+    public String getTenantId() {
+        return this.tenantId;
+    }
+}

--- a/hawkular-wildfly-agent/src/main/resources/org/hawkular/agent/monitor/extension/LocalDescriptions.properties
+++ b/hawkular-wildfly-agent/src/main/resources/org/hawkular/agent/monitor/extension/LocalDescriptions.properties
@@ -124,6 +124,8 @@ hawkular-wildfly-agent.managed-servers.remote-dmr.security-realm=If SSL is to be
 hawkular-wildfly-agent.managed-servers.remote-dmr.set-avail-on-shutdown=If set then when the agent shuts down all availability metrics on all resources for this managed server will be set to this value (typically you will set this to DOWN or UNKNOWN, default is unset).
 hawkular-wildfly-agent.managed-servers.remote-dmr.resource-type-sets=Comma-separated names of the resource type sets which indicate what resources to manage in this managed server
 hawkular-wildfly-agent.managed-servers.remote-dmr.tenant-id=If specified, metrics from this endpoint will be associated with the given tenant ID rather than the agent's tenant ID.
+hawkular-wildfly-agent.managed-servers.remote-dmr.metric-id-template=If specified, all metric IDs for this managed server will be constructed from the given template which can use tokens such as %FeedId, %ManagedServerName, and others. If not specified, a default ID will be generated.
+
 hawkular-wildfly-agent.managed-servers.local-dmr=The local WildFly application server
 hawkular-wildfly-agent.managed-servers.local-dmr.add=unused
 hawkular-wildfly-agent.managed-servers.local-dmr.remove=do no use
@@ -132,6 +134,7 @@ hawkular-wildfly-agent.managed-servers.local-dmr.enabled=True if you want to mon
 hawkular-wildfly-agent.managed-servers.local-dmr.set-avail-on-shutdown=If set then when the agent shuts down all availability metrics on all resources for this managed server will be set to this value (typically you will set this to DOWN or UNKNOWN, default is DOWN).
 hawkular-wildfly-agent.managed-servers.local-dmr.resource-type-sets=Comma-separated names of the resource type sets which indicate what resources to manage in this managed server
 hawkular-wildfly-agent.managed-servers.local-dmr.tenant-id=If specified, metrics from this endpoint will be associated with the given tenant ID rather than the agent's tenant ID.
+hawkular-wildfly-agent.managed-servers.local-dmr.metric-id-template=If specified, all metric IDs for this managed server will be constructed from the given template which can use tokens such as %FeedId, %ManagedServerName, and others. If not specified, a default ID will be generated.
 
 # MANAGED SERVERS - JMX
 
@@ -147,6 +150,7 @@ hawkular-wildfly-agent.managed-servers.remote-jmx.security-realm=If SSL is to be
 hawkular-wildfly-agent.managed-servers.remote-jmx.set-avail-on-shutdown=If set then when the agent shuts down all availability metrics on all resources for this managed server will be set to this value (typically you will set this to DOWN or UNKNOWN, default is unset).
 hawkular-wildfly-agent.managed-servers.remote-jmx.resource-type-sets=Comma-separated names of the resource type sets which indicate what resources to manage in this managed server
 hawkular-wildfly-agent.managed-servers.remote-jmx.tenant-id=If specified, metrics from this endpoint will be associated with the given tenant ID rather than the agent's tenant ID.
+hawkular-wildfly-agent.managed-servers.remote-jmx.metric-id-template=If specified, all metric IDs for this managed server will be constructed from the given template which can use tokens such as %FeedId, %ManagedServerName, and others. If not specified, a default ID will be generated.
 
 # MANAGED SERVERS - PROMETHEUS
 
@@ -163,6 +167,7 @@ hawkular-wildfly-agent.managed-servers.remote-prometheus.interval=The amount of 
 hawkular-wildfly-agent.managed-servers.remote-prometheus.time-units=The units of the interval (milliseconds|seconds|minutes)
 hawkular-wildfly-agent.managed-servers.remote-prometheus.metric-sets=Comma-separated names of the metric sets which indicate what metrics will be stored. All others will be ignored. If this is not specified, all metrics will be stored.
 hawkular-wildfly-agent.managed-servers.remote-prometheus.tenant-id=If specified, metrics from this endpoint will be associated with the given tenant ID rather than the agent's tenant ID.
+hawkular-wildfly-agent.managed-servers.remote-prometheus.metric-id-template=If specified, all metric IDs for this managed server will be constructed from the given template which can use tokens such as %FeedId, %ManagedServerName, and others. If not specified, a default ID will be generated.
 
 # RESOURCE TYPES
 

--- a/hawkular-wildfly-agent/src/main/resources/org/hawkular/agent/monitor/extension/LocalDescriptions.properties
+++ b/hawkular-wildfly-agent/src/main/resources/org/hawkular/agent/monitor/extension/LocalDescriptions.properties
@@ -125,6 +125,7 @@ hawkular-wildfly-agent.managed-servers.remote-dmr.set-avail-on-shutdown=If set t
 hawkular-wildfly-agent.managed-servers.remote-dmr.resource-type-sets=Comma-separated names of the resource type sets which indicate what resources to manage in this managed server
 hawkular-wildfly-agent.managed-servers.remote-dmr.tenant-id=If specified, metrics from this endpoint will be associated with the given tenant ID rather than the agent's tenant ID.
 hawkular-wildfly-agent.managed-servers.remote-dmr.metric-id-template=If specified, all metric IDs for this managed server will be constructed from the given template which can use tokens such as %FeedId, %ManagedServerName, and others. If not specified, a default ID will be generated.
+hawkular-wildfly-agent.managed-servers.remote-dmr.metric-tags=Comma separated list of name=value pairs that will be tags created on the metric definition in Hawkular Metrics.
 
 hawkular-wildfly-agent.managed-servers.local-dmr=The local WildFly application server
 hawkular-wildfly-agent.managed-servers.local-dmr.add=unused
@@ -135,6 +136,7 @@ hawkular-wildfly-agent.managed-servers.local-dmr.set-avail-on-shutdown=If set th
 hawkular-wildfly-agent.managed-servers.local-dmr.resource-type-sets=Comma-separated names of the resource type sets which indicate what resources to manage in this managed server
 hawkular-wildfly-agent.managed-servers.local-dmr.tenant-id=If specified, metrics from this endpoint will be associated with the given tenant ID rather than the agent's tenant ID.
 hawkular-wildfly-agent.managed-servers.local-dmr.metric-id-template=If specified, all metric IDs for this managed server will be constructed from the given template which can use tokens such as %FeedId, %ManagedServerName, and others. If not specified, a default ID will be generated.
+hawkular-wildfly-agent.managed-servers.local-dmr.metric-tags=Comma separated list of name=value pairs that will be tags created on the metric definition in Hawkular Metrics.
 
 # MANAGED SERVERS - JMX
 
@@ -151,6 +153,7 @@ hawkular-wildfly-agent.managed-servers.remote-jmx.set-avail-on-shutdown=If set t
 hawkular-wildfly-agent.managed-servers.remote-jmx.resource-type-sets=Comma-separated names of the resource type sets which indicate what resources to manage in this managed server
 hawkular-wildfly-agent.managed-servers.remote-jmx.tenant-id=If specified, metrics from this endpoint will be associated with the given tenant ID rather than the agent's tenant ID.
 hawkular-wildfly-agent.managed-servers.remote-jmx.metric-id-template=If specified, all metric IDs for this managed server will be constructed from the given template which can use tokens such as %FeedId, %ManagedServerName, and others. If not specified, a default ID will be generated.
+hawkular-wildfly-agent.managed-servers.remote-jmx.metric-tags=Comma separated list of name=value pairs that will be tags created on the metric definition in Hawkular Metrics.
 
 # MANAGED SERVERS - PROMETHEUS
 
@@ -168,6 +171,7 @@ hawkular-wildfly-agent.managed-servers.remote-prometheus.time-units=The units of
 hawkular-wildfly-agent.managed-servers.remote-prometheus.metric-sets=Comma-separated names of the metric sets which indicate what metrics will be stored. All others will be ignored. If this is not specified, all metrics will be stored.
 hawkular-wildfly-agent.managed-servers.remote-prometheus.tenant-id=If specified, metrics from this endpoint will be associated with the given tenant ID rather than the agent's tenant ID.
 hawkular-wildfly-agent.managed-servers.remote-prometheus.metric-id-template=If specified, all metric IDs for this managed server will be constructed from the given template which can use tokens such as %FeedId, %ManagedServerName, and others. If not specified, a default ID will be generated.
+hawkular-wildfly-agent.managed-servers.remote-prometheus.metric-tags=Comma separated list of name=value pairs that will be tags created on the metric definition in Hawkular Metrics.
 
 # RESOURCE TYPES
 

--- a/hawkular-wildfly-agent/src/main/resources/schema/hawkular-agent-monitor-subsystem.xsd
+++ b/hawkular-wildfly-agent/src/main/resources/schema/hawkular-agent-monitor-subsystem.xsd
@@ -291,6 +291,7 @@
     <xs:attribute name="set-avail-on-shutdown" type="xs:string"/>
     <xs:attribute name="tenant-id"             type="xs:string"/>
     <xs:attribute name="metric-id-template"    type="xs:string"/>
+    <xs:attribute name="metric-labels"         type="xs:string"/>
   </xs:complexType>
 
   <xs:complexType name="remoteDmrType">
@@ -306,6 +307,7 @@
     <xs:attribute name="resource-type-sets"    type="xs:string"/>
     <xs:attribute name="tenant-id"             type="xs:string"/>
     <xs:attribute name="metric-id-template"    type="xs:string"/>
+    <xs:attribute name="metric-labels"         type="xs:string"/>
   </xs:complexType>
 
   <xs:complexType name="remoteJmxType">
@@ -319,6 +321,7 @@
     <xs:attribute name="resource-type-sets"    type="xs:string"/>
     <xs:attribute name="tenant-id"             type="xs:string"/>
     <xs:attribute name="metric-id-template"    type="xs:string"/>
+    <xs:attribute name="metric-labels"         type="xs:string"/>
   </xs:complexType>
 
   <xs:complexType name="remotePrometheusType">
@@ -333,6 +336,7 @@
     <xs:attribute name="time-units"            type="timeUnitsType"/>
     <xs:attribute name="tenant-id"             type="xs:string"/>
     <xs:attribute name="metric-id-template"    type="xs:string"/>
+    <xs:attribute name="metric-labels"         type="xs:string"/>
   </xs:complexType>
 
   <!-- [agent] platform configuration -->

--- a/hawkular-wildfly-agent/src/main/resources/schema/hawkular-agent-monitor-subsystem.xsd
+++ b/hawkular-wildfly-agent/src/main/resources/schema/hawkular-agent-monitor-subsystem.xsd
@@ -290,20 +290,22 @@
     <xs:attribute name="resource-type-sets"    type="xs:string"/>
     <xs:attribute name="set-avail-on-shutdown" type="xs:string"/>
     <xs:attribute name="tenant-id"             type="xs:string"/>
+    <xs:attribute name="metric-id-template"    type="xs:string"/>
   </xs:complexType>
 
   <xs:complexType name="remoteDmrType">
-    <xs:attribute name="name"                   type="xs:string" use="required"/>
-    <xs:attribute name="enabled"                type="xs:boolean"/>
-    <xs:attribute name="host"                   type="xs:string" use="required"/>
-    <xs:attribute name="port"                   type="xs:int"    use="required"/>
-    <xs:attribute name="username"               type="xs:string"/>
-    <xs:attribute name="password"               type="xs:string"/>
-    <xs:attribute name="use-ssl"                type="xs:boolean"/>
-    <xs:attribute name="security-realm"         type="xs:string"/>
-    <xs:attribute name="set-avail-on-shutdown"  type="xs:string"/>
-    <xs:attribute name="resource-type-sets"     type="xs:string"/>
-    <xs:attribute name="tenant-id"              type="xs:string"/>
+    <xs:attribute name="name"                  type="xs:string" use="required"/>
+    <xs:attribute name="enabled"               type="xs:boolean"/>
+    <xs:attribute name="host"                  type="xs:string" use="required"/>
+    <xs:attribute name="port"                  type="xs:int"    use="required"/>
+    <xs:attribute name="username"              type="xs:string"/>
+    <xs:attribute name="password"              type="xs:string"/>
+    <xs:attribute name="use-ssl"               type="xs:boolean"/>
+    <xs:attribute name="security-realm"        type="xs:string"/>
+    <xs:attribute name="set-avail-on-shutdown" type="xs:string"/>
+    <xs:attribute name="resource-type-sets"    type="xs:string"/>
+    <xs:attribute name="tenant-id"             type="xs:string"/>
+    <xs:attribute name="metric-id-template"    type="xs:string"/>
   </xs:complexType>
 
   <xs:complexType name="remoteJmxType">
@@ -316,19 +318,21 @@
     <xs:attribute name="set-avail-on-shutdown" type="xs:string"/>
     <xs:attribute name="resource-type-sets"    type="xs:string"/>
     <xs:attribute name="tenant-id"             type="xs:string"/>
+    <xs:attribute name="metric-id-template"    type="xs:string"/>
   </xs:complexType>
 
   <xs:complexType name="remotePrometheusType">
-    <xs:attribute name="name"           type="xs:string" use="required"/>
-    <xs:attribute name="enabled"        type="xs:boolean"/>
-    <xs:attribute name="url"            type="xs:string" use="required"/>
-    <xs:attribute name="username"       type="xs:string"/>
-    <xs:attribute name="password"       type="xs:string"/>
-    <xs:attribute name="security-realm" type="xs:string"/>
-    <xs:attribute name="labels"         type="xs:string"/>
-    <xs:attribute name="interval"       type="xs:int"/>
-    <xs:attribute name="time-units"     type="timeUnitsType"/>
-    <xs:attribute name="tenant-id"      type="xs:string"/>
+    <xs:attribute name="name"                  type="xs:string" use="required"/>
+    <xs:attribute name="enabled"               type="xs:boolean"/>
+    <xs:attribute name="url"                   type="xs:string" use="required"/>
+    <xs:attribute name="username"              type="xs:string"/>
+    <xs:attribute name="password"              type="xs:string"/>
+    <xs:attribute name="security-realm"        type="xs:string"/>
+    <xs:attribute name="labels"                type="xs:string"/>
+    <xs:attribute name="interval"              type="xs:int"/>
+    <xs:attribute name="time-units"            type="timeUnitsType"/>
+    <xs:attribute name="tenant-id"             type="xs:string"/>
+    <xs:attribute name="metric-id-template"    type="xs:string"/>
   </xs:complexType>
 
   <!-- [agent] platform configuration -->

--- a/hawkular-wildfly-agent/src/test/java/org/hawkular/agent/monitor/inventory/InventoryIdUtilTest.java
+++ b/hawkular-wildfly-agent/src/test/java/org/hawkular/agent/monitor/inventory/InventoryIdUtilTest.java
@@ -31,7 +31,7 @@ public class InventoryIdUtilTest {
         ResourceIdParts parts;
 
         EndpointConfiguration endpointConfig = new EndpointConfiguration("testmanagedserver", true,
-                Collections.emptyList(), null, null, null, null, null);
+                Collections.emptyList(), null, null, null, null, null, null);
         MonitoredEndpoint<EndpointConfiguration> me = MonitoredEndpoint.<EndpointConfiguration> of(endpointConfig,
                 null);
 

--- a/hawkular-wildfly-agent/src/test/java/org/hawkular/agent/monitor/inventory/InventoryIdUtilTest.java
+++ b/hawkular-wildfly-agent/src/test/java/org/hawkular/agent/monitor/inventory/InventoryIdUtilTest.java
@@ -31,7 +31,7 @@ public class InventoryIdUtilTest {
         ResourceIdParts parts;
 
         EndpointConfiguration endpointConfig = new EndpointConfiguration("testmanagedserver", true,
-                Collections.emptyList(), null, null, null, null, null, null);
+                Collections.emptyList(), null, null, null, null, null, null, null);
         MonitoredEndpoint<EndpointConfiguration> me = MonitoredEndpoint.<EndpointConfiguration> of(endpointConfig,
                 null);
 

--- a/hawkular-wildfly-agent/src/test/java/org/hawkular/agent/monitor/storage/MetricTagPayloadBuilderTest.java
+++ b/hawkular-wildfly-agent/src/test/java/org/hawkular/agent/monitor/storage/MetricTagPayloadBuilderTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.agent.monitor.storage;
+
+import java.util.Map;
+
+import org.hawkular.metrics.client.common.MetricType;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MetricTagPayloadBuilderTest {
+
+    @Test
+    public void testEmpty() {
+        MetricTagPayloadBuilderImpl builder = new MetricTagPayloadBuilderImpl();
+        Assert.assertEquals(0, builder.toPayload().size());
+    }
+
+    @Test
+    public void testWithOneMetricId() {
+        String json;
+
+        MetricTagPayloadBuilderImpl builder = new MetricTagPayloadBuilderImpl();
+
+        builder.addTag("metric1", "tagname1", "tagvalue1", MetricType.GAUGE);
+        json = builder.toPayload().get("gauges/metric1");
+        Assert.assertEquals("{\"tagname1\":\"tagvalue1\"}", json);
+
+        builder.addTag("metric1", "tagname2", "tagvalue2", MetricType.GAUGE);
+        json = builder.toPayload().get("gauges/metric1");
+        Assert.assertEquals("{\"tagname1\":\"tagvalue1\",\"tagname2\":\"tagvalue2\"}", json);
+    }
+
+    @Test
+    public void testWithMultipleMetricIds() {
+        MetricTagPayloadBuilderImpl builder = new MetricTagPayloadBuilderImpl();
+
+        builder.addTag("metric1", "m1tagname1", "m1tagvalue1", MetricType.GAUGE);
+        builder.addTag("metric1", "m1tagname2", "m1tagvalue2", MetricType.GAUGE);
+
+        builder.addTag("metric2", "m2tagname1", "m2tagvalue1", MetricType.GAUGE);
+        builder.addTag("metric2", "m2tagname2", "m2tagvalue2", MetricType.GAUGE);
+
+        builder.addTag("metric3", "m3tagname1", "m3tagvalue1", MetricType.COUNTER);
+        builder.addTag("metric3", "m3tagname2", "m3tagvalue2", MetricType.COUNTER);
+
+        builder.addTag("metric4", "m4tagname1", "m4tagvalue1", MetricType.COUNTER);
+        builder.addTag("metric4", "m4tagname2", "m4tagvalue2", MetricType.COUNTER);
+
+        Map<String, String> payload = builder.toPayload();
+
+        String json;
+
+        json = payload.get("gauges/metric1");
+        Assert.assertEquals("{\"m1tagname1\":\"m1tagvalue1\",\"m1tagname2\":\"m1tagvalue2\"}", json);
+        json = payload.get("gauges/metric2");
+        Assert.assertEquals("{\"m2tagname1\":\"m2tagvalue1\",\"m2tagname2\":\"m2tagvalue2\"}", json);
+        json = payload.get("counters/metric3");
+        Assert.assertEquals("{\"m3tagname1\":\"m3tagvalue1\",\"m3tagname2\":\"m3tagvalue2\"}", json);
+        json = payload.get("counters/metric4");
+        Assert.assertEquals("{\"m4tagname1\":\"m4tagvalue1\",\"m4tagname2\":\"m4tagvalue2\"}", json);
+
+    }
+}

--- a/hawkular-wildfly-agent/src/test/resources/org/hawkular/agent/monitor/extension/subsystem-xsd-full.xml
+++ b/hawkular-wildfly-agent/src/test/resources/org/hawkular/agent/monitor/extension/subsystem-xsd-full.xml
@@ -132,14 +132,16 @@
                 set-avail-on-shutdown="UP"
                 resource-type-sets="Main"
                 tenant-id=""
-                metric-id-template="%FeedId-%ResourceName-%MetricTypeName" />
+                metric-id-template="%FeedId-%ResourceName-%MetricTypeName"
+                metric-labels="feed=%FeedId,Label One=Value One" />
 
     <local-dmr name="Self"
                enabled="true"
                set-avail-on-shutdown="UP"
                resource-type-sets="Main"
                tenant-id="tenantOverride"
-               metric-id-template="%FeedId-%ResourceName-%MetricTypeName" />
+               metric-id-template="%FeedId-%ResourceName-%MetricTypeName"
+               metric-labels="feed=%FeedId,Label One=Value One" />
 
     <remote-jmx name="Remote JMX"
                 enabled="true"
@@ -150,7 +152,8 @@
                 set-avail-on-shutdown="UP"
                 resource-type-sets="R Resource Type Set"
                 tenant-id="tenantOverride"
-                metric-id-template="%FeedId-%ResourceName-%MetricTypeName" />
+                metric-id-template="%FeedId-%ResourceName-%MetricTypeName"
+                metric-labels="feed=%FeedId,Label One=Value One" />
 
     <remote-prometheus name="Remote Prometheus"
                        enabled="true"
@@ -161,7 +164,8 @@
                        interval="30"
                        time-units="seconds"
                        tenant-id="tenantOverride"
-                       metric-id-template="%FeedId-%MetricName" />
+                       metric-id-template="%FeedId-%MetricName"
+                       metric-labels="feed=%FeedId,Label One=Value One" />
 
   </managed-servers>
 

--- a/hawkular-wildfly-agent/src/test/resources/org/hawkular/agent/monitor/extension/subsystem-xsd-full.xml
+++ b/hawkular-wildfly-agent/src/test/resources/org/hawkular/agent/monitor/extension/subsystem-xsd-full.xml
@@ -131,13 +131,15 @@
                 security-realm="HawkularRealm"
                 set-avail-on-shutdown="UP"
                 resource-type-sets="Main"
-                tenant-id="" />
+                tenant-id=""
+                metric-id-template="%FeedId-%ResourceName-%MetricTypeName" />
 
     <local-dmr name="Self"
                enabled="true"
                set-avail-on-shutdown="UP"
                resource-type-sets="Main"
-               tenant-id="tenantOverride" />
+               tenant-id="tenantOverride"
+               metric-id-template="%FeedId-%ResourceName-%MetricTypeName" />
 
     <remote-jmx name="Remote JMX"
                 enabled="true"
@@ -147,7 +149,8 @@
                 security-realm="HawkularRealm"
                 set-avail-on-shutdown="UP"
                 resource-type-sets="R Resource Type Set"
-                tenant-id="tenantOverride" />
+                tenant-id="tenantOverride"
+                metric-id-template="%FeedId-%ResourceName-%MetricTypeName" />
 
     <remote-prometheus name="Remote Prometheus"
                        enabled="true"
@@ -157,7 +160,8 @@
                        security-realm="HawkularRealm"
                        interval="30"
                        time-units="seconds"
-                       tenant-id="tenantOverride" />
+                       tenant-id="tenantOverride"
+                       metric-id-template="%FeedId-%MetricName" />
 
   </managed-servers>
 

--- a/hawkular-wildfly-agent/src/test/resources/org/hawkular/agent/monitor/extension/subsystem.xml
+++ b/hawkular-wildfly-agent/src/test/resources/org/hawkular/agent/monitor/extension/subsystem.xml
@@ -118,7 +118,8 @@
                 port="9990"
                 use-ssl="false"
                 security-realm="HawkularRealm"
-                resource-type-sets="Main" />
+                resource-type-sets="Main"
+                metric-id-template="%FeedId-%ResourceName-%MetricTypeName" />
 
     <local-dmr name="Self"
                resource-type-sets="Main" />


### PR DESCRIPTION
right now this only supports defining tags per managed server. So for each remote-dmr, remote-jmx, etc, you can define a set of tags for each metric collected under that managed server. You can add tokens to the labels (like %MetricTypeUnits or %ResourceName).

This does not allow you to define tags for specific metric types. I'm thinking about how it would be possible to support that.
