### PR TITLE
Add 'in-container' to xsd

### DIFF
--- a/hawkular-wildfly-agent/src/main/resources/schema/hawkular-agent-monitor-subsystem.xsd
+++ b/hawkular-wildfly-agent/src/main/resources/schema/hawkular-agent-monitor-subsystem.xsd
@@ -41,6 +41,7 @@
     </xs:sequence>
     <xs:attribute name="enabled"                          type="xs:boolean"/>
     <xs:attribute name="immutable"                        type="xs:boolean"/>
+    <xs:attribute name="in-container"                     type="xs:boolean"/>
     <xs:attribute name="api-jndi-name"                    type="xs:string"/>
     <xs:attribute name="auto-discovery-scan-period-secs"  type="xs:int"/>
     <xs:attribute name="min-collection-interval-secs"     type="xs:int"/>


### PR DESCRIPTION
The in-container attribute was missing in the XSD.