### PR TITLE
Prometheus parser should handle decimal notation longs and trailing commas

### DIFF
--- a/prometheus-scraper/src/main/java/org/hawkular/agent/prometheus/text/TextPrometheusMetricDataParser.java
+++ b/prometheus-scraper/src/main/java/org/hawkular/agent/prometheus/text/TextPrometheusMetricDataParser.java
@@ -123,7 +123,7 @@ public class TextPrometheusMetricDataParser extends PrometheusMetricDataParser<M
                             sBuilder.setName(name);
                             sBuilder.addLabels(textSample.getLabels());
                             if (textSample.getName().endsWith("_count")) {
-                                sBuilder.setSampleCount(Long.valueOf(textSample.getValue()));
+                                sBuilder.setSampleCount((long)Util.convertStringToDouble(textSample.getValue()));
                             } else if (textSample.getName().endsWith("_sum")) {
                                 sBuilder.setSampleSum(Util.convertStringToDouble(textSample.getValue()));
                             } else {
@@ -152,7 +152,7 @@ public class TextPrometheusMetricDataParser extends PrometheusMetricDataParser<M
                             hBuilder.setName(name);
                             hBuilder.addLabels(textSample.getLabels());
                             if (textSample.getName().endsWith("_count")) {
-                                hBuilder.setSampleCount(Long.valueOf(textSample.getValue()));
+                                hBuilder.setSampleCount((long)Util.convertStringToDouble(textSample.getValue()));
                             } else if (textSample.getName().endsWith("_sum")) {
                                 hBuilder.setSampleSum(Util.convertStringToDouble(textSample.getValue()));
                             } else {
@@ -161,7 +161,7 @@ public class TextPrometheusMetricDataParser extends PrometheusMetricDataParser<M
                                     throw new Exception("Histogram bucket sample is missing the 'le' label");
                                 }
                                 hBuilder.addBucket(Util.convertStringToDouble(bucket),
-                                        Long.valueOf(textSample.getValue()));
+                                        (long)Util.convertStringToDouble(textSample.getValue()));
                             }
                             break;
                     }
@@ -346,6 +346,8 @@ public class TextPrometheusMetricDataParser extends PrometheusMetricDataParser<M
             } else if (state.equals("labelname")) {
                 if (charAt == '=') {
                     state = "labelvaluequote";
+                } else if (charAt == '}') {
+                    state = "endoflabels";
                 } else if (charAt == ' ' || charAt == '\t') {
                     state = "labelvalueequals";
                 } else {

--- a/prometheus-scraper/src/test/resources/prometheus-histogram.txt
+++ b/prometheus-scraper/src/test/resources/prometheus-histogram.txt
@@ -7,7 +7,7 @@ http_request_duration_seconds_bucket{mylabel="wotgorilla?",le="0.05"} 24054 1234
 http_request_duration_seconds_bucket{mylabel="wotgorilla?",le="0.1"} 33444 123456789
 http_request_duration_seconds_bucket{mylabel="wotgorilla?",le="0.2"} 100392 123456789
 http_request_duration_seconds_bucket{mylabel="wotgorilla?",le="0.5"} 129389 123456789
-http_request_duration_seconds_bucket{mylabel="wotgorilla?",le="1"} 133988 123456789
-http_request_duration_seconds_bucket{mylabel="wotgorilla?",le="+Inf"} 144320 123456789
-http_request_duration_seconds_sum{mylabel="wotgorilla?"} 53423 123456789
-http_request_duration_seconds_count{mylabel="wotgorilla?"} 144320 123456789
+http_request_duration_seconds_bucket{mylabel="wotgorilla?",le="1"} 1.33988E5 123456789
+http_request_duration_seconds_bucket{mylabel="wotgorilla?",le="+Inf"} 144320.0 123456789
+http_request_duration_seconds_sum{mylabel="wotgorilla?"} 53423.0 123456789
+http_request_duration_seconds_count{mylabel="wotgorilla?"} 1.4432E5 123456789

--- a/prometheus-scraper/src/test/resources/prometheus.txt
+++ b/prometheus-scraper/src/test/resources/prometheus.txt
@@ -245,11 +245,11 @@ http_request_size_bytes_sum{handler="version"} 0
 http_request_size_bytes_count{handler="version"} 0
 # HELP http_requests_total Total number of HTTP requests made.
 # TYPE http_requests_total counter
-http_requests_total{code="200",handler="prometheus",method="get"} 162030
-http_requests_total{code="200",handler="query",method="get"} 40
-http_requests_total{code="200",handler="series",method="get"} 4
-http_requests_total{code="400",handler="query",method="get"} 6
-http_requests_total{code="400",handler="series",method="get"} 6
+http_requests_total{code="200",handler="prometheus",method="get",} 162030
+http_requests_total{code="200",handler="query",method="get",} 40
+http_requests_total{code="200",handler="series",method="get",} 4
+http_requests_total{code="400",handler="query",method="get",} 6
+http_requests_total{code="400",handler="series",method="get",} 6
 # HELP http_response_size_bytes The HTTP response sizes in bytes.
 # TYPE http_response_size_bytes summary
 http_response_size_bytes{handler="alerts",quantile="0.5"} NaN


### PR DESCRIPTION
Prometheus's 0.0.4 text format emits metrics with these quirks by default. Without this patch, metrics with labels, histograms, and summaries fail to parse.
