### PR TITLE
Add some properties for JDBC drivers

### DIFF
--- a/hawkular-wildfly-agent-feature-pack/src/main/resources/subsystem-templates/hawkular-wildfly-agent.xml
+++ b/hawkular-wildfly-agent-feature-pack/src/main/resources/subsystem-templates/hawkular-wildfly-agent.xml
@@ -885,7 +885,12 @@
       <resource-type-dmr name="JDBC Driver"
                          resource-name-template="JDBC Driver [%-]"
                          path="/subsystem=datasources/jdbc-driver=*"
-                         parents="WildFly Server,Domain WildFly Server" />
+                         parents="WildFly Server,Domain WildFly Server" >
+        <resource-config-dmr name="Driver Class"        attribute="driver-class-name" />
+        <resource-config-dmr name="Module Name"         attribute="driver-module-name" />
+        <resource-config-dmr name="Driver Name"         attribute="driver-name" />
+        <resource-config-dmr name="XA DS Class"         attribute="driver-xa-datasource-class-name" />
+      </resource-type-dmr>
     </resource-type-set-dmr>
 
     <resource-type-set-dmr name="Transaction Manager" enabled="true">


### PR DESCRIPTION
This is to expose some properties for @mtho11 

Unfortunately the WildFly DMR model is a bit sparse with what it returns:

```
[standalone@localhost:9990 jdbc-driver=h2] :read-resource(include-defaults=true, include-runtime=true)
{
    "outcome" => "success",
    "result" => {
        "deployment-name" => undefined,
        "driver-class-name" => undefined,
        "driver-datasource-class-name" => undefined,
        "driver-major-version" => undefined,
        "driver-minor-version" => undefined,
        "driver-module-name" => "com.h2database.h2",
        "driver-name" => "h2",
        "driver-xa-datasource-class-name" => "org.h2.jdbcx.JdbcDataSource",
        "jdbc-compliant" => undefined,
        "module-slot" => undefined,
        "profile" => undefined,
        "xa-datasource-class" => undefined
    }
}

[standalone@localhost:9990 jdbc-driver=postgresql] :read-resource(include-defaults=true, include-runtime=true)
{
    "outcome" => "success",
    "result" => {
        "deployment-name" => undefined,
        "driver-class-name" => undefined,
        "driver-datasource-class-name" => undefined,
        "driver-major-version" => undefined,
        "driver-minor-version" => undefined,
        "driver-module-name" => "org.postgresql.postgresql",
        "driver-name" => "postgresql",
        "driver-xa-datasource-class-name" => "org.postgresql.xa.PGXADataSource",
        "jdbc-compliant" => undefined,
        "module-slot" => undefined,
        "profile" => undefined,
        "xa-datasource-class" => undefined
    }
}
```