### PR TITLE
HWKAGENT-118 use formal op parameters

### DIFF
--- a/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-domain-itest/src/test/java/org/hawkular/wildfly/agent/installer/AgentInstallerDomainITest.java
+++ b/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-domain-itest/src/test/java/org/hawkular/wildfly/agent/installer/AgentInstallerDomainITest.java
@@ -17,8 +17,12 @@
 package org.hawkular.wildfly.agent.installer;
 
 import java.util.Collection;
+import java.util.Map;
 
+import org.hawkular.inventory.api.model.DataEntity;
+import org.hawkular.inventory.api.model.OperationType;
 import org.hawkular.inventory.api.model.Resource;
+import org.hawkular.inventory.api.model.StructuredData;
 import org.hawkular.wildfly.agent.itest.util.AbstractITest;
 import org.hawkular.wildfly.agent.itest.util.WildFlyClientConfig;
 import org.jboss.as.controller.PathAddress;
@@ -52,7 +56,7 @@ public class AgentInstallerDomainITest extends AbstractITest {
         for (String hostName : dmrHostNames) {
             Resource host = getResource(
                     "/traversal/f;" + wfClientConfig.getFeedId() + "/type=rt;"
-                    + "id=Domain Host/rl;defines/type=r",
+                            + "id=Domain Host/rl;defines/type=r",
                     (r -> r.getName().contains(hostName)));
             System.out.println("domain host in inventory=" + host);
         }
@@ -60,6 +64,24 @@ public class AgentInstallerDomainITest extends AbstractITest {
         // make sure we are testing against what we were expecting
         Assert.assertTrue(dmrHostNames.contains("master"));
         Assert.assertEquals("Wrong number of domain hosts", 1, dmrHostNames.size());
+
+        // make sure the Domain Host operations are OK
+        // SHUTDOWN
+        OperationType op = getOperationType("/traversal/f;" + wfClientConfig.getFeedId() + "/type=rt;" +
+                "id=Domain Host/type=ot;id=Shutdown", 1, 1);
+        Assert.assertEquals("Shutdown", op.getId());
+        DataEntity data = getDataEntity("/entity/f;" + wfClientConfig.getFeedId()
+                + "/rt;Domain Host/ot;Shutdown/d;parameterTypes", 1, 1);
+        Map<String, StructuredData> paramsMap = data.getValue().map();
+        Map<String, StructuredData> param = paramsMap.get("restart").map();
+        Assert.assertEquals("bool", param.get("type").string());
+        Assert.assertNull(param.get("defaultValue")); // this is not defined today
+        Assert.assertNotNull(param.get("description").string());
+
+        // RELOAD
+        op = getOperationType("/traversal/f;" + wfClientConfig.getFeedId() + "/type=rt;" +
+                "id=Domain Host/type=ot;id=Reload", 1, 1);
+        Assert.assertEquals("Reload", op.getId());
     }
 
     @Test(groups = { GROUP }, dependsOnMethods = { "wfStarted" })
@@ -69,7 +91,7 @@ public class AgentInstallerDomainITest extends AbstractITest {
         for (String serverName : dmrServerNames) {
             Resource server = getResource(
                     "/traversal/f;" + wfClientConfig.getFeedId() + "/type=rt;"
-                    + "id=Domain WildFly Server/rl;defines/type=r",
+                            + "id=Domain WildFly Server/rl;defines/type=r",
                     (r -> r.getName().contains(serverName)));
             System.out.println("domain server in inventory=" + server);
         }
@@ -88,7 +110,7 @@ public class AgentInstallerDomainITest extends AbstractITest {
         for (String groupName : dmrServerGroupNames) {
             Resource group = getResource(
                     "/traversal/f;" + wfClientConfig.getFeedId() + "/type=rt;"
-                    + "id=Domain Server Group/rl;defines/type=r",
+                            + "id=Domain Server Group/rl;defines/type=r",
                     (r -> r.getName().contains(groupName)));
             System.out.println("domain server group in inventory=" + group);
         }
@@ -97,6 +119,76 @@ public class AgentInstallerDomainITest extends AbstractITest {
         Assert.assertTrue(dmrServerGroupNames.contains("main-server-group"));
         Assert.assertTrue(dmrServerGroupNames.contains("other-server-group"));
         Assert.assertEquals("Wrong number of domain server groups", 2, dmrServerGroupNames.size());
+
+        // make sure the Domain Server Groups operations are OK
+        // RELOAD SERVERS
+        OperationType op = getOperationType("/traversal/f;" + wfClientConfig.getFeedId() + "/type=rt;" +
+                "id=Domain Server Group/type=ot;id=Reload Servers", 1, 1);
+        Assert.assertEquals("Reload Servers", op.getId());
+        DataEntity data = getDataEntity("/entity/f;" + wfClientConfig.getFeedId()
+                + "/rt;Domain Server Group/ot;Reload Servers/d;parameterTypes", 1, 1);
+        Map<String, StructuredData> paramsMap = data.getValue().map();
+        Map<String, StructuredData> param = paramsMap.get("blocking").map();
+        Assert.assertEquals("bool", param.get("type").string());
+        Assert.assertEquals("false", param.get("defaultValue").string());
+        Assert.assertNotNull(param.get("description").string());
+
+        // RESTART SERVERS
+        op = getOperationType("/traversal/f;" + wfClientConfig.getFeedId() + "/type=rt;" +
+                "id=Domain Server Group/type=ot;id=Restart Servers", 1, 1);
+        Assert.assertEquals("Restart Servers", op.getId());
+        data = getDataEntity("/entity/f;" + wfClientConfig.getFeedId()
+                + "/rt;Domain Server Group/ot;Restart Servers/d;parameterTypes", 1, 1);
+        paramsMap = data.getValue().map();
+        param = paramsMap.get("blocking").map();
+        Assert.assertEquals("bool", param.get("type").string());
+        Assert.assertEquals("false", param.get("defaultValue").string());
+        Assert.assertNotNull(param.get("description").string());
+
+        // START SERVERS
+        op = getOperationType("/traversal/f;" + wfClientConfig.getFeedId() + "/type=rt;" +
+                "id=Domain Server Group/type=ot;id=Start Servers", 1, 1);
+        Assert.assertEquals("Start Servers", op.getId());
+        data = getDataEntity("/entity/f;" + wfClientConfig.getFeedId()
+                + "/rt;Domain Server Group/ot;Start Servers/d;parameterTypes", 1, 1);
+        paramsMap = data.getValue().map();
+        param = paramsMap.get("blocking").map();
+        Assert.assertEquals("bool", param.get("type").string());
+        Assert.assertEquals("false", param.get("defaultValue").string());
+        Assert.assertNotNull(param.get("description").string());
+
+        // SUSPEND SERVERS
+        op = getOperationType("/traversal/f;" + wfClientConfig.getFeedId() + "/type=rt;" +
+                "id=Domain Server Group/type=ot;id=Suspend Servers", 1, 1);
+        Assert.assertEquals("Suspend Servers", op.getId());
+        data = getDataEntity("/entity/f;" + wfClientConfig.getFeedId()
+                + "/rt;Domain Server Group/ot;Suspend Servers/d;parameterTypes", 1, 1);
+        paramsMap = data.getValue().map();
+        param = paramsMap.get("timeout").map();
+        Assert.assertEquals("int", param.get("type").string());
+        Assert.assertNull(param.get("defaultValue")); // today, no default value is defined for this
+        Assert.assertNotNull(param.get("description").string());
+
+        // STOP SERVERS
+        op = getOperationType("/traversal/f;" + wfClientConfig.getFeedId() + "/type=rt;" +
+                "id=Domain Server Group/type=ot;id=Stop Servers", 1, 1);
+        Assert.assertEquals("Stop Servers", op.getId());
+        data = getDataEntity("/entity/f;" + wfClientConfig.getFeedId()
+                + "/rt;Domain Server Group/ot;Stop Servers/d;parameterTypes", 1, 1);
+        paramsMap = data.getValue().map();
+        param = paramsMap.get("timeout").map();
+        Assert.assertEquals("int", param.get("type").string());
+        Assert.assertNull(param.get("defaultValue")); // today, no default value is defined for this
+        Assert.assertNotNull(param.get("description").string());
+        param = paramsMap.get("blocking").map();
+        Assert.assertEquals("bool", param.get("type").string());
+        Assert.assertEquals("false", param.get("defaultValue").string());
+        Assert.assertNotNull(param.get("description").string());
+
+        // RESUME SERVERS
+        op = getOperationType("/traversal/f;" + wfClientConfig.getFeedId() + "/type=rt;" +
+                "id=Domain Server Group/type=ot;id=Resume Servers", 1, 1);
+        Assert.assertEquals("Resume Servers", op.getId());
     }
 
     @Test(groups = { GROUP }, dependsOnMethods = { "wfStarted" })
@@ -106,7 +198,7 @@ public class AgentInstallerDomainITest extends AbstractITest {
         for (String profileName : dmrProfileNames) {
             Resource profile = getResource(
                     "/traversal/f;" + wfClientConfig.getFeedId() + "/type=rt;"
-                    + "id=Domain Profile/rl;defines/type=r",
+                            + "id=Domain Profile/rl;defines/type=r",
                     (r -> r.getName().contains(profileName)));
             System.out.println("domain profile in inventory=" + profile);
         }
@@ -126,7 +218,7 @@ public class AgentInstallerDomainITest extends AbstractITest {
         for (String sbgName : dmrSBGNames) {
             Resource sbg = getResource(
                     "/traversal/f;" + wfClientConfig.getFeedId() + "/type=rt;"
-                    + "id=Socket Binding Group/rl;defines/type=r",
+                            + "id=Socket Binding Group/rl;defines/type=r",
                     (r -> r.getName().contains(sbgName)));
             System.out.println("socket binding group in inventory=" + sbg);
         }

--- a/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-itest-util/src/main/java/org/hawkular/wildfly/agent/itest/util/AbstractITest.java
+++ b/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-itest-util/src/main/java/org/hawkular/wildfly/agent/itest/util/AbstractITest.java
@@ -49,7 +49,10 @@ import org.hawkular.cmdgw.api.WelcomeResponse;
 import org.hawkular.dmr.api.OperationBuilder;
 import org.hawkular.dmrclient.Address;
 import org.hawkular.dmrclient.JBossASClient;
+import org.hawkular.inventory.api.model.DataEntity;
+import org.hawkular.inventory.api.model.OperationType;
 import org.hawkular.inventory.api.model.Resource;
+import org.hawkular.inventory.api.model.ResourceType;
 import org.hawkular.inventory.json.InventoryJacksonConfig;
 import org.hawkular.inventory.paths.CanonicalPath;
 import org.jboss.as.controller.PathAddress;
@@ -339,6 +342,100 @@ public abstract class AbstractITest {
                 }
                 System.out.println("Got only " + result.size() + " resources while expected " + minCount + " on "
                         + (i + 1) + " of " + attemptCount + " attempts for URL [" + url + "]");
+                // System.out.println(body);
+            } catch (Throwable t) {
+                /* some initial attempts may fail */
+                e = t;
+                System.out.println("URL [" + url + "] not ready yet on " + (i + 1) + " of " + attemptCount
+                        + " attempts, about to retry after " + attemptDelay + " ms");
+            }
+            Thread.sleep(attemptDelay);
+        }
+        if (e != null) {
+            throw e;
+        } else {
+            throw new AssertionError("Could not get [" + url + "]");
+        }
+    }
+
+    protected ResourceType getResourceType(String path, int attemptCount, long attemptDelay)
+            throws Throwable {
+        String url = baseInvUri + path;
+        Throwable e = null;
+        int minCount = 1; // for now, we expect to retrieve only 1 type
+        for (int i = 0; i < attemptCount; i++) {
+            try {
+                String body = getWithRetries(url, attemptCount, attemptDelay);
+                TypeFactory tf = mapper.getTypeFactory();
+                JavaType listType = tf.constructCollectionType(ArrayList.class, ResourceType.class);
+                JsonNode node = mapper.readTree(body);
+                List<ResourceType> result = mapper.readValue(node.traverse(), listType);
+                if (result.size() >= minCount) {
+                    return result.get(0); // we assume we are just getting 1
+                }
+                System.out.println("Got only " + result.size() + " resource types while expected " + minCount + " on "
+                        + (i + 1) + " of " + attemptCount + " attempts for URL [" + url + "]");
+                // System.out.println(body);
+            } catch (Throwable t) {
+                /* some initial attempts may fail */
+                e = t;
+                System.out.println("URL [" + url + "] not ready yet on " + (i + 1) + " of " + attemptCount
+                        + " attempts, about to retry after " + attemptDelay + " ms");
+            }
+            Thread.sleep(attemptDelay);
+        }
+        if (e != null) {
+            throw e;
+        } else {
+            throw new AssertionError("Could not get [" + url + "]");
+        }
+    }
+
+    protected OperationType getOperationType(String path, int attemptCount, long attemptDelay)
+            throws Throwable {
+        String url = baseInvUri + path;
+        Throwable e = null;
+        int minCount = 1; // for now, we expect to retrieve only 1 type
+        for (int i = 0; i < attemptCount; i++) {
+            try {
+                String body = getWithRetries(url, attemptCount, attemptDelay);
+                TypeFactory tf = mapper.getTypeFactory();
+                JavaType listType = tf.constructCollectionType(ArrayList.class, OperationType.class);
+                JsonNode node = mapper.readTree(body);
+                List<OperationType> result = mapper.readValue(node.traverse(), listType);
+                if (result.size() >= minCount) {
+                    return result.get(0); // we assume we are just getting 1
+                }
+                System.out.println("Got only " + result.size() + " operation types while expected " + minCount + " on "
+                        + (i + 1) + " of " + attemptCount + " attempts for URL [" + url + "]");
+                // System.out.println(body);
+            } catch (Throwable t) {
+                /* some initial attempts may fail */
+                e = t;
+                System.out.println("URL [" + url + "] not ready yet on " + (i + 1) + " of " + attemptCount
+                        + " attempts, about to retry after " + attemptDelay + " ms");
+            }
+            Thread.sleep(attemptDelay);
+        }
+        if (e != null) {
+            throw e;
+        } else {
+            throw new AssertionError("Could not get [" + url + "]");
+        }
+    }
+
+    protected DataEntity getDataEntity(String path, int attemptCount, long attemptDelay)
+            throws Throwable {
+        String url = baseInvUri + path;
+        Throwable e = null;
+        for (int i = 0; i < attemptCount; i++) {
+            try {
+                String body = getWithRetries(url, attemptCount, attemptDelay);
+                TypeFactory tf = mapper.getTypeFactory();
+                JavaType javaType = tf.constructType(DataEntity.class);
+                JsonNode node = mapper.readTree(body);
+                DataEntity result = mapper.readValue(node.traverse(), javaType);
+                return result;
                 // System.out.println(body);
             } catch (Throwable t) {
                 /* some initial attempts may fail */


### PR DESCRIPTION
this tests that the agent is storing operation parameters using the "formal" inventory way of parameterTypes data entities. Currently, the agent also stores these in general properties - we'll remove that in the future when clients are able to convert to using the new way (e.g. the ruby client)
