### PR TITLE
Try to read machine-id from property if set by user.

### DIFF
--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/util/Util.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/util/Util.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -68,6 +68,7 @@ public class Util {
 
     private static final String ENCODING_UTF_8 = "utf-8";
     private static final int BUFFER_SIZE = 128;
+    private static final String HAWKULAR_AGENT_MACHINE_ID = "hawkular.agent.machine.id";
     private static ObjectMapper mapper;
     private static String systemId;
 
@@ -233,7 +234,7 @@ public class Util {
      * closed when this method returns. WARNING: do not slurp large streams to avoid out-of-memory errors.
      *
      * @param input the input stream to slup
-     * @param the encoding to use when reading from {@code input}
+     * @param encoding the encoding to use when reading from {@code input}
      * @return the input stream data as a String
      * @throws IOException in IO problems
      */
@@ -329,10 +330,20 @@ public class Util {
 
     /**
      * Tries to determine the system ID for the machine where this JVM is located.
+     * First check if the user explicitly set it. If not try to read it from
+     * /etc/machine-id
      *
      * @return system ID or null if cannot determine
      */
     public static String getSystemId() {
+
+        if (systemId == null) {
+            systemId = System.getProperty(HAWKULAR_AGENT_MACHINE_ID);
+            if (systemId != null) {
+                log.infof("MachineId was explicitly set to [%s]", systemId);
+            }
+        }
+
         if (systemId == null) {
             File machineIdFile = new File("/etc/machine-id");
             if (machineIdFile.exists() && machineIdFile.canRead()) {


### PR DESCRIPTION
This is a proposal to read the machine id from a property if set there.
That can then in container deployments be set to the container-id 
(in fact in this case it could just be the hostname = server name = feed id)

See also https://github.com/pilhuhn/hawkular-agent/blob/hawkfly/docker-dist/src/main/resources/standalone.conf#L58