### PR TITLE
Prevent multiple restarts when changing multiple attributes on a

### DIFF
--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/MonitorServiceRestartParentAttributeHandler.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/MonitorServiceRestartParentAttributeHandler.java
@@ -19,6 +19,7 @@ package org.hawkular.agent.monitor.extension;
 import java.util.Collection;
 
 import org.hawkular.agent.monitor.service.MonitorService;
+import org.hawkular.agent.monitor.util.WildflyCompatibilityUtils;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -76,6 +77,7 @@ public class MonitorServiceRestartParentAttributeHandler extends RestartParentWr
                     throw new OperationFailedException("The removeServices step got added more times than needed - " +
                             "This shouldn't happen.");
                 }
+                WildflyCompatibilityUtils.operationContextStepCompleted(context);
             }
         }, OperationContext.Stage.RUNTIME);
     }
@@ -96,6 +98,7 @@ public class MonitorServiceRestartParentAttributeHandler extends RestartParentWr
                     throw new OperationFailedException("The recreateParentService step got added more times than needed - " +
                             "This shouldn't happen.");
                 }
+                WildflyCompatibilityUtils.operationContextStepCompleted(context);
             }
         }, OperationContext.Stage.RUNTIME);
     }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/util/WildflyCompatibilityUtils.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/util/WildflyCompatibilityUtils.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.List;
 
 import org.hawkular.agent.monitor.extension.MonitorServiceRestartParentAttributeHandler;
+import org.hawkular.inventory.api.Log;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -286,5 +287,24 @@ public class WildflyCompatibilityUtils {
             recreateParentService(context, parentAddress, parentModel);
         }
 
+    }
+
+    public static void operationContextStepCompleted(OperationContext context) {
+        // This method is now deprecated, but we are required to call it under EAP6.4 to mark an Step
+        // as completed else we will get: "Operation handler failed to complete"
+        // Since is deprecated we would like to know if it still exists before calling it.
+        Method stepCompletedMethod = null;
+        try {
+            stepCompletedMethod = OperationContext.class.getMethod("stepCompleted");
+            stepCompletedMethod.invoke(context);
+        } catch (ReflectiveOperationException roe) {
+            if (stepCompletedMethod != null) {
+                // The method exists, but for some reason we couldn't invoke it. If we are on EAP6.4 we are most
+                // likely see errors.
+                Log.LOGGER.warn("We couldn't execute stepCompleted", roe);
+            } else {
+                // We couldn't find this method, lets just ignore this exception.
+            }
+        }
     }
 }


### PR DESCRIPTION
composite operation.

I like this approach because I don't need to copy code from parent class.

@jmazzitelli please take a look at let me know if I should use this PR or the other as [base](https://github.com/hawkular/hawkular-agent/pull/291).

I'll continue on Monday, will add itests to check if the agent is being restarted more than once.
