### PR TITLE
HWKAGENT-148 Support specifying a protocol on a remote-dmr tag

### DIFF
--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/MonitorServiceConfigurationBuilder.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/MonitorServiceConfigurationBuilder.java
@@ -935,6 +935,7 @@ public class MonitorServiceConfigurationBuilder {
                             RemoteDMRAttributes.SET_AVAIL_ON_SHUTDOWN);
                     Avail setAvailOnShutdown = (setAvailOnShutdownStr == null) ? null
                             : Avail.valueOf(setAvailOnShutdownStr);
+                    String protocol = getString(remoteDMRValueNode, context, RemoteDMRAttributes.PROTOCOL);
                     String host = getString(remoteDMRValueNode, context, RemoteDMRAttributes.HOST);
                     int port = getInt(remoteDMRValueNode, context, RemoteDMRAttributes.PORT);
                     String username = getString(remoteDMRValueNode, context, RemoteDMRAttributes.USERNAME);
@@ -953,7 +954,9 @@ public class MonitorServiceConfigurationBuilder {
                         log.debugf("Using SSL with no security realm - will rely on the JVM truststore: " + name);
                     }
 
-                    String protocol = useSsl ? "https-remoting" : "http-remoting";
+                    if (protocol == null) {
+                        protocol = useSsl ? "https-remoting" : "http-remoting";
+                    }
                     ConnectionData connectionData = new ConnectionData(protocol, host, port, username, password);
                     EndpointConfiguration endpoint = new EndpointConfiguration(name, enabled, resourceTypeSets,
                             connectionData, securityRealm, setAvailOnShutdown, tenantId, metricIdTemplate, metricTags,

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteDMRAttributes.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteDMRAttributes.java
@@ -35,6 +35,13 @@ public interface RemoteDMRAttributes {
                     .addFlag(AttributeAccess.Flag.RESTART_NONE)
                     .build();
 
+    SimpleAttributeDefinition PROTOCOL = new SimpleAttributeDefinitionBuilder("protocol",
+            ModelType.STRING)
+                    .setAllowNull(true)
+                    .setAllowExpression(true)
+                    .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+                    .build();
+
     SimpleAttributeDefinition HOST = new SimpleAttributeDefinitionBuilder("host",
             ModelType.STRING)
                     .setAllowNull(false)
@@ -115,6 +122,7 @@ public interface RemoteDMRAttributes {
 
     AttributeDefinition[] ATTRIBUTES = {
             ENABLED,
+            PROTOCOL,
             HOST,
             PORT,
             USERNAME,

--- a/hawkular-wildfly-agent/src/main/resources/org/hawkular/agent/monitor/extension/LocalDescriptions.properties
+++ b/hawkular-wildfly-agent/src/main/resources/org/hawkular/agent/monitor/extension/LocalDescriptions.properties
@@ -115,6 +115,7 @@ hawkular-wildfly-agent.managed-servers.remote-dmr.add=Adds a remote DMR managed 
 hawkular-wildfly-agent.managed-servers.remote-dmr.remove=Removes a remote DMR managed server
 hawkular-wildfly-agent.managed-servers.remote-dmr.name=A name this agent will assign to the remote application server
 hawkular-wildfly-agent.managed-servers.remote-dmr.enabled=True if you want to monitor the resources hosted in this server
+hawkular-wildfly-agent.managed-servers.remote-dmr.protocol=If specified, the protocol to use to connect where the remote application server management interface is listening. For example "remote". This ignores the value of use-ssl. If not specified, the default is "http-remoting" unless use-ssl is true in which case the default is "https-remoting".
 hawkular-wildfly-agent.managed-servers.remote-dmr.host=The host where the remote application server management interface is listening on
 hawkular-wildfly-agent.managed-servers.remote-dmr.port=The port where the remote application server management interface is listening to
 hawkular-wildfly-agent.managed-servers.remote-dmr.username=Name of the management user that can connect to the application server management interface

--- a/hawkular-wildfly-agent/src/main/resources/schema/hawkular-agent-monitor-subsystem.xsd
+++ b/hawkular-wildfly-agent/src/main/resources/schema/hawkular-agent-monitor-subsystem.xsd
@@ -232,6 +232,7 @@
   <xs:complexType name="remoteDmrType">
     <xs:attribute name="name"                  type="xs:string" use="required"/>
     <xs:attribute name="enabled"               type="xs:boolean"/>
+    <xs:attribute name="protocol"              type="xs:string"/>
     <xs:attribute name="host"                  type="xs:string" use="required"/>
     <xs:attribute name="port"                  type="xs:int"    use="required"/>
     <xs:attribute name="username"              type="xs:string"/>


### PR DESCRIPTION
With this change I was able to use a remote-dmr tag to monitor an EAP6 (as hawkular wildfly agent won't run on an EAP6 due the use of Wildfly libs).

`protocol` has to be 'remote'
i.e.
```xml
<remote-dmr enabled="true" name="remote-eap6" protocol="remote" host="localhost" port="10999" username="jdoe" password="password1." resource-type-sets="Standalone Environment,Deployment,Web Component,EJB,Datasource,XA Datasource,JDBC Driver,Transaction Manager,Messaging,Socket Binding Group,Clustering,Hawkular"/>
```

![screenshot from 2016-11-14 18-00-28](https://cloud.githubusercontent.com/assets/3845764/20288030/10639f3c-aa96-11e6-8239-4c6f4e05ae21.png)


I'm not sure if is OK to ignore use-ssl attribute when using protocol.

