### PR TITLE
HWKAGENT-125 Support Enable/Disable/Restart Deployment commands

### DIFF
--- a/hawkular-dmr-client/src/main/java/org/hawkular/dmrclient/DeploymentJBossASClient.java
+++ b/hawkular-dmr-client/src/main/java/org/hawkular/dmrclient/DeploymentJBossASClient.java
@@ -47,6 +47,9 @@ public class DeploymentJBossASClient extends JBossASClient {
     }
 
     private void enableDisableDeployment(String name, boolean enable, Set<String> serverGroups) throws Exception {
+        if (serverGroups == null) {
+            serverGroups = Collections.emptySet();
+        }
         DeploymentManager dm = DeploymentManager.Factory.create(getModelControllerClient());
         DeploymentResult result;
 
@@ -69,6 +72,9 @@ public class DeploymentJBossASClient extends JBossASClient {
     }
 
     public void restartDeployment(String name, Set<String> serverGroups) throws Exception {
+        if (serverGroups == null) {
+            serverGroups = Collections.emptySet();
+        }
         DeploymentManager dm = DeploymentManager.Factory.create(getModelControllerClient());
         DeploymentResult result;
 

--- a/hawkular-dmr-client/src/main/java/org/hawkular/dmrclient/DeploymentJBossASClient.java
+++ b/hawkular-dmr-client/src/main/java/org/hawkular/dmrclient/DeploymentJBossASClient.java
@@ -38,23 +38,43 @@ public class DeploymentJBossASClient extends JBossASClient {
         super(client);
     }
 
-    public void enableDeployment(String name) throws Exception {
-        enableDisableDeployment(name, true);
+    public void enableDeployment(String name, Set<String> serverGroups) throws Exception {
+        enableDisableDeployment(name, true, serverGroups);
     }
 
-    public void disableDeployment(String name) throws Exception {
-        enableDisableDeployment(name, false);
+    public void disableDeployment(String name, Set<String> serverGroups) throws Exception {
+        enableDisableDeployment(name, false, serverGroups);
     }
 
-    private void enableDisableDeployment(String name, boolean enable) throws Exception {
+    private void enableDisableDeployment(String name, boolean enable, Set<String> serverGroups) throws Exception {
         DeploymentManager dm = DeploymentManager.Factory.create(getModelControllerClient());
         DeploymentResult result;
 
         if (enable) {
-            result = dm.deployToRuntime(SimpleDeploymentDescription.of(name));
+            SimpleDeploymentDescription sdd = SimpleDeploymentDescription.of(name);
+            sdd.addServerGroups(serverGroups);
+            result = dm.deployToRuntime(sdd);
         } else {
-            result = dm.undeploy(UndeployDescription.of(name).setRemoveContent(false));
+            UndeployDescription ud = UndeployDescription.of(name);
+            ud.addServerGroups(serverGroups);
+            ud.setRemoveContent(false);
+            result = dm.undeploy(ud);
         }
+
+        if (!result.successful()) {
+            throw new FailureException(result.getFailureMessage());
+        }
+
+        return; // everything is OK
+    }
+
+    public void restartDeployment(String name, Set<String> serverGroups) throws Exception {
+        DeploymentManager dm = DeploymentManager.Factory.create(getModelControllerClient());
+        DeploymentResult result;
+
+        SimpleDeploymentDescription sdd = SimpleDeploymentDescription.of(name);
+        sdd.addServerGroups(serverGroups);
+        result = dm.redeployToRuntime(sdd);
 
         if (!result.successful()) {
             throw new FailureException(result.getFailureMessage());

--- a/hawkular-dmr-client/src/main/java/org/hawkular/dmrclient/JBossASClient.java
+++ b/hawkular-dmr-client/src/main/java/org/hawkular/dmrclient/JBossASClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -69,7 +69,7 @@ public class JBossASClient implements AutoCloseable {
     }
 
     /////////////////////////////////////////////////////////////////
-    // Some static methods useful for convienence
+    // Some static methods useful for convenience
 
     /**
      * Convienence method that allows you to create request that reads a single attribute

--- a/hawkular-swarm-agents/hawkular-swarm-agent-dists/hawkular-swarm-agent-dist/src/main/resources/hawkular-swarm-agent-config.xml
+++ b/hawkular-swarm-agents/hawkular-swarm-agent-dists/hawkular-swarm-agent-dist/src/main/resources/hawkular-swarm-agent-config.xml
@@ -695,9 +695,11 @@
           <operation-dmr name="Suspend"  internal-name="suspend">
             <param name="timemout" type="int" description="Timeout in seconds to allow active connections to drain"/>
           </operation-dmr>
-          <operation-dmr name="Deploy"   internal-name="deploy"/>
-          <operation-dmr name="Undeploy" internal-name="undeploy"/>
-
+          <operation-dmr name="Deploy"             internal-name="deploy"/>
+          <operation-dmr name="Undeploy"           internal-name="undeploy"/>
+          <operation-dmr name="Enable Deployment"  internal-name="enable-deployment"/>
+          <operation-dmr name="Disable Deployment" internal-name="disable-deployment"/>
+          <operation-dmr name="Restart Deployment" internal-name="restart-deployment"/>
         </resource-type-dmr>
       </resource-type-set-dmr>
 
@@ -727,8 +729,11 @@
           <operation-dmr name="Suspend Servers" internal-name="suspend-servers" >
             <param name="timeout" type="int" default-value="0" description="Timeout in seconds to allow active connections to drain"/>
           </operation-dmr>
-          <operation-dmr name="Deploy"          internal-name="deploy" />
-          <operation-dmr name="Undeploy"        internal-name="undeploy" />
+          <operation-dmr name="Deploy"             internal-name="deploy"/>
+          <operation-dmr name="Undeploy"           internal-name="undeploy"/>
+          <operation-dmr name="Enable Deployment"  internal-name="enable-deployment"/>
+          <operation-dmr name="Disable Deployment" internal-name="disable-deployment"/>
+          <operation-dmr name="Restart Deployment" internal-name="restart-deployment"/>
         </resource-type-dmr>
 
         <resource-type-dmr name="Domain Profile"

--- a/hawkular-wildfly-agent-feature-pack/src/main/resources/subsystem-templates/hawkular-wildfly-agent.xml
+++ b/hawkular-wildfly-agent-feature-pack/src/main/resources/subsystem-templates/hawkular-wildfly-agent.xml
@@ -623,9 +623,11 @@
         <operation-dmr name="Suspend"  internal-name="suspend" >
           <param name="timeout" type="int"    default-value="0"     description="Timeout in seconds to allow active connections to drain"/>
         </operation-dmr>
-        <operation-dmr name="Deploy"   internal-name="deploy" />
-        <operation-dmr name="Undeploy" internal-name="undeploy" />
-
+        <operation-dmr name="Deploy"             internal-name="deploy"/>
+        <operation-dmr name="Undeploy"           internal-name="undeploy"/>
+        <operation-dmr name="Enable Deployment"  internal-name="enable-deployment"/>
+        <operation-dmr name="Disable Deployment" internal-name="disable-deployment"/>
+        <operation-dmr name="Restart Deployment" internal-name="restart-deployment"/>
       </resource-type-dmr>
     </resource-type-set-dmr>
 
@@ -655,8 +657,11 @@
         <operation-dmr name="Suspend Servers" internal-name="suspend-servers" >
           <param name="timeout" type="int" default-value="0" description="Timeout in seconds to allow active connections to drain"/>
         </operation-dmr>
-        <operation-dmr name="Deploy"          internal-name="deploy" />
-        <operation-dmr name="Undeploy"        internal-name="undeploy" />
+        <operation-dmr name="Deploy"             internal-name="deploy"/>
+        <operation-dmr name="Undeploy"           internal-name="undeploy"/>
+        <operation-dmr name="Enable Deployment"  internal-name="enable-deployment"/>
+        <operation-dmr name="Disable Deployment" internal-name="disable-deployment"/>
+        <operation-dmr name="Restart Deployment" internal-name="restart-deployment"/>
       </resource-type-dmr>
 
       <resource-type-dmr name="Domain Profile"

--- a/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-cmdgw-itest/src/test/java/org/hawkular/agent/ws/test/StandaloneDeployApplicationITest.java
+++ b/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-cmdgw-itest/src/test/java/org/hawkular/agent/ws/test/StandaloneDeployApplicationITest.java
@@ -21,7 +21,6 @@ import java.io.File;
 import org.hawkular.cmdgw.ws.test.TestWebSocketClient;
 import org.hawkular.cmdgw.ws.test.TestWebSocketClient.MessageAnswer;
 import org.hawkular.dmrclient.Address;
-import org.hawkular.inventory.api.model.Resource;
 import org.hawkular.inventory.paths.CanonicalPath;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.testng.annotations.Test;
@@ -71,6 +70,159 @@ public class StandaloneDeployApplicationITest extends AbstractCommandITest {
     }
 
     @Test(groups = { GROUP }, dependsOnMethods = { "testAddDeployment" })
+    public void testDisableDeployment() throws Throwable {
+        waitForAccountsAndInventory();
+
+        // check that the app is currently enabled
+        try (ModelControllerClient mcc = newHawkularModelControllerClient()) {
+            assertNodeAttributeEquals(mcc,
+                    Address.parse(
+                            "/deployment=hawkular-wildfly-agent-helloworld-war.war")
+                            .getAddressNode(),
+                    "enabled",
+                    "true");
+        }
+
+        CanonicalPath wfPath = getHawkularWildFlyServerResourcePath();
+        File applicationFile = getTestApplicationFile();
+        final String deploymentName = applicationFile.getName();
+
+        String req = "DisableApplicationRequest={\"authentication\":" + authentication + ", "
+                + "\"resourcePath\":\"" + wfPath.toString() + "\","
+                + "\"destinationFileName\":\"" + deploymentName + "\""
+                + "}";
+        String response = "DisableApplicationResponse={"
+                + "\"destinationFileName\":\"" + deploymentName + "\","
+                + "\"resourcePath\":\"" + wfPath.toString() + "\","
+                + "\"destinationSessionId\":\"{{sessionId}}\","
+                + "\"status\":\"OK\","
+                + "\"message\":\"Performed [Disable Deployment] on a [Application] given by Inventory path ["
+                + wfPath.toString() + "]\""
+                + "}";
+        try (TestWebSocketClient testClient = TestWebSocketClient.builder()
+                .url(baseGwUri + "/ui/ws")
+                .expectWelcome(new MessageAnswer(req, applicationFile.toURI().toURL(), 0))
+                .expectGenericSuccess(wfPath.ids().getFeedId())
+                .expectText(response, TestWebSocketClient.Answer.CLOSE)
+                .expectClose()
+                .build()) {
+            testClient.validate(30000);
+        }
+
+        // check that the app is currently disabled
+        try (ModelControllerClient mcc = newHawkularModelControllerClient()) {
+            assertNodeAttributeEquals(mcc,
+                    Address.parse(
+                            "/deployment=hawkular-wildfly-agent-helloworld-war.war")
+                            .getAddressNode(),
+                    "enabled",
+                    "false");
+        }
+    }
+
+    @Test(groups = { GROUP }, dependsOnMethods = { "testDisableDeployment" })
+    public void testEnableDeployment() throws Throwable {
+        waitForAccountsAndInventory();
+
+        // check that the app is currently disabled
+        try (ModelControllerClient mcc = newHawkularModelControllerClient()) {
+            assertNodeAttributeEquals(mcc,
+                    Address.parse(
+                            "/deployment=hawkular-wildfly-agent-helloworld-war.war")
+                            .getAddressNode(),
+                    "enabled",
+                    "false");
+        }
+
+        CanonicalPath wfPath = getHawkularWildFlyServerResourcePath();
+        File applicationFile = getTestApplicationFile();
+        final String deploymentName = applicationFile.getName();
+
+        String req = "EnableApplicationRequest={\"authentication\":" + authentication + ", "
+                + "\"resourcePath\":\"" + wfPath.toString() + "\","
+                + "\"destinationFileName\":\"" + deploymentName + "\""
+                + "}";
+        String response = "EnableApplicationResponse={"
+                + "\"destinationFileName\":\"" + deploymentName + "\","
+                + "\"resourcePath\":\"" + wfPath.toString() + "\","
+                + "\"destinationSessionId\":\"{{sessionId}}\","
+                + "\"status\":\"OK\","
+                + "\"message\":\"Performed [Enable Deployment] on a [Application] given by Inventory path ["
+                + wfPath.toString() + "]\""
+                + "}";
+        try (TestWebSocketClient testClient = TestWebSocketClient.builder()
+                .url(baseGwUri + "/ui/ws")
+                .expectWelcome(new MessageAnswer(req, applicationFile.toURI().toURL(), 0))
+                .expectGenericSuccess(wfPath.ids().getFeedId())
+                .expectText(response, TestWebSocketClient.Answer.CLOSE)
+                .expectClose()
+                .build()) {
+            testClient.validate(30000);
+        }
+
+        // check that the app is currently enabled
+        try (ModelControllerClient mcc = newHawkularModelControllerClient()) {
+            assertNodeAttributeEquals(mcc,
+                    Address.parse(
+                            "/deployment=hawkular-wildfly-agent-helloworld-war.war")
+                            .getAddressNode(),
+                    "enabled",
+                    "true");
+        }
+    }
+
+    @Test(groups = { GROUP }, dependsOnMethods = { "testEnableDeployment" })
+    public void testRestartDeployment() throws Throwable {
+        waitForAccountsAndInventory();
+
+        // check that the app is currently enabled
+        try (ModelControllerClient mcc = newHawkularModelControllerClient()) {
+            assertNodeAttributeEquals(mcc,
+                    Address.parse(
+                            "/deployment=hawkular-wildfly-agent-helloworld-war.war")
+                            .getAddressNode(),
+                    "enabled",
+                    "true");
+        }
+
+        CanonicalPath wfPath = getHawkularWildFlyServerResourcePath();
+        File applicationFile = getTestApplicationFile();
+        final String deploymentName = applicationFile.getName();
+
+        String req = "RestartApplicationRequest={\"authentication\":" + authentication + ", "
+                + "\"resourcePath\":\"" + wfPath.toString() + "\","
+                + "\"destinationFileName\":\"" + deploymentName + "\""
+                + "}";
+        String response = "RestartApplicationResponse={"
+                + "\"destinationFileName\":\"" + deploymentName + "\","
+                + "\"resourcePath\":\"" + wfPath.toString() + "\","
+                + "\"destinationSessionId\":\"{{sessionId}}\","
+                + "\"status\":\"OK\","
+                + "\"message\":\"Performed [Restart Deployment] on a [Application] given by Inventory path ["
+                + wfPath.toString() + "]\""
+                + "}";
+        try (TestWebSocketClient testClient = TestWebSocketClient.builder()
+                .url(baseGwUri + "/ui/ws")
+                .expectWelcome(new MessageAnswer(req, applicationFile.toURI().toURL(), 0))
+                .expectGenericSuccess(wfPath.ids().getFeedId())
+                .expectText(response, TestWebSocketClient.Answer.CLOSE)
+                .expectClose()
+                .build()) {
+            testClient.validate(30000);
+        }
+
+        // check that the app is again enabled
+        try (ModelControllerClient mcc = newHawkularModelControllerClient()) {
+            assertNodeAttributeEquals(mcc,
+                    Address.parse(
+                            "/deployment=hawkular-wildfly-agent-helloworld-war.war")
+                            .getAddressNode(),
+                    "enabled",
+                    "true");
+        }
+    }
+
+    @Test(groups = { GROUP }, dependsOnMethods = { "testRestartDeployment" })
     public void testUndeploy() throws Throwable {
         waitForAccountsAndInventory();
 
@@ -107,109 +259,6 @@ public class StandaloneDeployApplicationITest extends AbstractCommandITest {
                             "/deployment=hawkular-wildfly-agent-helloworld-war.war")
                             .getAddressNode(),
                     false);
-        }
-    }
-
-    // this and the following tests will use the individual operations on the deployment itself to do things
-    @Test(groups = { GROUP }, dependsOnMethods = { "testUndeploy" })
-    public void testReloadDeploymentViaExecOp() throws Throwable {
-        waitForAccountsAndInventory();
-
-        // put the deployments back in (our earlier test "testUndeploy" removed them)
-        testAddDeployment();
-
-        CanonicalPath wfPath = getHawkularWildFlyServerResourcePath();
-        final String deploymentName = getTestApplicationFile().getName();
-        Resource deployment = getResource("/traversal/f;" + hawkularFeedId + "/type=rt;"
-                + "id=Deployment/rl;defines/type=r",
-                (r -> r.getId().endsWith("=" + deploymentName)));
-
-        String req = "ExecuteOperationRequest={\"authentication\":" + authentication + ", "
-                + "\"resourcePath\":\"" + deployment.getPath().toString() + "\","
-                + "\"operationName\":\"Redeploy\""
-                + "}";
-        String response = "ExecuteOperationResponse={"
-                + "\"operationName\":\"Redeploy\","
-                + "\"resourcePath\":\"" + deployment.getPath() + "\","
-                + "\"destinationSessionId\":\"{{sessionId}}\","
-                + "\"status\":\"OK\","
-                + "\"message\":\"Performed [Redeploy] on a [DMR Node] given by Inventory path ["
-                + deployment.getPath() + "]\""
-                + "}";
-        try (TestWebSocketClient testClient = TestWebSocketClient.builder()
-                .url(baseGwUri + "/ui/ws")
-                .expectWelcome(req)
-                .expectGenericSuccess(wfPath.ids().getFeedId())
-                .expectText(response, TestWebSocketClient.Answer.CLOSE)
-                .expectClose()
-                .build()) {
-            testClient.validate(30000);
-        }
-    }
-
-    @Test(groups = { GROUP }, dependsOnMethods = { "testReloadDeploymentViaExecOp" })
-    public void testUndeployDeploymentViaExecOp() throws Throwable {
-        waitForAccountsAndInventory();
-
-        CanonicalPath wfPath = getHawkularWildFlyServerResourcePath();
-        final String deploymentName = getTestApplicationFile().getName();
-        Resource deployment = getResource("/traversal/f;" + hawkularFeedId + "/type=rt;"
-                + "id=Deployment/rl;defines/type=r",
-                (r -> r.getId().endsWith("=" + deploymentName)));
-
-        String req = "ExecuteOperationRequest={\"authentication\":" + authentication + ", "
-                + "\"resourcePath\":\"" + deployment.getPath().toString() + "\","
-                + "\"operationName\":\"Undeploy\""
-                + "}";
-        String response = "ExecuteOperationResponse={"
-                + "\"operationName\":\"Undeploy\","
-                + "\"resourcePath\":\"" + deployment.getPath() + "\","
-                + "\"destinationSessionId\":\"{{sessionId}}\","
-                + "\"status\":\"OK\","
-                + "\"message\":\"Performed [Undeploy] on a [DMR Node] given by Inventory path ["
-                + deployment.getPath() + "]\""
-                + "}";
-        try (TestWebSocketClient testClient = TestWebSocketClient.builder()
-                .url(baseGwUri + "/ui/ws")
-                .expectWelcome(req)
-                .expectGenericSuccess(wfPath.ids().getFeedId())
-                .expectText(response, TestWebSocketClient.Answer.CLOSE)
-                .expectClose()
-                .build()) {
-            testClient.validate(30000);
-        }
-    }
-
-    @Test(groups = { GROUP }, dependsOnMethods = { "testUndeployDeploymentViaExecOp" })
-    public void testRemoveDeploymentViaExecOp() throws Throwable {
-        waitForAccountsAndInventory();
-
-        CanonicalPath wfPath = getHawkularWildFlyServerResourcePath();
-        final String deploymentName = getTestApplicationFile().getName();
-        Resource deployment = getResource("/traversal/f;" + hawkularFeedId + "/type=rt;"
-                 + "id=Deployment/rl;defines/type=r",
-                (r -> r.getId().endsWith("=" + deploymentName)));
-
-        String req = "ExecuteOperationRequest={\"authentication\":" + authentication + ", "
-                + "\"resourcePath\":\"" + deployment.getPath().toString() + "\","
-                + "\"operationName\":\"Remove\""
-                + "}";
-        String response = "ExecuteOperationResponse={"
-                + "\"operationName\":\"Remove\","
-                + "\"resourcePath\":\"" + deployment.getPath() + "\","
-                + "\"destinationSessionId\":\"{{sessionId}}\","
-                + "\"status\":\"OK\","
-                + "\"message\":\"Performed [Remove] on a [DMR Node] given by Inventory path ["
-                + deployment.getPath() + "]\""
-                + "}";
-        try (TestWebSocketClient testClient = TestWebSocketClient.builder()
-                .url(baseGwUri + "/ui/ws")
-                .expectWelcome(req)
-                .expectGenericSuccess(wfPath.ids().getFeedId())
-                .expectText(response, TestWebSocketClient.Answer.CLOSE)
-                .expectClose()
-                .build()) {
-            testClient.validate(30000);
         }
     }
 }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/cmd/DisableApplicationCommand.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/cmd/DisableApplicationCommand.java
@@ -35,24 +35,26 @@ import org.hawkular.agent.monitor.protocol.dmr.DMRNodeLocation;
 import org.hawkular.agent.monitor.protocol.dmr.DMRSession;
 import org.hawkular.bus.common.BasicMessageWithExtraData;
 import org.hawkular.bus.common.BinaryData;
+import org.hawkular.cmdgw.api.DisableApplicationRequest;
+import org.hawkular.cmdgw.api.DisableApplicationResponse;
 import org.hawkular.cmdgw.api.MessageUtils;
-import org.hawkular.cmdgw.api.UndeployApplicationRequest;
-import org.hawkular.cmdgw.api.UndeployApplicationResponse;
 import org.hawkular.dmrclient.DeploymentJBossASClient;
 import org.hawkular.inventory.paths.CanonicalPath;
 import org.jboss.as.controller.client.ModelControllerClient;
 
 /**
- * Removes a deployed application from a resource.
+ * Disables a deployed application for a server resource.
  */
-public class UndeployApplicationCommand
-        extends AbstractResourcePathCommand<UndeployApplicationRequest, UndeployApplicationResponse> {
+public class DisableApplicationCommand
+        extends AbstractResourcePathCommand<DisableApplicationRequest, DisableApplicationResponse> {
 
-    private static final MsgLogger log = AgentLoggers.getLogger(UndeployApplicationCommand.class);
-    public static final Class<UndeployApplicationRequest> REQUEST_CLASS = UndeployApplicationRequest.class;
+    private static final MsgLogger log = AgentLoggers.getLogger(DisableApplicationCommand.class);
 
-    public UndeployApplicationCommand() {
-        super("Undeploy", "Application");
+    public static final Class<DisableApplicationRequest> REQUEST_CLASS = DisableApplicationRequest.class;
+    public static final String NAME = "Disable Deployment";
+
+    public DisableApplicationCommand() {
+        super(NAME, "Application");
     }
 
     @Override
@@ -60,19 +62,16 @@ public class UndeployApplicationCommand
             ModelControllerClient controllerClient,
             EndpointService<DMRNodeLocation, DMRSession> endpointService,
             String modelNodePath,
-            BasicMessageWithExtraData<UndeployApplicationRequest> envelope,
-            UndeployApplicationResponse response,
+            BasicMessageWithExtraData<DisableApplicationRequest> envelope,
+            DisableApplicationResponse response,
             CommandContext context,
             DMRSession dmrContext)
-            throws Exception {
+                    throws Exception {
 
-        UndeployApplicationRequest request = envelope.getBasicMessage();
+        DisableApplicationRequest request = envelope.getBasicMessage();
 
         final String resourcePath = request.getResourcePath();
         final String destFileName = request.getDestinationFileName();
-        final boolean removeContent = (request.getRemoveContent() == null) ? true
-                : request.getRemoveContent().booleanValue();
-
         final Set<String> serverGroups = convertCsvToSet(request.getServerGroups());
 
         CanonicalPath canonicalPath = CanonicalPath.fromString(request.getResourcePath());
@@ -82,30 +81,31 @@ public class UndeployApplicationCommand
         Resource<DMRNodeLocation> resource = resourceManager.getResource(new ID(resourceId));
         if (resource == null) {
             throw new IllegalArgumentException(
-                    String.format("Cannot undeploy application: unknown resource [%s]", resourcePath));
+                    String.format("Cannot disable application: unknown resource [%s]", resourcePath));
         }
 
-        // find the operation we need to execute - make sure it exists
         Collection<Operation<DMRNodeLocation>> ops = resource.getResourceType().getOperations();
-        boolean canUndeploy = false;
-        log.tracef("Searching for Undeploy operation among operations [%s] for resource [%s].", ops, resource.getID());
+        boolean canPerform = false;
+        log.tracef("Searching for [%s] operation among operations [%s] for resource [%s].", NAME, ops,
+                resource.getID());
         for (Operation<DMRNodeLocation> op : ops) {
-            if ("Undeploy".equals(op.getName().getNameString())) {
-                canUndeploy = true;
+            if (NAME.equals(op.getName().getNameString())) {
+                canPerform = true;
                 break;
             }
         }
 
-        if (!canUndeploy) {
+        if (!canPerform) {
             throw new IllegalArgumentException(
-                    String.format("Cannot undeploy application from [%s]. That feature is disabled.", resource));
+                    String.format("Cannot [%s] from [%s]. The operation is undefined.", NAME, resource));
         }
 
         MessageUtils.prepareResourcePathResponse(request, response);
         response.setDestinationFileName(request.getDestinationFileName());
 
+        // don't close this wrapper client
         DeploymentJBossASClient client = new DeploymentJBossASClient(dmrContext.getClient());
-        client.undeploy(destFileName, serverGroups, removeContent);
+        client.disableDeployment(destFileName, serverGroups);
 
         // run discovery now so we can quickly show the app has been removed
         endpointService.discoverAll();
@@ -120,16 +120,16 @@ public class UndeployApplicationCommand
     }
 
     @Override
-    protected void validate(String modelNodePath, BasicMessageWithExtraData<UndeployApplicationRequest> envelope) {
+    protected void validate(String modelNodePath, BasicMessageWithExtraData<DisableApplicationRequest> envelope) {
     }
 
     @Override
-    protected void validate(BasicMessageWithExtraData<UndeployApplicationRequest> envelope,
+    protected void validate(BasicMessageWithExtraData<DisableApplicationRequest> envelope,
             MonitoredEndpoint<? extends AbstractEndpointConfiguration> endpoint) {
     }
 
     @Override
-    protected UndeployApplicationResponse createResponse() {
-        return new UndeployApplicationResponse();
+    protected DisableApplicationResponse createResponse() {
+        return new DisableApplicationResponse();
     }
 }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/cmd/FeedCommProcessor.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/cmd/FeedCommProcessor.java
@@ -56,18 +56,21 @@ public class FeedCommProcessor implements WebSocketListener {
 
     static {
         VALID_COMMANDS = new HashMap<>();
-        VALID_COMMANDS.put(EchoCommand.REQUEST_CLASS.getName(), EchoCommand.class);
-        VALID_COMMANDS.put(GenericErrorResponseCommand.REQUEST_CLASS.getName(), GenericErrorResponseCommand.class);
-        VALID_COMMANDS.put(ExecuteOperationCommand.REQUEST_CLASS.getName(), ExecuteOperationCommand.class);
-        VALID_COMMANDS.put(DeployApplicationCommand.REQUEST_CLASS.getName(), DeployApplicationCommand.class);
-        VALID_COMMANDS.put(UndeployApplicationCommand.REQUEST_CLASS.getName(), UndeployApplicationCommand.class);
-        VALID_COMMANDS.put(AddJdbcDriverCommand.REQUEST_CLASS.getName(), AddJdbcDriverCommand.class);
         VALID_COMMANDS.put(AddDatasourceCommand.REQUEST_CLASS.getName(), AddDatasourceCommand.class);
+        VALID_COMMANDS.put(AddJdbcDriverCommand.REQUEST_CLASS.getName(), AddJdbcDriverCommand.class);
+        VALID_COMMANDS.put(DeployApplicationCommand.REQUEST_CLASS.getName(), DeployApplicationCommand.class);
+        VALID_COMMANDS.put(DisableApplicationCommand.REQUEST_CLASS.getName(), DisableApplicationCommand.class);
+        VALID_COMMANDS.put(EchoCommand.REQUEST_CLASS.getName(), EchoCommand.class);
+        VALID_COMMANDS.put(EnableApplicationCommand.REQUEST_CLASS.getName(), EnableApplicationCommand.class);
+        VALID_COMMANDS.put(ExecuteOperationCommand.REQUEST_CLASS.getName(), ExecuteOperationCommand.class);
         VALID_COMMANDS.put(ExportJdrCommand.REQUEST_CLASS.getName(), ExportJdrCommand.class);
+        VALID_COMMANDS.put(GenericErrorResponseCommand.REQUEST_CLASS.getName(), GenericErrorResponseCommand.class);
         VALID_COMMANDS.put(RemoveDatasourceCommand.REQUEST_CLASS.getName(), RemoveDatasourceCommand.class);
         VALID_COMMANDS.put(RemoveJdbcDriverCommand.REQUEST_CLASS.getName(), RemoveJdbcDriverCommand.class);
-        VALID_COMMANDS.put(UpdateDatasourceCommand.REQUEST_CLASS.getName(), UpdateDatasourceCommand.class);
+        VALID_COMMANDS.put(RestartApplicationCommand.REQUEST_CLASS.getName(), RestartApplicationCommand.class);
         VALID_COMMANDS.put(StatisticsControlCommand.REQUEST_CLASS.getName(), StatisticsControlCommand.class);
+        VALID_COMMANDS.put(UndeployApplicationCommand.REQUEST_CLASS.getName(), UndeployApplicationCommand.class);
+        VALID_COMMANDS.put(UpdateDatasourceCommand.REQUEST_CLASS.getName(), UpdateDatasourceCommand.class);
     }
 
     private final int disconnectCode = 1000;

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/cmd/RestartApplicationCommand.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/cmd/RestartApplicationCommand.java
@@ -36,23 +36,25 @@ import org.hawkular.agent.monitor.protocol.dmr.DMRSession;
 import org.hawkular.bus.common.BasicMessageWithExtraData;
 import org.hawkular.bus.common.BinaryData;
 import org.hawkular.cmdgw.api.MessageUtils;
-import org.hawkular.cmdgw.api.UndeployApplicationRequest;
-import org.hawkular.cmdgw.api.UndeployApplicationResponse;
+import org.hawkular.cmdgw.api.RestartApplicationRequest;
+import org.hawkular.cmdgw.api.RestartApplicationResponse;
 import org.hawkular.dmrclient.DeploymentJBossASClient;
 import org.hawkular.inventory.paths.CanonicalPath;
 import org.jboss.as.controller.client.ModelControllerClient;
 
 /**
- * Removes a deployed application from a resource.
+ * Restarts a deployed application for a server resource.
  */
-public class UndeployApplicationCommand
-        extends AbstractResourcePathCommand<UndeployApplicationRequest, UndeployApplicationResponse> {
+public class RestartApplicationCommand
+        extends AbstractResourcePathCommand<RestartApplicationRequest, RestartApplicationResponse> {
 
-    private static final MsgLogger log = AgentLoggers.getLogger(UndeployApplicationCommand.class);
-    public static final Class<UndeployApplicationRequest> REQUEST_CLASS = UndeployApplicationRequest.class;
+    private static final MsgLogger log = AgentLoggers.getLogger(RestartApplicationCommand.class);
 
-    public UndeployApplicationCommand() {
-        super("Undeploy", "Application");
+    public static final Class<RestartApplicationRequest> REQUEST_CLASS = RestartApplicationRequest.class;
+    public static final String NAME = "Restart Deployment";
+
+    public RestartApplicationCommand() {
+        super(NAME, "Application");
     }
 
     @Override
@@ -60,19 +62,16 @@ public class UndeployApplicationCommand
             ModelControllerClient controllerClient,
             EndpointService<DMRNodeLocation, DMRSession> endpointService,
             String modelNodePath,
-            BasicMessageWithExtraData<UndeployApplicationRequest> envelope,
-            UndeployApplicationResponse response,
+            BasicMessageWithExtraData<RestartApplicationRequest> envelope,
+            RestartApplicationResponse response,
             CommandContext context,
             DMRSession dmrContext)
-            throws Exception {
+                    throws Exception {
 
-        UndeployApplicationRequest request = envelope.getBasicMessage();
+        RestartApplicationRequest request = envelope.getBasicMessage();
 
         final String resourcePath = request.getResourcePath();
         final String destFileName = request.getDestinationFileName();
-        final boolean removeContent = (request.getRemoveContent() == null) ? true
-                : request.getRemoveContent().booleanValue();
-
         final Set<String> serverGroups = convertCsvToSet(request.getServerGroups());
 
         CanonicalPath canonicalPath = CanonicalPath.fromString(request.getResourcePath());
@@ -82,30 +81,31 @@ public class UndeployApplicationCommand
         Resource<DMRNodeLocation> resource = resourceManager.getResource(new ID(resourceId));
         if (resource == null) {
             throw new IllegalArgumentException(
-                    String.format("Cannot undeploy application: unknown resource [%s]", resourcePath));
+                    String.format("Cannot restart application: unknown resource [%s]", resourcePath));
         }
 
-        // find the operation we need to execute - make sure it exists
         Collection<Operation<DMRNodeLocation>> ops = resource.getResourceType().getOperations();
-        boolean canUndeploy = false;
-        log.tracef("Searching for Undeploy operation among operations [%s] for resource [%s].", ops, resource.getID());
+        boolean canPerform = false;
+        log.tracef("Searching for [%s] operation among operations [%s] for resource [%s].", NAME, ops,
+                resource.getID());
         for (Operation<DMRNodeLocation> op : ops) {
-            if ("Undeploy".equals(op.getName().getNameString())) {
-                canUndeploy = true;
+            if (NAME.equals(op.getName().getNameString())) {
+                canPerform = true;
                 break;
             }
         }
 
-        if (!canUndeploy) {
+        if (!canPerform) {
             throw new IllegalArgumentException(
-                    String.format("Cannot undeploy application from [%s]. That feature is disabled.", resource));
+                    String.format("Cannot [%s] from [%s]. The operation is undefined.", NAME, resource));
         }
 
         MessageUtils.prepareResourcePathResponse(request, response);
         response.setDestinationFileName(request.getDestinationFileName());
 
+        // don't close this wrapper client
         DeploymentJBossASClient client = new DeploymentJBossASClient(dmrContext.getClient());
-        client.undeploy(destFileName, serverGroups, removeContent);
+        client.restartDeployment(destFileName, serverGroups);
 
         // run discovery now so we can quickly show the app has been removed
         endpointService.discoverAll();
@@ -120,16 +120,16 @@ public class UndeployApplicationCommand
     }
 
     @Override
-    protected void validate(String modelNodePath, BasicMessageWithExtraData<UndeployApplicationRequest> envelope) {
+    protected void validate(String modelNodePath, BasicMessageWithExtraData<RestartApplicationRequest> envelope) {
     }
 
     @Override
-    protected void validate(BasicMessageWithExtraData<UndeployApplicationRequest> envelope,
+    protected void validate(BasicMessageWithExtraData<RestartApplicationRequest> envelope,
             MonitoredEndpoint<? extends AbstractEndpointConfiguration> endpoint) {
     }
 
     @Override
-    protected UndeployApplicationResponse createResponse() {
-        return new UndeployApplicationResponse();
+    protected RestartApplicationResponse createResponse() {
+        return new RestartApplicationResponse();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -62,8 +62,7 @@
     <version.io.dropwizard.metrics>3.1.0</version.io.dropwizard.metrics>
     <version.io.prometheus.client>0.0.2</version.io.prometheus.client>
     <version.org.hamcrest>1.3</version.org.hamcrest>
-
-    <version.org.hawkular.commons>0.7.7.Final</version.org.hawkular.commons>
+    <version.org.hawkular.commons>0.7.8.Final</version.org.hawkular.commons>
     <version.org.hawkular.inventory>0.17.3.Final</version.org.hawkular.inventory>
     <version.org.hawkular.metrics>0.18.0.Final</version.org.hawkular.metrics>
 


### PR DESCRIPTION
- add new commands
- add serverGroup handling to DeploymentJbossASClient for enable, disable
- add restart handling to DeploymentJbossASClient
- add new server operations in resource type config files
  - NOTE, leaving deployment commands until MIQ is updated
    to use the new server-level commands. See hwkagent-126.
