### PR TITLE
Local JMX managed server

### DIFF
--- a/hawkular-swarm-agents/hawkular-swarm-agent-dists/hawkular-swarm-agent-dist/src/main/resources/hawkular-swarm-agent-config.xml
+++ b/hawkular-swarm-agents/hawkular-swarm-agent-dists/hawkular-swarm-agent-dist/src/main/resources/hawkular-swarm-agent-config.xml
@@ -691,7 +691,7 @@
             <param name="restart" type="bool"   default-value="false" description="Should the server be restarted after shutdown?"/>
           </operation-dmr>
           <operation-dmr name="Suspend"  internal-name="suspend">
-            <param name="timemout" type="int" description="Timeout in seconds to allow active connections to drain"/>
+            <param name="timeout" type="int" default-value="0" description="Timeout in seconds to allow active connections to drain"/>
           </operation-dmr>
           <operation-dmr name="Deploy"             internal-name="deploy"/>
           <operation-dmr name="Undeploy"           internal-name="undeploy"/>
@@ -1060,7 +1060,7 @@
         </resource-type-dmr>
       </resource-type-set-dmr>
 
-    <!-- JMX metadata for monitoring Jolokia-enabled applications -->
+      <!-- JMX metadata for monitoring Jolokia-enabled or local JMX applications -->
 
       <avail-set-jmx name="RuntimeAvailsJMX" enabled="true">
         <avail-jmx name="VM Avail"

--- a/hawkular-wildfly-agent-feature-pack/src/main/resources/subsystem-templates/hawkular-wildfly-agent.xml
+++ b/hawkular-wildfly-agent-feature-pack/src/main/resources/subsystem-templates/hawkular-wildfly-agent.xml
@@ -621,7 +621,7 @@
           <param name="restart" type="bool"   default-value="false" description="Should the server be restarted after shutdown?"/>
         </operation-dmr>
         <operation-dmr name="Suspend"  internal-name="suspend" >
-          <param name="timeout" type="int"    default-value="0"     description="Timeout in seconds to allow active connections to drain"/>
+          <param name="timeout" type="int" default-value="0" description="Timeout in seconds to allow active connections to drain"/>
         </operation-dmr>
         <operation-dmr name="Deploy"             internal-name="deploy"/>
         <operation-dmr name="Undeploy"           internal-name="undeploy"/>
@@ -990,6 +990,89 @@
       </resource-type-dmr>
     </resource-type-set-dmr>
 
+    <!-- JMX metadata for monitoring Jolokia-enabled or local JMX applications -->
+
+    <avail-set-jmx name="RuntimeAvailsJMX" enabled="true">
+      <avail-jmx name="VM Avail"
+                 interval="30"
+                 time-units="seconds"
+                 attribute="StartTime"
+                 up-regex="[0123456789]+" />
+    </avail-set-jmx>
+
+    <avail-set-jmx name="MemoryPoolAvailsJMX" enabled="true">
+      <avail-jmx name="Memory Pool Avail"
+                 interval="30"
+                 time-units="seconds"
+                 attribute="Valid"
+                 up-regex="[tT].*" />
+    </avail-set-jmx>
+
+    <metric-set-jmx name="RuntimeMetricsJMX" enabled="true">
+      <metric-jmx name="VM Uptime"
+                  interval="30"
+                  time-units="seconds"
+                  metric-units="milliseconds"
+                  attribute="Uptime" />
+      <metric-jmx name="Used Heap Memory"
+                  interval="30"
+                  time-units="seconds"
+                  metric-units="bytes"
+                  object-name="java.lang:type=Memory"
+                  attribute="HeapMemoryUsage#used" />
+      <metric-jmx name="Aggregate GC Collection Time"
+                  interval="30"
+                  time-units="seconds"
+                  metric-units="milliseconds"
+                  object-name="java.lang:type=GarbageCollector,name=*"
+                  attribute="CollectionTime" />
+    </metric-set-jmx>
+
+    <metric-set-jmx name="MemoryPoolMetricsJMX" enabled="true">
+      <metric-jmx name="Initial"
+                  interval="2"
+                  time-units="minutes"
+                  metric-units="bytes"
+                  attribute="Usage#init" />
+      <metric-jmx name="Used"
+                  interval="1"
+                  time-units="minutes"
+                  metric-units="bytes"
+                  attribute="Usage#used" />
+      <metric-jmx name="Committed"
+                  interval="1"
+                  time-units="minutes"
+                  metric-units="bytes"
+                  attribute="Usage#committed" />
+      <metric-jmx name="Max"
+                  interval="2"
+                  time-units="minutes"
+                  metric-units="bytes"
+                  attribute="Usage#max" />
+    </metric-set-jmx>
+
+    <resource-type-set-jmx name="MainJMX" enabled="true">
+      <resource-type-jmx name="Runtime MBean"
+                         resource-name-template="JMX [%_ManagedServerName%][%type%]"
+                         object-name="java.lang:type=Runtime"
+                         metric-sets="RuntimeMetricsJMX"
+                         avail-sets="RuntimeAvailsJMX" >
+        <resource-config-jmx name="OS Name" object-name="java.lang:type=OperatingSystem" attribute="Name" />
+        <resource-config-jmx name="Java VM Name" attribute="VmName" />
+      </resource-type-jmx>
+    </resource-type-set-jmx>
+
+    <resource-type-set-jmx name="MemoryPoolJMX" enabled="true">
+      <resource-type-jmx name="Memory Pool MBean"
+                         parents="Runtime MBean"
+                         resource-name-template="JMX [%_ManagedServerName%] %type% %name%"
+                         object-name="java.lang:type=MemoryPool,name=*"
+                         metric-sets="MemoryPoolMetricsJMX"
+                         avail-sets="MemoryPoolAvailsJMX" >
+        <resource-config-jmx name="Type" attribute="Type" />
+      </resource-type-jmx>
+    </resource-type-set-jmx>
+
     <managed-servers>
       <remote-dmr name="Another Remote Server"
                   enabled="false"
@@ -1002,6 +1085,11 @@
       <local-dmr name="Local"
                  enabled="true"
                  resource-type-sets="Standalone Environment,Deployment,Web Component,EJB,Datasource,XA Datasource,JDBC Driver,Transaction Manager,Messaging,Socket Binding Group,Clustering,Hawkular" />
+
+      <remote-jmx name="Remote JMX" enabled="false" resource-type-sets="MainJMX,MemoryPoolJMX" url="http://localhost:8080/jolokia-war"/>
+
+      <local-jmx name="Local JMX" enabled="false" resource-type-sets="MainJMX,MemoryPoolJMX" />
+
     </managed-servers>
 
     <platform enabled="true">

--- a/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-jmx-itest/pom.xml
+++ b/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-jmx-itest/pom.xml
@@ -1,0 +1,394 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.hawkular.agent</groupId>
+    <artifactId>hawkular-wildfly-agent-all-itests</artifactId>
+    <version>0.24.4.Final-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>hawkular-wildfly-agent-jmx-itest</artifactId>
+
+  <name>Hawkular Agent: JMX Integration Tests</name>
+  <description>A module containing JMX integration tests</description>
+
+  <properties>
+    <hawkular.test.deployment.dir>${project.build.directory}/${project.build.finalName}/standalone/deployments</hawkular.test.deployment.dir>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.squareup.okhttp</groupId>
+      <artifactId>okhttp-ws</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hawkular.agent</groupId>
+      <artifactId>hawkular-dmr-client</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hawkular.agent</groupId>
+      <artifactId>hawkular-wildfly-agent</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hawkular.agent</groupId>
+      <artifactId>hawkular-wildfly-agent-itest-util</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hawkular.commons</groupId>
+      <artifactId>hawkular-bus-common</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hawkular.commons</groupId>
+      <artifactId>hawkular-command-gateway-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hawkular.commons</groupId>
+      <artifactId>hawkular-command-gateway-itest</artifactId>
+      <scope>test</scope>
+      <type>test-jar</type>
+      <version>${version.org.hawkular.commons}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hawkular.commons</groupId>
+      <artifactId>hawkular-inventory-paths</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jolokia</groupId>
+      <artifactId>jolokia-war</artifactId>
+      <version>${version.org.jolokia}</version>
+      <type>war</type>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.wildfly.core</groupId>
+      <artifactId>wildfly-controller</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+
+      <plugin>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <configuration>
+          <excludes combine.children="append">
+            <exclude>src/test/resources/**/*.node.txt</exclude>
+            <exclude>src/test/resources/**/*.node.txt.actual.txt</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <!-- because integration tests are run by maven-failsafe-plugin -->
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <!-- Integration tests -->
+      <id>itest</id>
+      <properties>
+        <surefire.testng.verbose>3</surefire.testng.verbose>
+
+        <hawkular.agent.itest.includes>**/*ITest.class</hawkular.agent.itest.includes>
+        <hawkular.agent.itest.run.dir>${project.build.directory}/${project.artifactId}-${project.version}</hawkular.agent.itest.run.dir>
+
+        <hawkular.agent.itest.mgmt.user>itest-admin</hawkular.agent.itest.mgmt.user>
+        <!-- <hawkular.agent.itest.mgmt.password> set to a random value using gmaven plugin </hawkular.agent.itest.mgmt.password> -->
+        <hawkular.itest.rest.tenantId>itest-rest-tenant</hawkular.itest.rest.tenantId>
+        <hawkular.itest.rest.user>itest-rest</hawkular.itest.rest.user>
+        <!-- <hawkular.itest.rest.password> set to a random value using gmaven plugin </hawkular.itest.rest.password> -->
+
+        <hawkular.bind.address>127.0.0.1</hawkular.bind.address>
+        <hawkular.port.offset>0</hawkular.port.offset>
+        <!-- $hawkular.management.port must be equal to $hawkular.port.offset + 9990 -->
+        <hawkular.management.port>9990</hawkular.management.port>
+
+        <hawkular.agent.enabled>true</hawkular.agent.enabled>
+
+        <hawkular.log.root>INFO</hawkular.log.root>
+        <hawkular.log.console>TRACE</hawkular.log.console>
+        <hawkular.log.agent>INFO</hawkular.log.agent>
+        <hawkular.log.bus>INFO</hawkular.log.bus>
+        <hawkular.log.cmdgw>INFO</hawkular.log.cmdgw>
+        <hawkular.log.inventory>INFO</hawkular.log.inventory>
+        <hawkular.log.inventory.rest.requests>INFO</hawkular.log.inventory.rest.requests>
+        <hawkular.log.metrics>INFO</hawkular.log.metrics>
+        <hawkular.log.nest>INFO</hawkular.log.nest>
+        <hawkular.log.datastax.driver>INFO</hawkular.log.datastax.driver>
+        <hawkular.log.cassandra>INFO</hawkular.log.cassandra>
+      </properties>
+
+      <build>
+        <plugins>
+
+          <plugin>
+            <groupId>org.wildfly.build</groupId>
+            <artifactId>wildfly-server-provisioning-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>server-provisioning</id>
+                <goals>
+                  <goal>build</goal>
+                </goals>
+                <phase>compile</phase>
+                <configuration>
+                  <config-file>server-provisioning.xml</config-file>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <!-- put Jolokia war in the deployment directory -->
+                <id>copy-deployments</id>
+                <phase>test-compile</phase>
+                <goals>
+                  <goal>copy</goal>
+                </goals>
+                <configuration>
+                  <stripVersion>true</stripVersion>
+                  <artifactItems>
+                    <artifactItem>
+                      <groupId>org.jolokia</groupId>
+                      <artifactId>jolokia-war</artifactId>
+                      <version>${version.org.jolokia}</version>
+                      <type>war</type>
+                    </artifactItem>
+                  </artifactItems>
+                  <outputDirectory>${hawkular.test.deployment.dir}</outputDirectory>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+          <!-- Generate random passwords -->
+          <plugin>
+            <groupId>org.codehaus.gmavenplus</groupId>
+            <artifactId>gmavenplus-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>compile</phase>
+                <goals>
+                  <goal>execute</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <scripts>
+                <script><![CDATA[
+                  project.properties['hawkular.agent.itest.mgmt.password'] = UUID.randomUUID().toString()
+                  project.properties['hawkular.itest.rest.password'] = UUID.randomUUID().toString()
+                ]]></script>
+              </scripts>
+            </configuration>
+            <dependencies>
+              <dependency>
+                <groupId>org.codehaus.groovy</groupId>
+                <artifactId>groovy-all</artifactId>
+                <version>${version.org.codehaus.groovy}</version>
+                <scope>runtime</scope>
+              </dependency>
+            </dependencies>
+          </plugin>
+
+          <!-- To run a subset of tests, specify the test class paths explicitly. For example:
+               -Dhawkular.agent.itest.includes=**/MyITest.class,**/EchoCommandITest.class -Pitest
+          -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <includes>
+                <include>${hawkular.agent.itest.includes}</include>
+              </includes>
+              <systemPropertyVariables>
+
+                <hawkular.bind.address>${hawkular.bind.address}</hawkular.bind.address>
+                <hawkular.port.offset>${hawkular.port.offset}</hawkular.port.offset>
+
+                <hawkular.agent.itest.mgmt.user>${hawkular.agent.itest.mgmt.user}</hawkular.agent.itest.mgmt.user>
+                <hawkular.agent.itest.mgmt.password>${hawkular.agent.itest.mgmt.password}</hawkular.agent.itest.mgmt.password>
+
+                <hawkular.itest.rest.tenantId>${hawkular.itest.rest.tenantId}</hawkular.itest.rest.tenantId>
+                <hawkular.itest.rest.user>${hawkular.itest.rest.user}</hawkular.itest.rest.user>
+                <hawkular.itest.rest.password>${hawkular.itest.rest.password}</hawkular.itest.rest.password>
+
+                <!-- output over-the-wire traffic -->
+                <org.apache.commons.logging.Log>
+                  org.apache.commons.logging.impl.SimpleLog
+                </org.apache.commons.logging.Log>
+                <org.apache.commons.logging.simplelog.log.org.apache.http>
+                  ${http.log}
+                </org.apache.commons.logging.simplelog.log.org.apache.http>
+                <org.apache.commons.logging.simplelog.log.org.apache.http.wire>
+                  ${http.log.wire}
+                </org.apache.commons.logging.simplelog.log.org.apache.http.wire>
+                <java.util.logging.config.file>${project.build.testOutputDirectory}/logging.properties</java.util.logging.config.file>
+              </systemPropertyVariables>
+              <properties>
+                <property>
+                  <name>surefire.testng.verbose</name>
+                  <value>${surefire.testng.verbose}</value>
+                </property>
+              </properties>
+              <argLine>${debug.failsafe.argLine}</argLine>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+
+          <!-- Start WildFly from the folder where the provisioning plugin has prepared it -->
+          <plugin>
+            <groupId>org.wildfly.plugins</groupId>
+            <artifactId>wildfly-maven-plugin</artifactId>
+            <configuration>
+              <skip>${skipTests}</skip>
+              <startupTimeout>360</startupTimeout>
+            </configuration>
+            <executions>
+              <execution>
+                <id>start-hawkular</id>
+                <phase>process-test-classes</phase>
+                <goals>
+                  <goal>start</goal>
+                </goals>
+                <configuration>
+                  <jboss-home>${project.build.directory}/${project.build.finalName}</jboss-home>
+                  <port>${hawkular.management.port}</port>
+                  <javaOpts>
+                    <javaOpt>-Xmx1024m</javaOpt>
+                    <javaOpt>-XX:MaxPermSize=1024m</javaOpt>
+                    <javaOpt>-Dhawkular.inventory.transaction.retries=15</javaOpt>
+                    <javaOpt>-Djava.net.preferIPv4Stack=true</javaOpt>
+                    <javaOpt>-Djboss.bind.address=${hawkular.bind.address}</javaOpt>
+                    <javaOpt>-Djboss.modules.system.pkgs=org.jboss.byteman</javaOpt>
+                    <javaOpt>-Djava.awt.headless=true</javaOpt>
+                    <javaOpt>-Djboss.socket.binding.port-offset=${hawkular.port.offset}</javaOpt>
+                    <javaOpt>-Dhawkular.agent.enabled=${hawkular.agent.enabled}</javaOpt>
+                    <javaOpt>-Dhawkular.rest.user=${hawkular.itest.rest.user}</javaOpt>
+                    <javaOpt>-Dhawkular.rest.password=${hawkular.itest.rest.password}</javaOpt>
+                    <javaOpt>-Dhawkular.rest.tenantId=${hawkular.itest.rest.tenantId}</javaOpt>
+                    <javaOpt>-Dhawkular.log.root=${hawkular.log.root}</javaOpt>
+                    <javaOpt>-Dhawkular.log.console=${hawkular.log.console}</javaOpt>
+                    <javaOpt>-Dhawkular.log.agent=${hawkular.log.agent}</javaOpt>
+                    <javaOpt>-Dhawkular.log.bus=${hawkular.log.bus}</javaOpt>
+                    <javaOpt>-Dhawkular.log.cmdgw=${hawkular.log.cmdgw}</javaOpt>
+                    <javaOpt>-Dhawkular.log.inventory=${hawkular.log.inventory}</javaOpt>
+                    <javaOpt>-Dhawkular.log.inventory.rest.requests=${hawkular.log.inventory.rest.requests}</javaOpt>
+                    <javaOpt>-Dhawkular.log.metrics=${hawkular.log.metrics}</javaOpt>
+                    <javaOpt>-Dhawkular.log.nest=${hawkular.log.nest}</javaOpt>
+                    <javaOpt>-Dhawkular.log.datastax.driver=${hawkular.log.datastax.driver}</javaOpt>
+                    <javaOpt>-Dhawkular.log.cassandra=${hawkular.log.cassandra}</javaOpt>
+                    <javaOpt>-Dhawkular.backend=embedded_cassandra</javaOpt>
+                    <javaOpt>${debug.hawkular.argLine}</javaOpt>
+                  </javaOpts>
+                  <add-user>
+                    <users>
+                      <user>
+                        <username>${hawkular.agent.itest.mgmt.user}</username>
+                        <password>${hawkular.agent.itest.mgmt.password}</password>
+                        <application-user>false</application-user>
+                      </user>
+                      <user>
+                        <username>${hawkular.itest.rest.user}</username>
+                        <password>${hawkular.itest.rest.password}</password>
+                        <application-user>true</application-user>
+                        <groups>
+                          <group>read-write</group>
+                          <group>read-only</group>
+                        </groups>
+                      </user>
+                    </users>
+                  </add-user>
+                </configuration>
+              </execution>
+
+              <execution>
+                <id>stop-hawkular</id>
+                <phase>post-integration-test</phase>
+                <goals>
+                  <goal>shutdown</goal>
+                </goals>
+                <configuration>
+                  <jboss-home>${project.build.directory}/${project.build.finalName}</jboss-home>
+                  <port>${hawkular.management.port}</port>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+        </plugins>
+      </build>
+    </profile>
+
+  </profiles>
+</project>

--- a/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-jmx-itest/server-provisioning.xml
+++ b/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-jmx-itest/server-provisioning.xml
@@ -1,0 +1,24 @@
+<!--
+
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<server-provisioning xmlns="urn:wildfly:server-provisioning:1.1" extract-schemas="true"
+  copy-module-artifacts="true">
+  <feature-packs>
+    <feature-pack groupId="org.hawkular.agent" artifactId="hawkular-wildfly-agent-itest-feature-pack" version="${project.version}" />
+  </feature-packs>
+</server-provisioning>

--- a/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-jmx-itest/src/test/java/org/hawkular/agent/jmx/test/LocalAndRemoteJmxITest.java
+++ b/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-jmx-itest/src/test/java/org/hawkular/agent/jmx/test/LocalAndRemoteJmxITest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.agent.jmx.test;
+
+import java.util.List;
+
+import org.hawkular.dmrclient.Address;
+import org.hawkular.dmrclient.CoreJBossASClient;
+import org.hawkular.dmrclient.FailureException;
+import org.hawkular.dmrclient.JBossASClient;
+import org.hawkular.inventory.api.model.Resource;
+import org.hawkular.wildfly.agent.itest.util.AbstractITest;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.Property;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class LocalAndRemoteJmxITest extends AbstractITest {
+    public static final String GROUP = "ExecuteOperationCommandITest";
+
+    @Test(groups = { GROUP })
+    public void testDmrResources() throws Throwable {
+        waitForAccountsAndInventory();
+
+        // make sure the agent is there - this comes from the DMR managed server - just making sure that still works
+        Resource agent = getResource(
+                "/traversal/f;" + hawkularFeedId + "/type=rt;id=Hawkular%20WildFly%20Agent/rl;defines/type=r",
+                (r -> r.getId() != null));
+        Assert.assertNotNull(agent);
+        Assert.assertEquals(agent.getName(), "Hawkular WildFly Agent");
+
+        enableJmxManagedServers();
+    }
+
+    private void enableJmxManagedServers() throws Throwable {
+        try (ModelControllerClient mcc = newHawkularModelControllerClient()) {
+            CoreJBossASClient c = new CoreJBossASClient(mcc);
+
+            // We want to enable by the remote JMX managed server and the local JMX managed server.
+            // The default agent configuration already has these managed servers defined with some basic
+            // metadata - we just want to enabled them since they are disabled by default.
+            String rAddr = "/subsystem=hawkular-wildfly-agent/managed-servers=default/remote-jmx=Remote JMX";
+            String lAddr = "/subsystem=hawkular-wildfly-agent/managed-servers=default/local-jmx=Local JMX";
+            ModelNode rReq = JBossASClient.createWriteAttributeRequest("enabled", "true", Address.parse(rAddr));
+            ModelNode lReq = JBossASClient.createWriteAttributeRequest("enabled", "true", Address.parse(lAddr));
+
+            ModelNode response;
+
+            response = c.execute(rReq);
+            if (!JBossASClient.isSuccess(response)) {
+                throw new FailureException("Cannot enable remote JMX managed server: " + response);
+            }
+
+            response = c.execute(lReq);
+            if (!JBossASClient.isSuccess(response)) {
+                throw new FailureException("Cannot enable local JMX managed server: " + response);
+            }
+        }
+    }
+
+    @Test(groups = { GROUP }, dependsOnMethods = { "testDmrResources" })
+    public void testLocalJmxResources() throws Throwable {
+        // make sure the JMX resource is there
+        Resource runtime = getResource(
+                "/traversal/f;" + hawkularFeedId + "/type=rt;id=Runtime%20MBean/rl;defines/type=r",
+                (r -> r.getId().equals("Local JMX~java.lang:type=Runtime")));
+        Assert.assertNotNull(runtime);
+        Assert.assertEquals(runtime.getName(), "JMX [Local JMX][Runtime]");
+
+        // makes sure the resources are in the agent's internal inventory
+        ModelNode inventoryReport = getAgentInventoryReport(hawkularHost, hawkularManagementPort);
+        Assert.assertNotNull(inventoryReport);
+        ModelNode jmxResourceNode = inventoryReport
+                .get("JMX") // the name of protocol service
+                .get("Local JMX") // the name of the managed-server - this is the local-jmx
+                .get("Resources")
+                .asList()
+                .get(0)
+                .get("Local JMX~java.lang:type=Runtime"); // the resource ID
+        Assert.assertNotNull(jmxResourceNode);
+        Assert.assertEquals(jmxResourceNode.get("Name").asString(), "JMX [Local JMX][Runtime]");
+        Assert.assertEquals(jmxResourceNode.get("Type ID").asString(), "Runtime MBean");
+        List<Property> resConfig = jmxResourceNode.get("Resource Configuration").asPropertyList();
+        Assert.assertEquals(resConfig.size(), 2);
+        for (Property prop : resConfig) {
+            if (prop.getName().equals("OS Name")) {
+                Assert.assertFalse(prop.getValue().asString().isEmpty());
+            } else if (prop.getName().equals("Java VM Name")) {
+                Assert.assertFalse(prop.getValue().asString().isEmpty());
+            } else {
+                Assert.fail("Bad resource config: " + prop.getName() + "=" + prop.getValue().asString());
+            }
+        }
+    }
+
+    @Test(groups = { GROUP }, dependsOnMethods = { "testLocalJmxResources" })
+    public void testRemoteJmxResources() throws Throwable {
+        // make sure the JMX resource is there
+        Resource runtime = getResource(
+                "/traversal/f;" + hawkularFeedId + "/type=rt;id=Runtime%20MBean/rl;defines/type=r",
+                (r -> r.getId().equals("Remote JMX~java.lang:type=Runtime")));
+        Assert.assertNotNull(runtime);
+        Assert.assertEquals(runtime.getName(), "JMX [Remote JMX][Runtime]");
+
+        // makes sure the resources are in the agent's internal inventory
+        ModelNode inventoryReport = getAgentInventoryReport(hawkularHost, hawkularManagementPort);
+        Assert.assertNotNull(inventoryReport);
+        ModelNode jmxResourceNode = inventoryReport
+                .get("JMX") // the name of protocol service
+                .get("Remote JMX") // the name of the managed-server - this is the remote-jmx
+                .get("Resources")
+                .asList()
+                .get(0)
+                .get("Remote JMX~java.lang:type=Runtime"); // the resource ID
+        Assert.assertNotNull(jmxResourceNode);
+        Assert.assertEquals(jmxResourceNode.get("Name").asString(), "JMX [Remote JMX][Runtime]");
+        Assert.assertEquals(jmxResourceNode.get("Type ID").asString(), "Runtime MBean");
+        List<Property> resConfig = jmxResourceNode.get("Resource Configuration").asPropertyList();
+        Assert.assertEquals(resConfig.size(), 2);
+        for (Property prop : resConfig) {
+            if (prop.getName().equals("OS Name")) {
+                Assert.assertFalse(prop.getValue().asString().isEmpty());
+            } else if (prop.getName().equals("Java VM Name")) {
+                Assert.assertFalse(prop.getValue().asString().isEmpty());
+            } else {
+                Assert.fail("Bad resource config: " + prop.getName() + "=" + prop.getValue().asString());
+            }
+        }
+    }
+}

--- a/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/pom.xml
+++ b/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/pom.xml
@@ -41,6 +41,7 @@
     <module>hawkular-wildfly-agent-installer-itest</module>
     <module>hawkular-wildfly-agent-domain-itest</module>
     <module>hawkular-wildfly-agent-cmdgw-itest</module>
+    <module>hawkular-wildfly-agent-jmx-itest</module>
   </modules>
 
   <profiles>

--- a/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-itest-feature-pack/src/main/xsl/subsystem-templates/hawkular-wildfly-agent-itest-logging.xsl
+++ b/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-itest-feature-pack/src/main/xsl/subsystem-templates/hawkular-wildfly-agent-itest-logging.xsl
@@ -34,6 +34,9 @@
       <logger category="org.hawkular.inventory.rest.requests">
         <level name="${{hawkular.log.inventory.rest.requests:INFO}}" />
       </logger>
+      <logger category="org.hawkular.agent">
+        <level name="${{hawkular.log.agent:INFO}}" />
+      </logger>
     </xsl:copy>
   </xsl:template>
 

--- a/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-itest-util/src/main/java/org/hawkular/wildfly/agent/itest/util/AbstractITest.java
+++ b/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-itest-util/src/main/java/org/hawkular/wildfly/agent/itest/util/AbstractITest.java
@@ -607,11 +607,11 @@ public abstract class AbstractITest {
             if (!accountsAndInventoryReady) {
                 Thread.sleep(10000);
 
-                /*
-                 * Ensure inventory is running by trying to read our tenant - this is what we authenticate with against
-                 * inventory.
-                 */
                 getWithRetries(baseInvUri + "/tenant");
+                while (!getWithRetries(baseMetricsUri + "/status").contains("STARTED")) {
+                    Thread.sleep(2000);
+                }
+
                 accountsAndInventoryReady = true;
             }
         }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalDMRDefinition.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalDMRDefinition.java
@@ -72,7 +72,7 @@ public class LocalDMRDefinition extends PersistentResourceDefinition {
                             ModelNode newValue,
                             ModelNode currentValue,
                             AbstractWriteAttributeHandler.HandbackHolder<Void> handbackHolder)
-                                    throws OperationFailedException {
+                            throws OperationFailedException {
 
                         if (context.isBooting()) {
                             return false;
@@ -85,6 +85,10 @@ public class LocalDMRDefinition extends PersistentResourceDefinition {
                         }
 
                         MonitorService monitorService = getMonitorService(context);
+                        if (monitorService == null || !monitorService.isMonitorServiceStarted()) {
+                            return true; // caught service starting up, need to be restarted to pick up this change
+                        }
+
                         ProtocolService<DMRNodeLocation, DMRSession> dmrService = monitorService.getProtocolServices()
                                 .getDmrProtocolService();
                         String thisEndpointName = context.getCurrentAddressValue();
@@ -122,7 +126,7 @@ public class LocalDMRDefinition extends PersistentResourceDefinition {
                             ModelNode originalValue,
                             ModelNode newBadValue,
                             Void handback)
-                                    throws OperationFailedException {
+                            throws OperationFailedException {
                         // nothing to revert?
                     }
                 });

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalJMXAdd.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalJMXAdd.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.agent.monitor.extension;
+
+import org.hawkular.agent.monitor.extension.MonitorServiceConfiguration.EndpointConfiguration;
+import org.hawkular.agent.monitor.log.AgentLoggers;
+import org.hawkular.agent.monitor.log.MsgLogger;
+import org.hawkular.agent.monitor.protocol.EndpointService;
+import org.hawkular.agent.monitor.protocol.ProtocolService;
+import org.hawkular.agent.monitor.protocol.ProtocolServices;
+import org.hawkular.agent.monitor.protocol.jmx.JMXNodeLocation;
+import org.hawkular.agent.monitor.protocol.jmx.JMXSession;
+import org.hawkular.agent.monitor.service.MonitorService;
+import org.hawkular.agent.monitor.util.Util;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.dmr.ModelNode;
+
+public class LocalJMXAdd extends MonitorServiceAddStepHandler {
+    private static final MsgLogger log = AgentLoggers.getLogger(LocalJMXAdd.class);
+
+    public static final LocalJMXAdd INSTANCE = new LocalJMXAdd();
+
+    private LocalJMXAdd() {
+        super(LocalJMXAttributes.ATTRIBUTES);
+    }
+
+    @Override
+    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model)
+            throws OperationFailedException {
+
+        if (context.isBooting()) {
+            return;
+        }
+
+        MonitorService monitorService = getMonitorService(context);
+        if (monitorService == null) {
+            return; // the agent wasn't enabled, nothing to do
+        }
+
+        MonitorServiceConfiguration config = Util.getMonitorServiceConfiguration(context);
+        String newEndpointName = context.getCurrentAddressValue();
+
+        // Register the feed under the tenant of the new managed server.
+        // If endpoint has a null tenant then there is nothing to do since it will just reuse the agent's tenant ID
+        EndpointConfiguration endpointConfig = config.getJmxConfiguration().getEndpoints().get(newEndpointName);
+        boolean isEnabled = endpointConfig.isEnabled();
+
+        String newTenantId = endpointConfig.getTenantId();
+        if (newTenantId != null) {
+            try {
+                monitorService.registerFeed(newTenantId, 0);
+            } catch (Exception e) {
+                isEnabled = false;
+                log.warnCannotRegisterFeedForNewManagedServer(newTenantId, newEndpointName, e.toString());
+            }
+        }
+
+        if (isEnabled) {
+            // create a new endpoint service
+            ProtocolServices newServices = monitorService.createProtocolServicesBuilder()
+                    .jmxProtocolService(config.getJmxConfiguration()).build();
+            EndpointService<JMXNodeLocation, JMXSession> endpointService = newServices.getJmxProtocolService()
+                    .getEndpointServices().get(newEndpointName);
+
+            // put the new endpoint service in the original protocol services container
+            ProtocolService<JMXNodeLocation, JMXSession> jmxService = monitorService.getProtocolServices()
+                    .getJmxProtocolService();
+            jmxService.add(endpointService);
+        }
+    }
+}

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalJMXAttributes.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalJMXAttributes.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.agent.monitor.extension;
+
+import org.hawkular.agent.monitor.api.Avail;
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.operations.validation.EnumValidator;
+import org.jboss.as.controller.registry.AttributeAccess;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+
+public interface LocalJMXAttributes {
+
+    SimpleAttributeDefinition ENABLED = new SimpleAttributeDefinitionBuilder("enabled",
+            ModelType.BOOLEAN)
+                    .setAllowNull(true)
+                    .setDefaultValue(new ModelNode(true))
+                    .setAllowExpression(true)
+                    .addFlag(AttributeAccess.Flag.RESTART_NONE)
+                    .build();
+
+    SimpleAttributeDefinition MBEAN_SERVER_NAME = new SimpleAttributeDefinitionBuilder("mbean-server-name",
+            ModelType.STRING)
+                    .setAllowNull(true)
+                    .setAllowExpression(true)
+                    .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+                    .build();
+
+    SimpleAttributeDefinition SET_AVAIL_ON_SHUTDOWN = new SimpleAttributeDefinitionBuilder("set-avail-on-shutdown",
+            ModelType.STRING)
+                    .setAllowNull(true)
+                    .setValidator(EnumValidator.create(Avail.class, true, true))
+                    .setAllowExpression(true)
+                    .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+                    .build();
+
+    SimpleAttributeDefinition RESOURCE_TYPE_SETS = new SimpleAttributeDefinitionBuilder("resource-type-sets",
+            ModelType.STRING)
+                    .setAllowNull(true)
+                    .setAllowExpression(true)
+                    .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+                    .build();
+
+    SimpleAttributeDefinition TENANT_ID = new SimpleAttributeDefinitionBuilder("tenant-id",
+            ModelType.STRING)
+                    .setAllowNull(true)
+                    .setAllowExpression(true)
+                    .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+                    .build();
+
+    SimpleAttributeDefinition METRIC_ID_TEMPLATE = new SimpleAttributeDefinitionBuilder("metric-id-template",
+            ModelType.STRING)
+                    .setAllowNull(true)
+                    .setAllowExpression(true)
+                    .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+                    .build();
+
+    SimpleAttributeDefinition METRIC_TAGS = new SimpleAttributeDefinitionBuilder("metric-tags",
+            ModelType.STRING)
+                    .setAllowNull(true)
+                    .setAllowExpression(true)
+                    .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+                    .build();
+
+    AttributeDefinition[] ATTRIBUTES = {
+            ENABLED,
+            MBEAN_SERVER_NAME,
+            SET_AVAIL_ON_SHUTDOWN,
+            RESOURCE_TYPE_SETS,
+            TENANT_ID,
+            METRIC_ID_TEMPLATE,
+            METRIC_TAGS
+    };
+}

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalJMXRemove.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalJMXRemove.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.agent.monitor.extension;
+
+import org.hawkular.agent.monitor.protocol.ProtocolService;
+import org.hawkular.agent.monitor.scheduler.SchedulerService;
+import org.hawkular.agent.monitor.service.MonitorService;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.dmr.ModelNode;
+
+public class LocalJMXRemove extends MonitorServiceRemoveStepHandler {
+
+    public static final LocalJMXRemove INSTANCE = new LocalJMXRemove();
+
+    private LocalJMXRemove() {
+    }
+
+    @Override
+    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model)
+            throws OperationFailedException {
+
+        if (context.isBooting()) {
+            return;
+        }
+
+        MonitorService monitorService = getMonitorService(context);
+        if (monitorService == null) {
+            return; // the agent wasn't enabled, nothing to do
+        }
+
+        SchedulerService schedulerService = monitorService.getSchedulerService();
+        ProtocolService<?, ?> jmxService = monitorService.getProtocolServices().getJmxProtocolService();
+        String doomedEndpointName = context.getCurrentAddressValue();
+        jmxService.remove(doomedEndpointName, schedulerService);
+    }
+}

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/ManagedServersDefinition.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/ManagedServersDefinition.java
@@ -50,6 +50,7 @@ public class ManagedServersDefinition extends PersistentResourceDefinition {
         return Arrays.asList(
                 LocalDMRDefinition.INSTANCE,
                 RemoteDMRDefinition.INSTANCE,
+                LocalJMXDefinition.INSTANCE,
                 RemoteJMXDefinition.INSTANCE);
     }
 }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/MonitorServiceConfigurationBuilder.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/MonitorServiceConfigurationBuilder.java
@@ -56,6 +56,7 @@ import org.hawkular.agent.monitor.inventory.TypeSets;
 import org.hawkular.agent.monitor.log.AgentLoggers;
 import org.hawkular.agent.monitor.log.MsgLogger;
 import org.hawkular.agent.monitor.protocol.dmr.DMRNodeLocation;
+import org.hawkular.agent.monitor.protocol.jmx.JMXEndpointService;
 import org.hawkular.agent.monitor.protocol.jmx.JMXNodeLocation;
 import org.hawkular.agent.monitor.protocol.platform.Constants;
 import org.hawkular.agent.monitor.protocol.platform.Constants.PlatformMetricType;
@@ -1283,6 +1284,34 @@ public class MonitorServiceConfigurationBuilder {
                     EndpointConfiguration endpoint = new EndpointConfiguration(name, enabled, resourceTypeSets,
                             connectionData, securityRealm, setAvailOnShutdown, tenantId, metricIdTemplate, metricTags,
                             null);
+
+                    jmxConfigBuilder.endpoint(endpoint);
+                }
+            }
+
+            if (managedServersValueNode.hasDefined(LocalJMXDefinition.LOCAL_JMX)) {
+                List<Property> localJMXsList = managedServersValueNode.get(LocalJMXDefinition.LOCAL_JMX)
+                        .asPropertyList();
+                for (Property localJMXProperty : localJMXsList) {
+                    String name = localJMXProperty.getName();
+                    ModelNode localJMXValueNode = localJMXProperty.getValue();
+                    boolean enabled = getBoolean(localJMXValueNode, context, LocalJMXAttributes.ENABLED);
+                    String setAvailOnShutdownStr = getString(localJMXValueNode, context,
+                            LocalJMXAttributes.SET_AVAIL_ON_SHUTDOWN);
+                    Avail setAvailOnShutdown = (setAvailOnShutdownStr == null) ? null
+                            : Avail.valueOf(setAvailOnShutdownStr);
+                    String mbsNameStr = getString(localJMXValueNode, context, LocalJMXAttributes.MBEAN_SERVER_NAME);
+                    List<Name> resourceTypeSets = getNameListFromString(localJMXValueNode, context,
+                            LocalJMXAttributes.RESOURCE_TYPE_SETS);
+                    String tenantId = getString(localJMXValueNode, context, LocalJMXAttributes.TENANT_ID);
+                    String metricIdTemplate = getString(localJMXValueNode, context,
+                            RemoteDMRAttributes.METRIC_ID_TEMPLATE);
+                    Map<String, String> metricTags = getMapFromString(localJMXValueNode, context,
+                            RemoteDMRAttributes.METRIC_TAGS);
+
+                    EndpointConfiguration endpoint = new EndpointConfiguration(name, enabled, resourceTypeSets,
+                            null, null, setAvailOnShutdown, tenantId, metricIdTemplate, metricTags,
+                            Collections.singletonMap(JMXEndpointService.MBEAN_SERVER_NAME_KEY, mbsNameStr));
 
                     jmxConfigBuilder.endpoint(endpoint);
                 }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/PlatformDefinition.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/PlatformDefinition.java
@@ -78,7 +78,7 @@ public class PlatformDefinition extends PersistentResourceDefinition {
                             ModelNode newValue,
                             ModelNode currentValue,
                             AbstractWriteAttributeHandler.HandbackHolder<Void> handbackHolder)
-                                    throws OperationFailedException {
+                            throws OperationFailedException {
 
                         if (context.isBooting()) {
                             return false;
@@ -91,6 +91,10 @@ public class PlatformDefinition extends PersistentResourceDefinition {
                         }
 
                         MonitorService monitorService = getMonitorService(context);
+                        if (monitorService == null || !monitorService.isMonitorServiceStarted()) {
+                            return true; // caught service starting up, need to be restarted to pick up this change
+                        }
+
                         ProtocolService<PlatformNodeLocation, PlatformSession> platformService = monitorService
                                 .getProtocolServices().getPlatformProtocolService();
                         String thisEndpointName = context.getCurrentAddressValue();
@@ -127,7 +131,7 @@ public class PlatformDefinition extends PersistentResourceDefinition {
                             ModelNode originalValue,
                             ModelNode newBadValue,
                             Void handback)
-                                    throws OperationFailedException {
+                            throws OperationFailedException {
                         // nothing to revert?
                     }
                 });

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteJMXDefinition.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteJMXDefinition.java
@@ -72,7 +72,7 @@ public class RemoteJMXDefinition extends PersistentResourceDefinition {
                             ModelNode newValue,
                             ModelNode currentValue,
                             AbstractWriteAttributeHandler.HandbackHolder<Void> handbackHolder)
-                                    throws OperationFailedException {
+                            throws OperationFailedException {
 
                         if (context.isBooting()) {
                             return false;
@@ -85,6 +85,10 @@ public class RemoteJMXDefinition extends PersistentResourceDefinition {
                         }
 
                         MonitorService monitorService = getMonitorService(context);
+                        if (monitorService == null || !monitorService.isMonitorServiceStarted()) {
+                            return true; // caught service starting up, need to be restarted to pick up this change
+                        }
+
                         ProtocolService<JMXNodeLocation, JMXSession> jmxService = monitorService.getProtocolServices()
                                 .getJmxProtocolService();
                         String thisEndpointName = context.getCurrentAddressValue();
@@ -121,7 +125,7 @@ public class RemoteJMXDefinition extends PersistentResourceDefinition {
                             ModelNode originalValue,
                             ModelNode newBadValue,
                             Void handback)
-                                    throws OperationFailedException {
+                            throws OperationFailedException {
                         // nothing to revert?
                     }
                 });

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/SubsystemParser.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/SubsystemParser.java
@@ -139,6 +139,10 @@ public class SubsystemParser implements XMLStreamConstants, XMLElementReader<Lis
                                             .setXmlElementName(RemoteJMXDefinition.REMOTE_JMX)
                                             .addAttributes(RemoteJMXAttributes.ATTRIBUTES)
                                     )
+                                    .addChild(builder(LocalJMXDefinition.INSTANCE)
+                                            .setXmlElementName(LocalJMXDefinition.LOCAL_JMX)
+                                            .addAttributes(LocalJMXAttributes.ATTRIBUTES)
+                                    )
                             )
 
                             .addChild(builder(PlatformDefinition.INSTANCE)

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/protocol/jmx/JMXDriver.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/protocol/jmx/JMXDriver.java
@@ -16,135 +16,28 @@
  */
 package org.hawkular.agent.monitor.protocol.jmx;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.management.ObjectName;
-
 import org.hawkular.agent.monitor.diagnostics.ProtocolDiagnostics;
-import org.hawkular.agent.monitor.inventory.AttributeLocation;
 import org.hawkular.agent.monitor.protocol.Driver;
-import org.hawkular.agent.monitor.protocol.ProtocolException;
-import org.jolokia.client.J4pClient;
-import org.jolokia.client.exception.J4pException;
-import org.jolokia.client.request.J4pReadRequest;
-import org.jolokia.client.request.J4pReadResponse;
-import org.jolokia.client.request.J4pSearchRequest;
-import org.jolokia.client.request.J4pSearchResponse;
-
-import com.codahale.metrics.Timer.Context;
 
 /**
- * @author <a href="https://github.com/ppalaga">Peter Palaga</a>
+ * Abstract JMX driver that both local and remote JMX drivers extend.
+ *
  * @see Driver
  */
-public class JMXDriver implements Driver<JMXNodeLocation> {
+public abstract class JMXDriver implements Driver<JMXNodeLocation> {
 
-    private final J4pClient client;
     private final ProtocolDiagnostics diagnostics;
+
     /**
      * Creates the JMX driver.
      *
-     * @param client the client used to connect to the JMX MBeanServer
      * @param diagnostics
      */
-    public JMXDriver(J4pClient client, ProtocolDiagnostics diagnostics) {
-        super();
-        this.client = client;
+    public JMXDriver(ProtocolDiagnostics diagnostics) {
         this.diagnostics = diagnostics;
     }
 
-    @SuppressWarnings("unchecked")
-    @Override
-    public Map<JMXNodeLocation, ObjectName> fetchNodes(JMXNodeLocation query) throws ProtocolException {
-        try {
-
-            J4pSearchRequest searchReq = new J4pSearchRequest(query.getObjectName().getCanonicalName());
-            J4pSearchResponse searchResponse;
-            try (Context timerContext = diagnostics.getRequestTimer().time()) {
-                searchResponse = client.execute(searchReq);
-            }
-
-            Map<JMXNodeLocation, ObjectName> result = new HashMap<>();
-            for (ObjectName objectName : searchResponse.getObjectNames()) {
-                JMXNodeLocation location = new JMXNodeLocation(objectName);
-                result.put(location, objectName);
-            }
-            return Collections.unmodifiableMap(result);
-        } catch (J4pException e) {
-            diagnostics.getErrorRate().mark(1);
-            throw new ProtocolException(e);
-        } catch (Exception e) {
-            throw new ProtocolException(e);
-        }
+    protected ProtocolDiagnostics getDiagnostics() {
+        return diagnostics;
     }
-
-    @Override
-    public boolean attributeExists(AttributeLocation<JMXNodeLocation> location)
-            throws ProtocolException {
-        return true;
-    }
-
-    @Override
-    public Object fetchAttribute(AttributeLocation<JMXNodeLocation> location) throws ProtocolException {
-        try {
-
-            String[] attribute = location.getAttribute().split("#");
-            J4pReadRequest request = new J4pReadRequest(location.getLocation().getObjectName(), attribute[0]);
-            if (attribute.length > 1) {
-                request.setPath(attribute[1]); // this is the sub-reference
-            }
-
-            J4pReadResponse response;
-            try (Context timerContext = diagnostics.getRequestTimer().time()) {
-                response = client.execute(request);
-            }
-            Collection<ObjectName> responseObjectNames = response.getObjectNames();
-            switch (responseObjectNames.size()) {
-                case 0:
-                    return null;
-                case 1:
-                    return response.getValue();
-                default:
-                    List<Object> results = new ArrayList<>(responseObjectNames.size());
-                    for (ObjectName responseObjectName : responseObjectNames) {
-                        Object value = response.getValue(responseObjectName, location.getAttribute());
-                        results.add(value);
-                    }
-                    return Collections.unmodifiableList(results);
-            }
-        } catch (Exception e) {
-            diagnostics.getErrorRate().mark(1);
-            throw new ProtocolException(e);
-        }
-    }
-
-    @Override
-    public Map<JMXNodeLocation, Object> fetchAttributeAsMap(AttributeLocation<JMXNodeLocation> location)
-            throws ProtocolException {
-
-        // short-circuit if its only one location
-        if (!new JMXLocationResolver().isMultiTarget(location.getLocation())) {
-            Object o = fetchAttribute(location);
-            return Collections.singletonMap(location.getLocation(), o);
-        }
-
-        Map<JMXNodeLocation, ObjectName> nodes = fetchNodes(location.getLocation());
-        Map<JMXNodeLocation, Object> attribsMap = new HashMap<>(nodes.size());
-        for (Map.Entry<JMXNodeLocation, ObjectName> entry : nodes.entrySet()) {
-            Object o = fetchAttribute(new AttributeLocation<>(entry.getKey(), location.getAttribute()));
-            attribsMap.put(entry.getKey(), o);
-        }
-
-        return Collections.unmodifiableMap(attribsMap);
-    }
-
-    public J4pClient getClient() {
-        return client;
-    }
-
 }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/protocol/jmx/JMXSession.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/protocol/jmx/JMXSession.java
@@ -23,38 +23,23 @@ import org.hawkular.agent.monitor.inventory.ResourceTypeManager;
 import org.hawkular.agent.monitor.protocol.Driver;
 import org.hawkular.agent.monitor.protocol.LocationResolver;
 import org.hawkular.agent.monitor.protocol.Session;
-import org.jolokia.client.J4pClient;
 
 /**
- * @author <a href="https://github.com/ppalaga">Peter Palaga</a>
+ * A session for any JMX endpoint (local or remote)
  * @see Session
  */
 public class JMXSession
         extends Session<JMXNodeLocation> {
-    private final J4pClient client;
 
     public JMXSession(String feedId,
             MonitoredEndpoint endpoint,
             ResourceTypeManager<JMXNodeLocation> resourceTypeManager,
             Driver<JMXNodeLocation> driver,
-            LocationResolver<JMXNodeLocation> locationResolver,
-            J4pClient client) {
+            LocationResolver<JMXNodeLocation> locationResolver) {
         super(feedId, endpoint, resourceTypeManager, driver, locationResolver);
-        this.client = client;
     }
 
-    /** @see java.io.Closeable#close() */
     @Override
     public void close() throws IOException {
-        /* we could eventually close the client here if it was closeable */
-    }
-
-    /**
-     * Returns a native client.
-     *
-     * @return a native client
-     */
-    public J4pClient getClient() {
-        return client;
     }
 }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/protocol/jmx/JolokiaJMXDriver.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/protocol/jmx/JolokiaJMXDriver.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.agent.monitor.protocol.jmx;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.management.ObjectName;
+
+import org.hawkular.agent.monitor.diagnostics.ProtocolDiagnostics;
+import org.hawkular.agent.monitor.inventory.AttributeLocation;
+import org.hawkular.agent.monitor.protocol.Driver;
+import org.hawkular.agent.monitor.protocol.ProtocolException;
+import org.jolokia.client.J4pClient;
+import org.jolokia.client.exception.J4pException;
+import org.jolokia.client.request.J4pReadRequest;
+import org.jolokia.client.request.J4pReadResponse;
+import org.jolokia.client.request.J4pSearchRequest;
+import org.jolokia.client.request.J4pSearchResponse;
+
+import com.codahale.metrics.Timer.Context;
+
+/**
+ * The driver that will access a remote MBeanServer via the Jolokia REST API.
+ *
+ * @see Driver
+ */
+public class JolokiaJMXDriver extends JMXDriver {
+
+    private final J4pClient client;
+
+    /**
+     * Creates the JMX driver.
+     *
+     * @param diagnostics
+     * @param client the client used to connect to the JMX MBeanServer
+     */
+    public JolokiaJMXDriver(ProtocolDiagnostics diagnostics, J4pClient client) {
+        super(diagnostics);
+        this.client = client;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Map<JMXNodeLocation, ObjectName> fetchNodes(JMXNodeLocation query) throws ProtocolException {
+
+        try {
+            J4pSearchRequest searchReq = new J4pSearchRequest(query.getObjectName().getCanonicalName());
+            J4pSearchResponse searchResponse;
+            try (Context timerContext = getDiagnostics().getRequestTimer().time()) {
+                searchResponse = client.execute(searchReq);
+            }
+
+            Map<JMXNodeLocation, ObjectName> result = new HashMap<>();
+            for (ObjectName objectName : searchResponse.getObjectNames()) {
+                JMXNodeLocation location = new JMXNodeLocation(objectName);
+                result.put(location, objectName);
+            }
+            return Collections.unmodifiableMap(result);
+        } catch (J4pException e) {
+            getDiagnostics().getErrorRate().mark(1);
+            throw new ProtocolException(e);
+        } catch (Exception e) {
+            throw new ProtocolException(e);
+        }
+    }
+
+    @Override
+    public boolean attributeExists(AttributeLocation<JMXNodeLocation> location)
+            throws ProtocolException {
+        return true;
+    }
+
+    @Override
+    public Object fetchAttribute(AttributeLocation<JMXNodeLocation> location) throws ProtocolException {
+
+        try {
+            String[] attribute = location.getAttribute().split("#", 2);
+            J4pReadRequest request = new J4pReadRequest(location.getLocation().getObjectName(), attribute[0]);
+            if (attribute.length > 1) {
+                request.setPath(attribute[1]); // this is the sub-reference
+            }
+
+            J4pReadResponse response;
+            try (Context timerContext = getDiagnostics().getRequestTimer().time()) {
+                response = client.execute(request);
+            }
+            Collection<ObjectName> responseObjectNames = response.getObjectNames();
+            switch (responseObjectNames.size()) {
+                case 0:
+                    return null;
+                case 1:
+                    return response.getValue();
+                default:
+                    List<Object> results = new ArrayList<>(responseObjectNames.size());
+                    for (ObjectName responseObjectName : responseObjectNames) {
+                        Object value = response.getValue(responseObjectName, location.getAttribute());
+                        results.add(value);
+                    }
+                    return Collections.unmodifiableList(results);
+            }
+        } catch (Exception e) {
+            getDiagnostics().getErrorRate().mark(1);
+            throw new ProtocolException(e);
+        }
+    }
+
+    @Override
+    public Map<JMXNodeLocation, Object> fetchAttributeAsMap(AttributeLocation<JMXNodeLocation> location)
+            throws ProtocolException {
+
+        // short-circuit if its only one location
+        if (!new JMXLocationResolver().isMultiTarget(location.getLocation())) {
+            Object o = fetchAttribute(location);
+            return Collections.singletonMap(location.getLocation(), o);
+        }
+
+        Map<JMXNodeLocation, ObjectName> nodes = fetchNodes(location.getLocation());
+        Map<JMXNodeLocation, Object> attribsMap = new HashMap<>(nodes.size());
+        for (Map.Entry<JMXNodeLocation, ObjectName> entry : nodes.entrySet()) {
+            Object o = fetchAttribute(new AttributeLocation<>(entry.getKey(), location.getAttribute()));
+            attribsMap.put(entry.getKey(), o);
+        }
+
+        return Collections.unmodifiableMap(attribsMap);
+    }
+
+    public J4pClient getClient() {
+        return client;
+    }
+
+}

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/protocol/jmx/MBeanServerConnectionJMXDriver.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/protocol/jmx/MBeanServerConnectionJMXDriver.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.agent.monitor.protocol.jmx;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.management.MBeanServerConnection;
+import javax.management.ObjectName;
+import javax.management.openmbean.CompositeData;
+
+import org.hawkular.agent.monitor.diagnostics.ProtocolDiagnostics;
+import org.hawkular.agent.monitor.inventory.AttributeLocation;
+import org.hawkular.agent.monitor.protocol.Driver;
+import org.hawkular.agent.monitor.protocol.ProtocolException;
+
+import com.codahale.metrics.Timer.Context;
+
+/**
+ * The driver that will access a local MBeanServer via the JMX API.
+ *
+ * @see Driver
+ */
+public class MBeanServerConnectionJMXDriver extends JMXDriver {
+
+    private final MBeanServerConnection mbs;
+
+    /**
+     * Creates the JMX driver.
+     *
+     * @param diagnostics
+     * @param mbs the client used to connect to the JMX MBeanServer
+     */
+    public MBeanServerConnectionJMXDriver(ProtocolDiagnostics diagnostics, MBeanServerConnection mbs) {
+        super(diagnostics);
+        this.mbs = mbs;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Map<JMXNodeLocation, ObjectName> fetchNodes(JMXNodeLocation query) throws ProtocolException {
+
+        try {
+            Set<ObjectName> searchResponse;
+            try (Context timerContext = getDiagnostics().getRequestTimer().time()) {
+                searchResponse = this.mbs.queryNames(query.getObjectName(), null);
+            }
+
+            Map<JMXNodeLocation, ObjectName> result = new HashMap<>();
+            for (ObjectName objectName : searchResponse) {
+                JMXNodeLocation location = new JMXNodeLocation(objectName);
+                result.put(location, objectName);
+            }
+            return Collections.unmodifiableMap(result);
+        } catch (Exception e) {
+            getDiagnostics().getErrorRate().mark(1);
+            throw new ProtocolException(e);
+        }
+    }
+
+    @Override
+    public boolean attributeExists(AttributeLocation<JMXNodeLocation> location)
+            throws ProtocolException {
+        return true; // assume it exists
+    }
+
+    @Override
+    public Object fetchAttribute(AttributeLocation<JMXNodeLocation> location) throws ProtocolException {
+        try {
+            Map<JMXNodeLocation, ObjectName> all = fetchNodes(location.getLocation());
+            if (all.isEmpty()) {
+                return null;
+            }
+
+            String[] attributeArr = location.getAttribute().split("#", 2);
+            String mainAttribute = attributeArr[0];
+            String subAttribute = (attributeArr.length > 1) ? attributeArr[1] : null;
+
+            List<Object> results = new ArrayList<>(all.size());
+
+            for (Map.Entry<JMXNodeLocation, ObjectName> entry : all.entrySet()) {
+                ObjectName objName = entry.getValue();
+                Object value;
+                try (Context timerContext = getDiagnostics().getRequestTimer().time()) {
+                    value = this.mbs.getAttribute(objName, mainAttribute);
+                }
+                if (subAttribute == null) {
+                    results.add(value); // found the attribute
+                } else {
+                    if (value instanceof CompositeData) {
+                        CompositeData cd = (CompositeData) value;
+                        results.add(cd.get(subAttribute));
+                    } else {
+                        throw new Exception("Not a composite attribute: " + location);
+                    }
+                }
+            }
+
+            if (results.size() == 1) {
+                return results.get(0);
+            } else {
+                return Collections.unmodifiableList(results);
+            }
+        } catch (Exception e) {
+            getDiagnostics().getErrorRate().mark(1);
+            throw new ProtocolException(e);
+        }
+    }
+
+    @Override
+    public Map<JMXNodeLocation, Object> fetchAttributeAsMap(AttributeLocation<JMXNodeLocation> location)
+            throws ProtocolException {
+
+        // short-circuit if its only one location
+        if (!new JMXLocationResolver().isMultiTarget(location.getLocation())) {
+            Object o = fetchAttribute(location);
+            return Collections.singletonMap(location.getLocation(), o);
+        }
+
+        Map<JMXNodeLocation, ObjectName> nodes = fetchNodes(location.getLocation());
+        Map<JMXNodeLocation, Object> attribsMap = new HashMap<>(nodes.size());
+        for (Map.Entry<JMXNodeLocation, ObjectName> entry : nodes.entrySet()) {
+            Object o = fetchAttribute(new AttributeLocation<>(entry.getKey(), location.getAttribute()));
+            attribsMap.put(entry.getKey(), o);
+        }
+
+        return Collections.unmodifiableMap(attribsMap);
+    }
+}

--- a/hawkular-wildfly-agent/src/main/resources/org/hawkular/agent/monitor/extension/LocalDescriptions.properties
+++ b/hawkular-wildfly-agent/src/main/resources/org/hawkular/agent/monitor/extension/LocalDescriptions.properties
@@ -156,6 +156,18 @@ hawkular-wildfly-agent.managed-servers.remote-jmx.tenant-id=If specified, metric
 hawkular-wildfly-agent.managed-servers.remote-jmx.metric-id-template=If specified, all metric IDs for this managed server will be constructed from the given template which can use tokens such as %FeedId, %ManagedServerName, and others. If not specified, a default ID will be generated.
 hawkular-wildfly-agent.managed-servers.remote-jmx.metric-tags=Comma separated list of name=value pairs that will be tags created on the metric definition in Hawkular Metrics.
 
+hawkular-wildfly-agent.managed-servers.local-jmx=A local JMX managed server accessed via the standard internal JMX API
+hawkular-wildfly-agent.managed-servers.local-jmx.add=Adds a local JMX managed server
+hawkular-wildfly-agent.managed-servers.local-jmx.remove=Removes a local JMX managed server
+hawkular-wildfly-agent.managed-servers.local-jmx.name=A name this agent will assign to the local JMX endpoint
+hawkular-wildfly-agent.managed-servers.local-jmx.enabled=True if you want to monitor the resources hosted in this server
+hawkular-wildfly-agent.managed-servers.local-jmx.mbean-server-name=The name of the internal MBean Server that hosts the MBeans being monitored. This is technically the default domain name of the MBeanServer.
+hawkular-wildfly-agent.managed-servers.local-jmx.set-avail-on-shutdown=If set then when the agent shuts down all availability metrics on all resources for this managed server will be set to this value (typically you will set this to DOWN or UNKNOWN, default is unset). This is for use only with storage-adapter type="METRICS". The "HAWKULAR" storage-adapter utilizes a server-side mechanism.
+hawkular-wildfly-agent.managed-servers.local-jmx.resource-type-sets=Comma-separated names of the resource type sets which indicate what resources to manage in this managed server
+hawkular-wildfly-agent.managed-servers.local-jmx.tenant-id=If specified, metrics from this endpoint will be associated with the given tenant ID rather than the agent's tenant ID.
+hawkular-wildfly-agent.managed-servers.local-jmx.metric-id-template=If specified, all metric IDs for this managed server will be constructed from the given template which can use tokens such as %FeedId, %ManagedServerName, and others. If not specified, a default ID will be generated.
+hawkular-wildfly-agent.managed-servers.local-jmx.metric-tags=Comma separated list of name=value pairs that will be tags created on the metric definition in Hawkular Metrics.
+
 # RESOURCE TYPES
 
 # RESOURCE TYPES - DMR

--- a/hawkular-wildfly-agent/src/main/resources/schema/hawkular-agent-monitor-subsystem.xsd
+++ b/hawkular-wildfly-agent/src/main/resources/schema/hawkular-agent-monitor-subsystem.xsd
@@ -297,6 +297,7 @@
       <xs:element name="remote-dmr"        type="remoteDmrType"        minOccurs="0" maxOccurs="unbounded"/>
       <xs:element name="local-dmr"         type="localDmrType"         minOccurs="0" maxOccurs="1"/>
       <xs:element name="remote-jmx"        type="remoteJmxType"        minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="local-jmx"         type="localJmxType"         minOccurs="0" maxOccurs="unbounded"/>
     </xs:sequence>
   </xs:complexType>
 
@@ -334,6 +335,17 @@
     <xs:attribute name="username"              type="xs:string"/>
     <xs:attribute name="password"              type="xs:string"/>
     <xs:attribute name="security-realm"        type="xs:string"/>
+    <xs:attribute name="set-avail-on-shutdown" type="xs:string"/>
+    <xs:attribute name="resource-type-sets"    type="xs:string"/>
+    <xs:attribute name="tenant-id"             type="xs:string"/>
+    <xs:attribute name="metric-id-template"    type="xs:string"/>
+    <xs:attribute name="metric-labels"         type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="localJmxType">
+    <xs:attribute name="name"                  type="xs:string" use="required"/>
+    <xs:attribute name="enabled"               type="xs:boolean"/>
+    <xs:attribute name="mbean-server-name"     type="xs:string"/>
     <xs:attribute name="set-avail-on-shutdown" type="xs:string"/>
     <xs:attribute name="resource-type-sets"    type="xs:string"/>
     <xs:attribute name="tenant-id"             type="xs:string"/>

--- a/hawkular-wildfly-agent/src/test/java/org/hawkular/agent/monitor/extension/SubsystemParsingTestCase.java
+++ b/hawkular-wildfly-agent/src/test/java/org/hawkular/agent/monitor/extension/SubsystemParsingTestCase.java
@@ -55,7 +55,7 @@ public class SubsystemParsingTestCase extends SubsystemBaseParsingTestCase {
         List<ModelNode> operations = super.parse(subsystemXml);
 
         ///Check that we have the expected number of operations
-        final int expectedOperations = 35;
+        final int expectedOperations = 36;
         Assert.assertEquals("Wrong operations: " + operations, expectedOperations, operations.size());
 
         //Check that each operation has the correct content

--- a/hawkular-wildfly-agent/src/test/resources/org/hawkular/agent/monitor/extension/subsystem-xsd-full.xml
+++ b/hawkular-wildfly-agent/src/test/resources/org/hawkular/agent/monitor/extension/subsystem-xsd-full.xml
@@ -169,6 +169,15 @@
                 metric-id-template="%FeedId-%ResourceName-%MetricTypeName"
                 metric-labels="feed=%FeedId,Label One=Value One" />
 
+    <local-jmx name="Local JMX"
+               enabled="true"
+               mbean-server-name="mbs"
+               set-avail-on-shutdown="UP"
+               resource-type-sets="R Resource Type Set"
+               tenant-id="tenantOverride"
+               metric-id-template="%FeedId-%ResourceName-%MetricTypeName"
+               metric-labels="feed=%FeedId,Label One=Value One" />
+
   </managed-servers>
 
   <platform enabled="true" machine-id="1234567890abcdef" interval="10" time-units="seconds">

--- a/hawkular-wildfly-agent/src/test/resources/org/hawkular/agent/monitor/extension/subsystem-xsd-required.xml
+++ b/hawkular-wildfly-agent/src/test/resources/org/hawkular/agent/monitor/extension/subsystem-xsd-required.xml
@@ -77,6 +77,8 @@
     <remote-jmx name="Remote JMX"
                 url="https://localhost:8080/jolokia"/>
 
+    <local-jmx name="Local JMX" />
+
   </managed-servers>
 
 </subsystem>

--- a/hawkular-wildfly-agent/src/test/resources/org/hawkular/agent/monitor/extension/subsystem.xml
+++ b/hawkular-wildfly-agent/src/test/resources/org/hawkular/agent/monitor/extension/subsystem.xml
@@ -136,6 +136,11 @@
                 security-realm="HawkularRealm"
                 resource-type-sets="R Resource Type Set" />
 
+    <local-jmx name="Remote JMX"
+               enabled="false"
+               mbean-server-name="mbs"
+               resource-type-sets="R Resource Type Set" />
+
   </managed-servers>
 
   <platform enabled="false">

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
 
     <version.org.jboss.aesh>0.66.7</version.org.jboss.aesh>
     <version.org.jgrapht>0.9.1</version.org.jgrapht>
-    <version.org.jolokia>1.3.2</version.org.jolokia>
+    <version.org.jolokia>1.3.5</version.org.jolokia>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
This adds a new local-jmx managed server so you can monitor JMX from within the same VM as where the agent is running without going over Jolokia REST.

NOTE: this is based on the PR#274 branch