### PR TITLE
Changes metric-id to hawkular-metric-id

### DIFF
--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/inventory/MeasurementInstance.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/inventory/MeasurementInstance.java
@@ -31,7 +31,7 @@ public final class MeasurementInstance<L, T extends MeasurementType<L>> extends 
      * the data for this measurement instance as it is found in Hawkular Metrics storage. If this
      * property doesn't exist, you can assume the metric ID is the same as the ID of this measurement instance.
      */
-    private static final String METRIC_ID_PROPERTY = "metric-id";
+    private static final String METRIC_ID_PROPERTY = "hawkular-metric-id";
 
     public MeasurementInstance(ID id, Name name, AttributeLocation<L> attributeLocation, T type) {
         super(id, name, attributeLocation, type);


### PR DESCRIPTION
> "hawkular-metric-id" does seem to make sense since this does represent the "Hawkular Metrics ID".

For more info see: https://github.com/hawkular/hawkular-client-ruby/pull/140#issuecomment-246987834
