### PR TITLE
Related to Hawkular-1101

### DIFF
--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalDMRAttributes.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalDMRAttributes.java
@@ -38,7 +38,6 @@ public interface LocalDMRAttributes {
     SimpleAttributeDefinition SET_AVAIL_ON_SHUTDOWN = new SimpleAttributeDefinitionBuilder("set-avail-on-shutdown",
             ModelType.STRING)
                     .setAllowNull(true)
-                    .setDefaultValue(new ModelNode(Avail.DOWN.name()))
                     .setValidator(EnumValidator.create(Avail.class, true, true))
                     .setAllowExpression(true)
                     .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/protocol/Discovery.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/protocol/Discovery.java
@@ -215,6 +215,9 @@ public final class Discovery<L> {
 
                     MeasurementInstance<L, AvailType<L>> availInstance = new MeasurementInstance<>(id, name,
                             instanceLocation, availType);
+                    if (!session.getEndpoint().getEndpointConfiguration().isLocal()) {
+                        availInstance.addProperty("hawkular-services.monitoring-type", "remote");
+                    }
                     builder.avail(availInstance);
                 }
             } catch (ProtocolException e) {

--- a/hawkular-wildfly-agent/src/main/resources/org/hawkular/agent/monitor/extension/LocalDescriptions.properties
+++ b/hawkular-wildfly-agent/src/main/resources/org/hawkular/agent/monitor/extension/LocalDescriptions.properties
@@ -121,7 +121,7 @@ hawkular-wildfly-agent.managed-servers.remote-dmr.username=Name of the managemen
 hawkular-wildfly-agent.managed-servers.remote-dmr.password=Credentials of the management user
 hawkular-wildfly-agent.managed-servers.remote-dmr.use-ssl=Should SSL be used for the communication to the remote application server?
 hawkular-wildfly-agent.managed-servers.remote-dmr.security-realm=If SSL is to be used, this is the name of the configured security realm that provides keystore information for secure communications
-hawkular-wildfly-agent.managed-servers.remote-dmr.set-avail-on-shutdown=If set then when the agent shuts down all availability metrics on all resources for this managed server will be set to this value (typically you will set this to DOWN or UNKNOWN, default is unset).
+hawkular-wildfly-agent.managed-servers.remote-dmr.set-avail-on-shutdown=If set then when the agent shuts down all availability metrics on all resources for this managed server will be set to this value (typically you will set this to DOWN or UNKNOWN, default is unset). This is for use only with storage-adapter type="METRICS". The "HAWKULAR" storage-adapter utilizes a server-side mechanism.
 hawkular-wildfly-agent.managed-servers.remote-dmr.resource-type-sets=Comma-separated names of the resource type sets which indicate what resources to manage in this managed server
 hawkular-wildfly-agent.managed-servers.remote-dmr.tenant-id=If specified, metrics from this endpoint will be associated with the given tenant ID rather than the agent's tenant ID.
 hawkular-wildfly-agent.managed-servers.remote-dmr.metric-id-template=If specified, all metric IDs for this managed server will be constructed from the given template which can use tokens such as %FeedId, %ManagedServerName, and others. If not specified, a default ID will be generated.
@@ -132,7 +132,7 @@ hawkular-wildfly-agent.managed-servers.local-dmr.add=unused
 hawkular-wildfly-agent.managed-servers.local-dmr.remove=do no use
 hawkular-wildfly-agent.managed-servers.local-dmr.name=A name this agent will assign to its own application server
 hawkular-wildfly-agent.managed-servers.local-dmr.enabled=True if you want to monitor this resource; false if not
-hawkular-wildfly-agent.managed-servers.local-dmr.set-avail-on-shutdown=If set then when the agent shuts down all availability metrics on all resources for this managed server will be set to this value (typically you will set this to DOWN or UNKNOWN, default is DOWN).
+hawkular-wildfly-agent.managed-servers.local-dmr.set-avail-on-shutdown=If set then when the agent shuts down all availability metrics on all resources for this managed server will be set to this value (typically you will set this to DOWN or UNKNOWN, default is unset).  This is for use only with storage-adapter type="METRICS". The "HAWKULAR" storage-adapter utilizes a server-side mechanism.
 hawkular-wildfly-agent.managed-servers.local-dmr.resource-type-sets=Comma-separated names of the resource type sets which indicate what resources to manage in this managed server
 hawkular-wildfly-agent.managed-servers.local-dmr.tenant-id=If specified, metrics from this endpoint will be associated with the given tenant ID rather than the agent's tenant ID.
 hawkular-wildfly-agent.managed-servers.local-dmr.metric-id-template=If specified, all metric IDs for this managed server will be constructed from the given template which can use tokens such as %FeedId, %ManagedServerName, and others. If not specified, a default ID will be generated.
@@ -149,7 +149,7 @@ hawkular-wildfly-agent.managed-servers.remote-jmx.url=The URL to the remote JMX 
 hawkular-wildfly-agent.managed-servers.remote-jmx.username=Name of the management user that can connect to the JMX Jolokia management interface
 hawkular-wildfly-agent.managed-servers.remote-jmx.password=Credentials of the management user
 hawkular-wildfly-agent.managed-servers.remote-jmx.security-realm=If SSL is to be used, this is the name of the configured security realm that provides keystore information for secure communications
-hawkular-wildfly-agent.managed-servers.remote-jmx.set-avail-on-shutdown=If set then when the agent shuts down all availability metrics on all resources for this managed server will be set to this value (typically you will set this to DOWN or UNKNOWN, default is unset).
+hawkular-wildfly-agent.managed-servers.remote-jmx.set-avail-on-shutdown=If set then when the agent shuts down all availability metrics on all resources for this managed server will be set to this value (typically you will set this to DOWN or UNKNOWN, default is unset).  This is for use only with storage-adapter type="METRICS". The "HAWKULAR" storage-adapter utilizes a server-side mechanism.
 hawkular-wildfly-agent.managed-servers.remote-jmx.resource-type-sets=Comma-separated names of the resource type sets which indicate what resources to manage in this managed server
 hawkular-wildfly-agent.managed-servers.remote-jmx.tenant-id=If specified, metrics from this endpoint will be associated with the given tenant ID rather than the agent's tenant ID.
 hawkular-wildfly-agent.managed-servers.remote-jmx.metric-id-template=If specified, all metric IDs for this managed server will be constructed from the given template which can use tokens such as %FeedId, %ManagedServerName, and others. If not specified, a default ID will be generated.

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <version.org.hamcrest>1.3</version.org.hamcrest>
 
     <version.org.hawkular.commons>0.7.4.Final</version.org.hawkular.commons>
-    <version.org.hawkular.inventory>0.17.1.Final</version.org.hawkular.inventory>
+    <version.org.hawkular.inventory>0.17.3.Final</version.org.hawkular.inventory>
     <version.org.hawkular.metrics>0.18.0.Final-SRC-revision-a72334d8591cc72f39741abbe7e40d6317e19a06</version.org.hawkular.metrics>
 
     <version.org.jboss.aesh>0.66.7</version.org.jboss.aesh>


### PR DESCRIPTION
- By default, don't perform "set-avail-on-shutdown" actions for anything
- Update descriptions for "set-avail-on-shutdown" to state that it should be used only in METRIC mode.
- For a remotely monitored resource, set the following property on
  its avail metric in inventory: hawkular-services.monitoring-type:remote.
  This tells the backfiller to set the avail to UNKNOWN for remotely managed
  resource avails, the default (or if the prop is set to "local") is DOWN.
