### PR TITLE
[WIP] Migrating agent to use jboss-as compatible API

### DIFF
--- a/hawkular-wildfly-agent-feature-pack/src/main/resources/modules/system/add-ons/hawkular-agent/org/hawkular/agent/main/module.xml
+++ b/hawkular-wildfly-agent-feature-pack/src/main/resources/modules/system/add-ons/hawkular-agent/org/hawkular/agent/main/module.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+    Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -72,6 +72,12 @@
     <artifact name="${httpmime}" />
      -->
 
+    <!-- EAP6 -->
+    <artifact name="${com.fasterxml.jackson.core:jackson-core}"/>
+    <artifact name="${com.fasterxml.jackson.core:jackson-databind}"/>
+    <artifact name="${com.fasterxml.jackson.core:jackson-annotations}"/>
+    <artifact name="${org.glassfish:javax.json}"/>
+
   </resources>
 
   <dependencies>
@@ -96,11 +102,12 @@
     <module name="org.jboss.logmanager" services="import"/>
     <module name="org.jboss.threads"/>
     <module name="org.slf4j"/>
-    <module name="org.wildfly.security.manager"/>
+    <!-- <module name="org.wildfly.security.manager"/> --> <!-- Not included with EAP6 -->
     <module name="sun.jdk"/> <!-- codahale needs sun.misc.Unsafe -->
-    <module name="com.fasterxml.jackson.core.jackson-core"/>
-    <module name="com.fasterxml.jackson.core.jackson-databind"/>
-    <module name="com.fasterxml.jackson.core.jackson-annotations"/>
+    <!-- Not included with EAP6 -->
+    <!-- <module name="com.fasterxml.jackson.core.jackson-core"/> -->
+    <!-- <module name="com.fasterxml.jackson.core.jackson-databind"/> -->
+    <!-- <module name="com.fasterxml.jackson.core.jackson-annotations"/> -->
 
     <system export="true">
       <paths>

--- a/hawkular-wildfly-agent/pom.xml
+++ b/hawkular-wildfly-agent/pom.xml
@@ -35,17 +35,20 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.glassfish</groupId>
+      <artifactId>javax.json</artifactId>
+      <version>1.0.4</version>
     </dependency>
 
     <dependency>
@@ -113,6 +116,12 @@
     <dependency>
       <groupId>org.jboss.logging</groupId>
       <artifactId>jboss-logging</artifactId>
+      <!-- We need to hardcode this version to ensure that calls like LOG.debugf("x", 1) don't link to
+      void debugf(String format, int arg);
+      Thus breaking compatibility with EAP6 which doesn't have said method.
+      Instead we use 3.1.4.GA to ensure it uses void debugf(String format, Object param1); which is provided
+      on both EAP6 and EAP7 see: https://github.com/hawkular/hawkular-agent/pull/271#discussion_r97190787 -->
+      <version>3.1.4.GA</version>
       <scope>provided</scope>
     </dependency>
 

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/cmd/StatisticsControlCommand.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/cmd/StatisticsControlCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,6 +31,7 @@ import org.hawkular.agent.monitor.log.MsgLogger;
 import org.hawkular.agent.monitor.protocol.EndpointService;
 import org.hawkular.agent.monitor.protocol.dmr.DMRNodeLocation;
 import org.hawkular.agent.monitor.protocol.dmr.DMRSession;
+import org.hawkular.agent.monitor.util.WildflyCompatibilityUtils;
 import org.hawkular.bus.common.BasicMessageWithExtraData;
 import org.hawkular.bus.common.BinaryData;
 import org.hawkular.cmdgw.api.MessageUtils;
@@ -105,22 +106,22 @@ public class StatisticsControlCommand
 
         if (datasources.isPresent()) {
             somethingToDo = true;
-            List<String> dsList = getChildrenNames(PathAddress.parseCLIStyleAddress("/subsystem=datasources"),
+            List<String> dsList = getChildrenNames(WildflyCompatibilityUtils.parseCLIStyleAddress("/subsystem=datasources"),
                     "data-source", controllerClient);
-            List<String> xaList = getChildrenNames(PathAddress.parseCLIStyleAddress("/subsystem=datasources"),
+            List<String> xaList = getChildrenNames(WildflyCompatibilityUtils.parseCLIStyleAddress("/subsystem=datasources"),
                     "xa-data-source", controllerClient);
 
             for (String ds : dsList) {
                 String dsAddr = String.format("/subsystem=datasources/data-source=%s", ds);
                 batch.writeAttribute()
-                        .address(PathAddress.parseCLIStyleAddress(dsAddr))
+                        .address(WildflyCompatibilityUtils.parseCLIStyleAddress(dsAddr))
                         .attribute("statistics-enabled", datasources.get().toString())
                         .parentBuilder();
             }
             for (String xa : xaList) {
                 String xaAddr = String.format("/subsystem=datasources/xa-data-source=%s", xa);
                 batch.writeAttribute()
-                        .address(PathAddress.parseCLIStyleAddress(xaAddr))
+                        .address(WildflyCompatibilityUtils.parseCLIStyleAddress(xaAddr))
                         .attribute("statistics-enabled", datasources.get().toString())
                         .parentBuilder();
             }
@@ -129,20 +130,20 @@ public class StatisticsControlCommand
         if (ejb3.isPresent()) {
             somethingToDo = true;
             batch.writeAttribute()
-                    .address(PathAddress.parseCLIStyleAddress("/subsystem=ejb3"))
+                    .address(WildflyCompatibilityUtils.parseCLIStyleAddress("/subsystem=ejb3"))
                     .attribute("enable-statistics", ejb3.get().toString())
                     .parentBuilder();
         }
 
         if (infinispan.isPresent()) {
             somethingToDo = true;
-            List<String> list = getChildrenNames(PathAddress.parseCLIStyleAddress("/subsystem=infinispan"),
+            List<String> list = getChildrenNames(WildflyCompatibilityUtils.parseCLIStyleAddress("/subsystem=infinispan"),
                     "cache-container", controllerClient);
 
             for (String name : list) {
                 String addr = String.format("/subsystem=infinispan/cache-container=%s", name);
                 batch.writeAttribute()
-                        .address(PathAddress.parseCLIStyleAddress(addr))
+                        .address(WildflyCompatibilityUtils.parseCLIStyleAddress(addr))
                         .attribute("statistics-enabled", infinispan.get().toString())
                         .parentBuilder();
             }
@@ -150,13 +151,13 @@ public class StatisticsControlCommand
 
         if (messaging.isPresent()) {
             somethingToDo = true;
-            List<String> list = getChildrenNames(PathAddress.parseCLIStyleAddress("/subsystem=messaging-activemq"),
+            List<String> list = getChildrenNames(WildflyCompatibilityUtils.parseCLIStyleAddress("/subsystem=messaging-activemq"),
                     "server", controllerClient);
 
             for (String name : list) {
                 String addr = String.format("/subsystem=messaging-activemq/server=%s", name);
                 batch.writeAttribute()
-                        .address(PathAddress.parseCLIStyleAddress(addr))
+                        .address(WildflyCompatibilityUtils.parseCLIStyleAddress(addr))
                         .attribute("statistics-enabled", messaging.get().toString())
                         .parentBuilder();
             }
@@ -165,7 +166,7 @@ public class StatisticsControlCommand
         if (transactions.isPresent()) {
             somethingToDo = true;
             batch.writeAttribute()
-                    .address(PathAddress.parseCLIStyleAddress("/subsystem=transactions"))
+                    .address(WildflyCompatibilityUtils.parseCLIStyleAddress("/subsystem=transactions"))
                     .attribute("enable-statistics", transactions.get().toString())
                     .parentBuilder();
         }
@@ -173,7 +174,7 @@ public class StatisticsControlCommand
         if (web.isPresent()) {
             somethingToDo = true;
             batch.writeAttribute()
-                    .address(PathAddress.parseCLIStyleAddress("/subsystem=undertow"))
+                    .address(WildflyCompatibilityUtils.parseCLIStyleAddress("/subsystem=undertow"))
                     .attribute("statistics-enabled", web.get().toString())
                     .parentBuilder();
         }
@@ -255,7 +256,7 @@ public class StatisticsControlCommand
 
         try {
             ModelNode result = new OperationBuilder().readAttribute()
-                    .address(PathAddress.parseCLIStyleAddress(addr))
+                    .address(WildflyCompatibilityUtils.parseCLIStyleAddress(addr))
                     .name(attribName)
                     .execute(controllerClient)
                     .assertSuccess()

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalDMRAdd.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalDMRAdd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,6 +25,7 @@ import org.hawkular.agent.monitor.protocol.dmr.DMRNodeLocation;
 import org.hawkular.agent.monitor.protocol.dmr.DMRSession;
 import org.hawkular.agent.monitor.service.MonitorService;
 import org.hawkular.agent.monitor.util.Util;
+import org.hawkular.agent.monitor.util.WildflyCompatibilityUtils;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.dmr.ModelNode;
@@ -41,7 +42,6 @@ public class LocalDMRAdd extends MonitorServiceAddStepHandler {
     @Override
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model)
             throws OperationFailedException {
-
         if (context.isBooting()) {
             return;
         }
@@ -57,7 +57,7 @@ public class LocalDMRAdd extends MonitorServiceAddStepHandler {
         ProtocolServices newServices = monitorService.createProtocolServicesBuilder().dmrProtocolService(
                 monitorService.getLocalModelControllerClientFactory(), config.getDmrConfiguration()).build();
         EndpointService<DMRNodeLocation, DMRSession> endpointService = newServices.getDmrProtocolService()
-                .getEndpointServices().get(context.getCurrentAddressValue());
+                .getEndpointServices().get(WildflyCompatibilityUtils.getCurrentAddressValue(context, operation));
 
         // put the new endpoint service in the original protocol services container
         ProtocolService<DMRNodeLocation, DMRSession> dmrService = monitorService.getProtocolServices()

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalDMRDefinition.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalDMRDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,6 +27,7 @@ import org.hawkular.agent.monitor.protocol.dmr.DMRSession;
 import org.hawkular.agent.monitor.scheduler.SchedulerService;
 import org.hawkular.agent.monitor.service.MonitorService;
 import org.hawkular.agent.monitor.util.Util;
+import org.hawkular.agent.monitor.util.WildflyCompatibilityUtils;
 import org.jboss.as.controller.AbstractWriteAttributeHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
@@ -91,7 +92,7 @@ public class LocalDMRDefinition extends PersistentResourceDefinition {
 
                         ProtocolService<DMRNodeLocation, DMRSession> dmrService = monitorService.getProtocolServices()
                                 .getDmrProtocolService();
-                        String thisEndpointName = context.getCurrentAddressValue();
+                        String thisEndpointName = WildflyCompatibilityUtils.getCurrentAddressValue(context, operation);
 
                         if (newBool) {
                             // add the endpoint so it begins to be monitored

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalDMRRemove.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalDMRRemove.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +19,7 @@ package org.hawkular.agent.monitor.extension;
 import org.hawkular.agent.monitor.protocol.ProtocolService;
 import org.hawkular.agent.monitor.scheduler.SchedulerService;
 import org.hawkular.agent.monitor.service.MonitorService;
+import org.hawkular.agent.monitor.util.WildflyCompatibilityUtils;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.dmr.ModelNode;
@@ -45,7 +46,7 @@ public class LocalDMRRemove extends MonitorServiceRemoveStepHandler {
 
         SchedulerService schedulerService = monitorService.getSchedulerService();
         ProtocolService<?, ?> dmrService = monitorService.getProtocolServices().getDmrProtocolService();
-        String doomedEndpointName = context.getCurrentAddressValue();
+        String doomedEndpointName = WildflyCompatibilityUtils.getCurrentAddressValue(context, operation);
         dmrService.remove(doomedEndpointName, schedulerService);
     }
 }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/MonitorServiceAddStepHandler.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/MonitorServiceAddStepHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,7 +17,7 @@
 package org.hawkular.agent.monitor.extension;
 
 import org.hawkular.agent.monitor.service.MonitorService;
-import org.jboss.as.controller.AbstractAddStepHandler;
+import org.hawkular.agent.monitor.util.WildflyCompatibilityUtils;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.msc.service.ServiceName;
@@ -27,7 +27,7 @@ import org.jboss.msc.service.ServiceRegistry;
  * Base class to any add-step handler that requires common functionality like a method
  * to obtain the service.
  */
-public abstract class MonitorServiceAddStepHandler extends AbstractAddStepHandler {
+public abstract class MonitorServiceAddStepHandler extends WildflyCompatibilityUtils.AbstractAddStepHandler {
 
     public MonitorServiceAddStepHandler(AttributeDefinition... attributes) {
         super(attributes);
@@ -39,4 +39,5 @@ public abstract class MonitorServiceAddStepHandler extends AbstractAddStepHandle
         MonitorService service = (MonitorService) serviceRegistry.getRequiredService(name).getValue();
         return service;
     }
+
 }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/MonitorServiceConfigurationBuilder.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/MonitorServiceConfigurationBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -63,6 +63,7 @@ import org.hawkular.agent.monitor.protocol.platform.Constants.PlatformMetricType
 import org.hawkular.agent.monitor.protocol.platform.Constants.PlatformResourceType;
 import org.hawkular.agent.monitor.protocol.platform.PlatformNodeLocation;
 import org.hawkular.agent.monitor.protocol.platform.PlatformPath;
+import org.hawkular.agent.monitor.util.WildflyCompatibilityUtils;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
@@ -1340,7 +1341,7 @@ public class MonitorServiceConfigurationBuilder {
         } else if ("/".equals(path)) {
             return PathAddress.EMPTY_ADDRESS;
         } else {
-            return PathAddress.parseCLIStyleAddress(path);
+            return WildflyCompatibilityUtils.parseCLIStyleAddress(path);
         }
     }
 

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/PlatformAdd.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/PlatformAdd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,6 +23,7 @@ import org.hawkular.agent.monitor.protocol.platform.PlatformNodeLocation;
 import org.hawkular.agent.monitor.protocol.platform.PlatformSession;
 import org.hawkular.agent.monitor.service.MonitorService;
 import org.hawkular.agent.monitor.util.Util;
+import org.hawkular.agent.monitor.util.WildflyCompatibilityUtils;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.dmr.ModelNode;
@@ -38,7 +39,6 @@ public class PlatformAdd extends MonitorServiceAddStepHandler {
     @Override
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model)
             throws OperationFailedException {
-
         if (context.isBooting()) {
             return;
         }
@@ -54,7 +54,7 @@ public class PlatformAdd extends MonitorServiceAddStepHandler {
         ProtocolServices newServices = monitorService.createProtocolServicesBuilder()
                 .platformProtocolService(config.getPlatformConfiguration()).build();
         EndpointService<PlatformNodeLocation, PlatformSession> endpointService = newServices
-                .getPlatformProtocolService().getEndpointServices().get(context.getCurrentAddressValue());
+                .getPlatformProtocolService().getEndpointServices().get(WildflyCompatibilityUtils.getCurrentAddressValue(context, operation));
 
         // put the new endpoint service in the original protocol services container
         ProtocolService<PlatformNodeLocation, PlatformSession> platformService = monitorService.getProtocolServices()

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/PlatformDefinition.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/PlatformDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,6 +28,7 @@ import org.hawkular.agent.monitor.protocol.platform.PlatformSession;
 import org.hawkular.agent.monitor.scheduler.SchedulerService;
 import org.hawkular.agent.monitor.service.MonitorService;
 import org.hawkular.agent.monitor.util.Util;
+import org.hawkular.agent.monitor.util.WildflyCompatibilityUtils;
 import org.jboss.as.controller.AbstractWriteAttributeHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
@@ -97,7 +98,7 @@ public class PlatformDefinition extends PersistentResourceDefinition {
 
                         ProtocolService<PlatformNodeLocation, PlatformSession> platformService = monitorService
                                 .getProtocolServices().getPlatformProtocolService();
-                        String thisEndpointName = context.getCurrentAddressValue();
+                        String thisEndpointName = WildflyCompatibilityUtils.getCurrentAddressValue(context, operation);
 
                         if (newBool) {
                             // add the endpoint so it begins to be monitored

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/PlatformRemove.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/PlatformRemove.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +19,7 @@ package org.hawkular.agent.monitor.extension;
 import org.hawkular.agent.monitor.protocol.ProtocolService;
 import org.hawkular.agent.monitor.scheduler.SchedulerService;
 import org.hawkular.agent.monitor.service.MonitorService;
+import org.hawkular.agent.monitor.util.WildflyCompatibilityUtils;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.dmr.ModelNode;
@@ -45,7 +46,7 @@ public class PlatformRemove extends MonitorServiceRemoveStepHandler {
 
         SchedulerService schedulerService = monitorService.getSchedulerService();
         ProtocolService<?, ?> platformService = monitorService.getProtocolServices().getPlatformProtocolService();
-        String doomedEndpointName = context.getCurrentAddressValue();
+        String doomedEndpointName = WildflyCompatibilityUtils.getCurrentAddressValue(context, operation);
         platformService.remove(doomedEndpointName, schedulerService);
     }
 }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteDMRAdd.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteDMRAdd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,6 +26,7 @@ import org.hawkular.agent.monitor.protocol.dmr.DMRNodeLocation;
 import org.hawkular.agent.monitor.protocol.dmr.DMRSession;
 import org.hawkular.agent.monitor.service.MonitorService;
 import org.hawkular.agent.monitor.util.Util;
+import org.hawkular.agent.monitor.util.WildflyCompatibilityUtils;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.dmr.ModelNode;
@@ -42,7 +43,6 @@ public class RemoteDMRAdd extends MonitorServiceAddStepHandler {
     @Override
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model)
             throws OperationFailedException {
-
         if (context.isBooting()) {
             return;
         }
@@ -53,7 +53,7 @@ public class RemoteDMRAdd extends MonitorServiceAddStepHandler {
         }
 
         MonitorServiceConfiguration config = Util.getMonitorServiceConfiguration(context);
-        String newEndpointName = context.getCurrentAddressValue();
+        String newEndpointName = WildflyCompatibilityUtils.getCurrentAddressValue(context, operation);
 
         // Register the feed under the tenant of the new managed server.
         // If endpoint has a null tenant then there is nothing to do since it will just reuse the agent's tenant ID

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteDMRDefinition.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteDMRDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,6 +27,7 @@ import org.hawkular.agent.monitor.protocol.dmr.DMRSession;
 import org.hawkular.agent.monitor.scheduler.SchedulerService;
 import org.hawkular.agent.monitor.service.MonitorService;
 import org.hawkular.agent.monitor.util.Util;
+import org.hawkular.agent.monitor.util.WildflyCompatibilityUtils;
 import org.jboss.as.controller.AbstractWriteAttributeHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
@@ -91,7 +92,7 @@ public class RemoteDMRDefinition extends PersistentResourceDefinition {
 
                         ProtocolService<DMRNodeLocation, DMRSession> dmrService = monitorService.getProtocolServices()
                                 .getDmrProtocolService();
-                        String thisEndpointName = context.getCurrentAddressValue();
+                        String thisEndpointName = WildflyCompatibilityUtils.getCurrentAddressValue(context, operation);
 
                         if (newBool) {
                             // add the endpoint so it begins to be monitored

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteDMRRemove.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteDMRRemove.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +19,7 @@ package org.hawkular.agent.monitor.extension;
 import org.hawkular.agent.monitor.protocol.ProtocolService;
 import org.hawkular.agent.monitor.scheduler.SchedulerService;
 import org.hawkular.agent.monitor.service.MonitorService;
+import org.hawkular.agent.monitor.util.WildflyCompatibilityUtils;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.dmr.ModelNode;
@@ -45,7 +46,7 @@ public class RemoteDMRRemove extends MonitorServiceRemoveStepHandler {
 
         SchedulerService schedulerService = monitorService.getSchedulerService();
         ProtocolService<?, ?> dmrService = monitorService.getProtocolServices().getDmrProtocolService();
-        String doomedEndpointName = context.getCurrentAddressValue();
+        String doomedEndpointName = WildflyCompatibilityUtils.getCurrentAddressValue(context, operation);
         dmrService.remove(doomedEndpointName, schedulerService);
     }
 }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/SubsystemAdd.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/SubsystemAdd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,7 +19,7 @@ package org.hawkular.agent.monitor.extension;
 import org.hawkular.agent.monitor.log.AgentLoggers;
 import org.hawkular.agent.monitor.log.MsgLogger;
 import org.hawkular.agent.monitor.service.MonitorService;
-import org.jboss.as.controller.AbstractAddStepHandler;
+import org.hawkular.agent.monitor.util.WildflyCompatibilityUtils;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
@@ -30,7 +30,7 @@ import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceTarget;
 
-public class SubsystemAdd extends AbstractAddStepHandler {
+public class SubsystemAdd extends WildflyCompatibilityUtils.AbstractAddStepHandler {
     private static final MsgLogger log = AgentLoggers.getLogger(SubsystemAdd.class);
     static final SubsystemAdd INSTANCE = new SubsystemAdd();
 

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/SubsystemExtension.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/SubsystemExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,7 @@
  */
 package org.hawkular.agent.monitor.extension;
 
+import org.hawkular.agent.monitor.util.WildflyCompatibilityUtils;
 import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.ExtensionContext;
 import org.jboss.as.controller.SubsystemRegistration;
@@ -58,7 +59,7 @@ public class SubsystemExtension implements Extension {
                 MAJOR_VERSION, MINOR_VERSION, MICRO_VERSION);
 
         // This subsystem should be runnable on a host
-        subsystem.setHostCapable();
+        WildflyCompatibilityUtils.subsystemSetHostCapable(subsystem);
 
         final ManagementResourceRegistration registration = subsystem
                 .registerSubsystemModel(SubsystemDefinition.INSTANCE);

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/protocol/dmr/DMRNodeLocation.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/protocol/dmr/DMRNodeLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +17,7 @@
 package org.hawkular.agent.monitor.protocol.dmr;
 
 import org.hawkular.agent.monitor.inventory.NodeLocation;
+import org.hawkular.agent.monitor.util.WildflyCompatibilityUtils;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.dmr.ModelNode;
 
@@ -46,7 +47,7 @@ public class DMRNodeLocation implements NodeLocation {
 
     public static DMRNodeLocation of(String path, boolean resolveExpressions, boolean includeDefaults) {
         return new DMRNodeLocation(
-                "/".equals(path) ? PathAddress.EMPTY_ADDRESS : PathAddress.parseCLIStyleAddress(path),
+                "/".equals(path) ? PathAddress.EMPTY_ADDRESS : WildflyCompatibilityUtils.parseCLIStyleAddress(path),
                 resolveExpressions, includeDefaults);
     }
 

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/service/MonitorService.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/service/MonitorService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -73,6 +73,7 @@ import org.hawkular.agent.monitor.storage.InventoryStorageProxy;
 import org.hawkular.agent.monitor.storage.MetricStorageProxy;
 import org.hawkular.agent.monitor.storage.StorageAdapter;
 import org.hawkular.agent.monitor.util.Util;
+import org.hawkular.agent.monitor.util.WildflyCompatibilityUtils;
 import org.hawkular.inventory.api.model.Feed;
 import org.jboss.as.controller.ControlledProcessState;
 import org.jboss.as.controller.ControlledProcessStateService;
@@ -83,7 +84,6 @@ import org.jboss.as.domain.management.SecurityRealm;
 import org.jboss.as.domain.management.security.SSLContextService;
 import org.jboss.as.host.controller.DomainModelControllerService;
 import org.jboss.as.host.controller.HostControllerEnvironment;
-import org.jboss.as.naming.ImmediateManagedReferenceFactory;
 import org.jboss.as.naming.ManagedReferenceFactory;
 import org.jboss.as.naming.ServiceBasedNamingStore;
 import org.jboss.as.naming.deployment.ContextNames;
@@ -94,6 +94,7 @@ import org.jboss.as.server.ServerEnvironment;
 import org.jboss.as.server.ServerEnvironmentService;
 import org.jboss.as.server.Services;
 import org.jboss.logging.Logger;
+import org.jboss.msc.inject.Injector;
 import org.jboss.msc.service.AbstractServiceListener;
 import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceBuilder;
@@ -177,7 +178,8 @@ public class MonitorService implements Service<MonitorService> {
                         port = socketBinding.getAbsolutePort();
                     } else {
                         OutboundSocketBinding serverBinding = serverOutboundSocketBindingValue.getValue();
-                        address = serverBinding.getResolvedDestinationAddress().getHostName();
+                        address = WildflyCompatibilityUtils.
+                                outboundSocketBindingGetResolvedDestinationAddress(serverBinding).getHostName();
                         port = serverBinding.getDestinationPort();
                     }
                     String protocol = (bootStorageAdapter.isUseSSL()) ? "https" : "http";
@@ -407,16 +409,20 @@ public class MonitorService implements Service<MonitorService> {
             Object jndiObject = getHawkularMonitorContext();
             ContextNames.BindInfo bindInfo = ContextNames.bindInfoFor(jndiName);
             BinderService binderService = new BinderService(bindInfo.getBindName());
-            ManagedReferenceFactory valueMRF = new ImmediateManagedReferenceFactory(jndiObject);
+            Injector<ManagedReferenceFactory> managedObjectInjector =
+                    WildflyCompatibilityUtils.getManagedObjectInjectorFromBinderService(binderService);
+            Injector<ServiceBasedNamingStore> namingStoreInjector =
+                    WildflyCompatibilityUtils.getNamingStoreInjectorFromBinderService(binderService);
+            ManagedReferenceFactory valueMRF = WildflyCompatibilityUtils.getImmediateManagedReferenceFactory(jndiObject);
             String jndiObjectClassName = HawkularWildFlyAgentContext.class.getName();
             ServiceName binderServiceName = bindInfo.getBinderServiceName();
             ServiceBuilder<?> binderBuilder = target
                     .addService(binderServiceName, binderService)
-                    .addInjection(binderService.getManagedObjectInjector(), valueMRF)
+                    .addInjection(managedObjectInjector, valueMRF)
                     .setInitialMode(ServiceController.Mode.ACTIVE)
                     .addDependency(bindInfo.getParentContextServiceName(),
                             ServiceBasedNamingStore.class,
-                            binderService.getNamingStoreInjector())
+                            namingStoreInjector)
                     .addListener(new JndiBindListener(jndiName, jndiObjectClassName));
 
             // our monitor service will depend on the binder service

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/util/ThreadFactoryGenerator.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/util/ThreadFactoryGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,14 +16,10 @@
  */
 package org.hawkular.agent.monitor.util;
 
-import static java.security.AccessController.doPrivileged;
-
 import java.lang.Thread.UncaughtExceptionHandler;
-import java.security.AccessControlContext;
 import java.util.concurrent.ThreadFactory;
 
 import org.jboss.threads.JBossThreadFactory;
-import org.wildfly.security.manager.action.GetAccessControlContextAction;
 
 /**
  * @author John Mazzitelli
@@ -34,7 +30,6 @@ public class ThreadFactoryGenerator {
         UncaughtExceptionHandler uncaughtExceptionHandler = null;
         Integer initialPriority = null;
         Long stackSize = null;
-        AccessControlContext acc = doPrivileged(GetAccessControlContextAction.getInstance());
         return new JBossThreadFactory(
                 new ThreadGroup(threadGroupName),
                 daemon,
@@ -42,6 +37,7 @@ public class ThreadFactoryGenerator {
                 namePattern,
                 uncaughtExceptionHandler,
                 stackSize,
-                acc);
+                null); // this last param is ignored according to docs.
+        // see: https://github.com/jbossas/jboss-threads/blob/2.2/src/main/java/org/jboss/threads/JBossThreadFactory.java#L90
     }
 }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/util/WildflyCompatibilityUtils.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/util/WildflyCompatibilityUtils.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.agent.monitor.util;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.List;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.ServiceVerificationHandler;
+import org.jboss.as.controller.SubsystemRegistration;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.naming.ImmediateManagedReferenceFactory;
+import org.jboss.as.naming.ManagedReference;
+import org.jboss.as.naming.ManagedReferenceFactory;
+import org.jboss.as.naming.ServiceBasedNamingStore;
+import org.jboss.as.naming.service.BinderService;
+import org.jboss.as.network.OutboundSocketBinding;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.inject.Injector;
+import org.jboss.msc.service.ServiceController;
+
+public class WildflyCompatibilityUtils {
+
+    public static InetAddress outboundSocketBindingGetResolvedDestinationAddress(OutboundSocketBinding serverBinding)
+            throws UnknownHostException {
+        try {
+            return serverBinding.getResolvedDestinationAddress();
+        } catch (NoSuchMethodError _nsme) {
+            // When using jboss-as we need to use the now deprecated getDestinationAddress
+            return serverBinding.getDestinationAddress();
+        }
+    }
+
+    public static void subsystemSetHostCapable(SubsystemRegistration subsystem) {
+        try {
+            subsystem.setHostCapable();
+        } catch (NoSuchMethodError _nsme) {
+            // This method doesn't exist on jboss-as
+            // We should detect if we are running on domain mode and warn that we can not
+            // use hawkular-agent on domain mode
+        }
+    }
+
+    public static ManagedReferenceFactory getImmediateManagedReferenceFactory(Object jndiObject) {
+        try {
+            return new ImmediateManagedReferenceFactory(jndiObject);
+        } catch (NoClassDefFoundError _ncdfe) {
+            // This class does not exist on jboss-as.
+            return new EAP6ImmediateManagedReferenceFactory(jndiObject);
+        }
+    }
+
+    public static Injector<ManagedReferenceFactory> getManagedObjectInjectorFromBinderService(BinderService binderService) {
+        try {
+            return binderService.getManagedObjectInjector();
+        } catch (NoSuchMethodError _nsme) {
+            // Since wildfly it returns a InjectedValue<*> (which is still an Injector<*>)
+            // but the runtime (when running jboss-as) excepts a method that returns the first.
+            // Use reflection to fetch it.
+            try {
+                Method getManagedObjectInjectorMethod = BinderService.class.getMethod("getManagedObjectInjector");
+                return (Injector<ManagedReferenceFactory>) getManagedObjectInjectorMethod.invoke(binderService);
+            } catch (NoSuchMethodException e) {
+                throw new RuntimeException(e);
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException(e);
+            } catch (InvocationTargetException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    public static Injector<ServiceBasedNamingStore> getNamingStoreInjectorFromBinderService(BinderService binderService) {
+        try {
+            return binderService.getNamingStoreInjector();
+        } catch (NoSuchMethodError _nsme) {
+            // See getManagedObjectInjectorFromBinderService comment on this exception for details.
+            try {
+                Method getManagedObjectInjectorMethod = BinderService.class.getMethod("getNamingStoreInjector");
+                return (Injector<ServiceBasedNamingStore>) getManagedObjectInjectorMethod.invoke(binderService);
+            } catch (NoSuchMethodException e) {
+                throw new RuntimeException(e);
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException(e);
+            } catch (InvocationTargetException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    /**
+     * PathAddress methods found on wildfly-core
+     * https://github.com/wildfly/wildfly-core/blob/588145a00ca5ed3beb0027f8f44be87db6689db3/controller/src/main/java/org/jboss/as/controller/PathAddress.java
+     */
+    public static PathAddress parseCLIStyleAddress(String address) throws IllegalArgumentException {
+        try {
+            return PathAddress.parseCLIStyleAddress(address);
+        } catch (NoSuchMethodError _nsme) {
+            // jboss-as doesn't have parseCLIStyleAddress
+            // Ignore the error and use the provided alternative
+            return _parseCLIStyleAddress(address);
+        }
+    }
+
+    private static PathAddress _parseCLIStyleAddress(String address) throws IllegalArgumentException {
+        PathAddress parsedAddress = PathAddress.EMPTY_ADDRESS;
+        if (address == null || address.trim().isEmpty()) {
+            return parsedAddress;
+        }
+        String trimmedAddress = address.trim();
+        if (trimmedAddress.charAt(0) != '/' || !Character.isAlphabetic(trimmedAddress.charAt(1))) {
+            // https://github.com/wildfly/wildfly-core/blob/588145a00ca5ed3beb0027f8f44be87db6689db3/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java#L3296-L3297
+            throw new IllegalArgumentException(
+                    "Illegal path address '" + address + "' , it is not in a correct CLI format");
+        }
+        char[] characters = address.toCharArray();
+        boolean escaped = false;
+        StringBuilder keyBuffer = new StringBuilder();
+        StringBuilder valueBuffer = new StringBuilder();
+        StringBuilder currentBuffer = keyBuffer;
+        for (int i = 1; i < characters.length; i++) {
+            switch (characters[i]) {
+                case '/':
+                    if (escaped) {
+                        escaped = false;
+                        currentBuffer.append(characters[i]);
+                    } else {
+                        parsedAddress = addpathAddressElement(parsedAddress, address, keyBuffer, valueBuffer);
+                        keyBuffer = new StringBuilder();
+                        valueBuffer = new StringBuilder();
+                        currentBuffer = keyBuffer;
+                    }
+                    break;
+                case '\\':
+                    if (escaped) {
+                        escaped = false;
+                        currentBuffer.append(characters[i]);
+                    } else {
+                        escaped = true;
+                    }
+                    break;
+                case '=':
+                    if (escaped) {
+                        escaped = false;
+                        currentBuffer.append(characters[i]);
+                    } else {
+                        currentBuffer = valueBuffer;
+                    }
+                    break;
+                default:
+                    currentBuffer.append(characters[i]);
+                    break;
+            }
+        }
+        parsedAddress = addpathAddressElement(parsedAddress, address, keyBuffer, valueBuffer);
+        return parsedAddress;
+    }
+
+    private static PathAddress addpathAddressElement(PathAddress parsedAddress, String address, StringBuilder keyBuffer, StringBuilder valueBuffer) {
+        if (keyBuffer.length() > 0) {
+            if (valueBuffer.length() > 0) {
+                return parsedAddress.append(PathElement.pathElement(keyBuffer.toString(), valueBuffer.toString()));
+            }
+            // https://github.com/wildfly/wildfly-core/blob/588145a00ca5ed3beb0027f8f44be87db6689db3/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java#L3296-L3297
+            throw new IllegalArgumentException(
+                    "Illegal path address '" + address + "' , it is not in a correct CLI format");
+        }
+        return parsedAddress;
+    }
+
+    public static String getCurrentAddressValue(OperationContext context, ModelNode operation) {
+        try {
+            return context.getCurrentAddressValue();
+        } catch (NoSuchMethodError _nsme) {
+            return PathAddress.pathAddress(
+                    operation.require(ModelDescriptionConstants.OP_ADDR)
+            ).getLastElement().getValue();
+        }
+    }
+
+    /**
+     * ManagedReferenceFactory based on:
+     * https://github.com/wildfly/wildfly/blob/c6f48cac0710457d9374eb24cc82093899bdd7bf/naming/src/main/java/org/jboss/as/naming/ImmediateManagedReferenceFactory.java
+     */
+    private static class EAP6ImmediateManagedReferenceFactory implements ManagedReferenceFactory {
+        private final ManagedReference reference;
+
+        public EAP6ImmediateManagedReferenceFactory(final Object instance) {
+            this.reference = new EAP6ImmediateManagedReference(instance);
+        }
+
+        @Override
+        public ManagedReference getReference() {
+            return this.reference;
+        }
+    }
+
+    /**
+     * ManagedReference based on:
+     * https://github.com/wildfly/wildfly/blob/2b6526250242810b9075c3dc79c5f06e6ea8cfe4/naming/src/main/java/org/jboss/as/naming/ImmediateManagedReference.java
+     */
+    private static class EAP6ImmediateManagedReference implements ManagedReference {
+        private final Object instance;
+
+        public EAP6ImmediateManagedReference(final Object instance) {
+            this.instance = instance;
+        }
+
+        @Override
+        public void release() {
+
+        }
+
+        @Override
+        public Object getInstance() {
+            return this.instance;
+        }
+    }
+
+    public static class AbstractAddStepHandler extends org.jboss.as.controller.AbstractAddStepHandler {
+
+        public AbstractAddStepHandler(AttributeDefinition... attributes) {
+            super(attributes);
+        }
+
+        @Override
+        protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model,
+                                      ServiceVerificationHandler verificationHandler,
+                                      List<ServiceController<?>> newControllers) throws OperationFailedException {
+            performRuntime(context, operation, model);
+        }
+
+        @Override
+        protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model)
+                throws OperationFailedException {
+        }
+    }
+}

--- a/hawkular-wildfly-agent/src/test/java/org/hawkular/agent/monitor/inventory/ResourceTypeManagerTest.java
+++ b/hawkular-wildfly-agent/src/test/java/org/hawkular/agent/monitor/inventory/ResourceTypeManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,7 +24,7 @@ import java.util.Set;
 
 import org.hawkular.agent.monitor.inventory.TypeSet.TypeSetBuilder;
 import org.hawkular.agent.monitor.protocol.dmr.DMRNodeLocation;
-import org.jboss.as.controller.PathAddress;
+import org.hawkular.agent.monitor.util.WildflyCompatibilityUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -291,7 +291,7 @@ public class ResourceTypeManagerTest {
                 .id(new ID(name)) //
                 .name(new Name(name)) //
                 .resourceNameTemplate(name) //
-                .location(new DMRNodeLocation(PathAddress.parseCLIStyleAddress(path))) //
+                .location(new DMRNodeLocation(WildflyCompatibilityUtils.parseCLIStyleAddress(path))) //
                 .parents(Arrays.asList(parents)) //
                 .build();
     }

--- a/hawkular-wildfly-agent/src/test/java/org/hawkular/agent/monitor/protocol/LocationResolverTest.java
+++ b/hawkular-wildfly-agent/src/test/java/org/hawkular/agent/monitor/protocol/LocationResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,7 +26,7 @@ import org.hawkular.agent.monitor.protocol.platform.Constants;
 import org.hawkular.agent.monitor.protocol.platform.PlatformLocationResolver;
 import org.hawkular.agent.monitor.protocol.platform.PlatformNodeLocation;
 import org.hawkular.agent.monitor.protocol.platform.PlatformPath;
-import org.jboss.as.controller.PathAddress;
+import org.hawkular.agent.monitor.util.WildflyCompatibilityUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -35,14 +35,14 @@ public class LocationResolverTest {
     @Test
     public void testFindWildcardMatchDMR() throws Exception {
         DMRNodeLocation multiTargetLocation = new DMRNodeLocation(
-                PathAddress.parseCLIStyleAddress("/subsystem=datasources/data-source=DS/connection-properties=*"));
+                WildflyCompatibilityUtils.parseCLIStyleAddress("/subsystem=datasources/data-source=DS/connection-properties=*"));
         DMRNodeLocation singleLocation = new DMRNodeLocation(
-                PathAddress.parseCLIStyleAddress("/subsystem=datasources/data-source=DS/connection-properties=foo"));
+                WildflyCompatibilityUtils.parseCLIStyleAddress("/subsystem=datasources/data-source=DS/connection-properties=foo"));
         DMRLocationResolver resolver = new DMRLocationResolver();
         Assert.assertEquals("foo", resolver.findWildcardMatch(multiTargetLocation, singleLocation));
 
         singleLocation = new DMRNodeLocation(
-                PathAddress.parseCLIStyleAddress("/subsystem=datasources/data-source=DS"));
+                WildflyCompatibilityUtils.parseCLIStyleAddress("/subsystem=datasources/data-source=DS"));
         try {
             resolver.findWildcardMatch(multiTargetLocation, singleLocation);
             Assert.fail("Single location was missing 'connection-properties' key - should have failed");
@@ -50,7 +50,7 @@ public class LocationResolverTest {
         }
 
         singleLocation = new DMRNodeLocation(
-                PathAddress.parseCLIStyleAddress("/subsystem=datasources/data-source=DS/not-what-we-want=foo"));
+                WildflyCompatibilityUtils.parseCLIStyleAddress("/subsystem=datasources/data-source=DS/not-what-we-want=foo"));
         try {
             resolver.findWildcardMatch(multiTargetLocation, singleLocation);
             Assert.fail("Single location was missing 'connection-properties' key - should have failed");


### PR DESCRIPTION
This is work in progress.

- [x] Have it running on an EAP6 standalone.
- [x] Test it on EAP7
- [x] Find replacement for `PathAddress.parseCLIStyleAddress()`
   - Had to create a new class `PathAddressExtension` with a copy of the wildfly methods with minor modification (see comments in code)
- [x] Find replacement for `OperationContext.getCurrentAddressValue()`
- [x] ~~Fix tests POMs that are complaining about not able to resolve:~~
- [x] Migrate other org.wildfly dependencies (from hawkular-dmr-client)
- [x] Use reflection to call `subsystem.setHostCapable();`
- [ ] Test it and see what else might fail (and update this list).
- [x] ~~Downgrade dependencies to match EAP6~~ 
  - Downgraded but had some issues, it seems easier to build against wildfly.
- [x] Check about the NosuchMethodException  https://github.com/hawkular/hawkular-agent/pull/271#issuecomment-264224063
- [x] Use EAP7 API if running on an EAP7-based instance.
- [x] enable JNDI stuff
- [ ] Look into supporting expressions.
  - To do so, I would need to first fetch the expresion, and then request a :resolve-expression operation on the server/domain, depending the context.
- [ ] Squash / tidy up the commits