### PR TITLE
Validate when data source properties attribute is null.

### DIFF
--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/cmd/AddDatasourceCommand.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/cmd/AddDatasourceCommand.java
@@ -109,7 +109,7 @@ public class AddDatasourceCommand extends AbstractResourcePathCommand<AddDatasou
                     .parentBuilder();
 
         }
-        if (!props.isEmpty()) {
+        if (props!=null && !props.isEmpty()) {
             for (Entry<String, String> prop : props.entrySet()) {
                 batch.add() //
                         .address().segments(dsAdr).segment(dsPropsDmrResourceType, prop.getKey()).parentBuilder() //


### PR DESCRIPTION
This PR validates when the data source properties attribute is null in the `AddDatasourceCommand` and prevents an NPE.