### PR TITLE
Revert "Allow to pass in the agent name via -Dhawkular.agent.name"

### DIFF
--- a/hawkular-wildfly-agent-feature-pack/src/main/resources/subsystem-templates/hawkular-wildfly-agent.xml
+++ b/hawkular-wildfly-agent-feature-pack/src/main/resources/subsystem-templates/hawkular-wildfly-agent.xml
@@ -1035,7 +1035,7 @@
                   password="adminPass"
                   resource-type-sets="Standalone Environment,Deployment,Web Component,EJB,Datasource,XA Datasource,JDBC Driver,Transaction Manager,Messaging,Socket Binding Group,Clustering" />
 
-      <local-dmr name="${hawkular.agent.name:Local}"
+      <local-dmr name="Local"
                  enabled="true"
                  resource-type-sets="Standalone Environment,Deployment,Web Component,EJB,Datasource,XA Datasource,JDBC Driver,Transaction Manager,Messaging,Socket Binding Group,Clustering,Hawkular" />
 


### PR DESCRIPTION
Reverts hawkular/hawkular-agent#232

you cannot put expressions in any wildfly "name" attribute
