### PR TITLE
Reflect immutable + in-container attributes at server level.

### DIFF
--- a/eap6-support/hawkular-wildfly-agent-feature-pack-eap6/src/main/resources/subsystem-templates/hawkular-wildfly-agent.xml
+++ b/eap6-support/hawkular-wildfly-agent-feature-pack-eap6/src/main/resources/subsystem-templates/hawkular-wildfly-agent.xml
@@ -616,7 +616,7 @@
         <resource-config-dmr name="Bound Address"
                              path="/socket-binding-group=standard-sockets/socket-binding=http"
                              attribute="bound-address" />
-        <resource-config-dmr name="Is Immutable"
+        <resource-config-dmr name="Immutable"
                              path="/subsystem=hawkular-wildfly-agent"
                              attribute="immutable"
                              resolve-expressions="true"/>

--- a/eap6-support/hawkular-wildfly-agent-feature-pack-eap6/src/main/resources/subsystem-templates/hawkular-wildfly-agent.xml
+++ b/eap6-support/hawkular-wildfly-agent-feature-pack-eap6/src/main/resources/subsystem-templates/hawkular-wildfly-agent.xml
@@ -616,6 +616,14 @@
         <resource-config-dmr name="Bound Address"
                              path="/socket-binding-group=standard-sockets/socket-binding=http"
                              attribute="bound-address" />
+        <resource-config-dmr name="Is Immutable"
+                             path="/subsystem=hawkular-wildfly-agent"
+                             attribute="immutable"
+                             resolve-expressions="true"/>
+        <resource-config-dmr name="In Container"
+                             path="/subsystem=hawkular-wildfly-agent"
+                             attribute="in-container"
+                             resolve-expressions="true"/>
 
         <operation-dmr name="JDR"      internal-name="generate-jdr-report" path="/subsystem=jdr" />
         <operation-dmr name="Reload"   internal-name="reload" modifies="true">

--- a/hawkular-swarm-agents/hawkular-swarm-agent-dists/hawkular-swarm-agent-dist/src/main/resources/hawkular-swarm-agent-config.xml
+++ b/hawkular-swarm-agents/hawkular-swarm-agent-dists/hawkular-swarm-agent-dist/src/main/resources/hawkular-swarm-agent-config.xml
@@ -716,7 +716,7 @@
           <resource-config-dmr name="Bound Address"
                                path="/socket-binding-group=standard-sockets/socket-binding=http"
                                attribute="bound-address"/>
-          <resource-config-dmr name="Is Immutable"
+          <resource-config-dmr name="Immutable"
                                path="/subsystem=hawkular-wildfly-agent"
                                attribute="immutable"
                                resolve-expressions="true"/>
@@ -754,7 +754,7 @@
           <resource-config-dmr name="Version"         attribute="product-version"/>
           <resource-config-dmr name="Process Type"    attribute="process-type"/> <!-- (Host|Domain) Controller -->
           <resource-config-dmr name="Local Host Name" attribute="local-host-name"/>
-          <resource-config-dmr name="Is Immutable"
+          <resource-config-dmr name="Immutable"
                                path="/subsystem=hawkular-wildfly-agent"
                                attribute="immutable"
                                resolve-expressions="true"/>

--- a/hawkular-swarm-agents/hawkular-swarm-agent-dists/hawkular-swarm-agent-dist/src/main/resources/hawkular-swarm-agent-config.xml
+++ b/hawkular-swarm-agents/hawkular-swarm-agent-dists/hawkular-swarm-agent-dist/src/main/resources/hawkular-swarm-agent-config.xml
@@ -716,6 +716,14 @@
           <resource-config-dmr name="Bound Address"
                                path="/socket-binding-group=standard-sockets/socket-binding=http"
                                attribute="bound-address"/>
+          <resource-config-dmr name="Is Immutable"
+                               path="/subsystem=hawkular-wildfly-agent"
+                               attribute="immutable"
+                               resolve-expressions="true"/>
+          <resource-config-dmr name="In Container"
+                               path="/subsystem=hawkular-wildfly-agent"
+                               attribute="in-container"
+                               resolve-expressions="true"/>
 
           <operation-dmr name="JDR"      internal-name="generate-jdr-report" path="/subsystem=jdr"/>
           <operation-dmr name="Reload"   internal-name="reload" modifies="true">
@@ -746,6 +754,14 @@
           <resource-config-dmr name="Version"         attribute="product-version"/>
           <resource-config-dmr name="Process Type"    attribute="process-type"/> <!-- (Host|Domain) Controller -->
           <resource-config-dmr name="Local Host Name" attribute="local-host-name"/>
+          <resource-config-dmr name="Is Immutable"
+                               path="/subsystem=hawkular-wildfly-agent"
+                               attribute="immutable"
+                               resolve-expressions="true"/>
+          <resource-config-dmr name="In Container"
+                               path="/subsystem=hawkular-wildfly-agent"
+                               attribute="in-container"
+                               resolve-expressions="true"/>
 
           <operation-dmr name="Reload Servers"  internal-name="reload-servers" modifies="true">
             <param name="blocking" type="bool" description="Wait until the servers are stopped before returning from the operation."/>

--- a/hawkular-wildfly-agent-feature-pack/src/main/resources/subsystem-templates/hawkular-wildfly-agent.xml
+++ b/hawkular-wildfly-agent-feature-pack/src/main/resources/subsystem-templates/hawkular-wildfly-agent.xml
@@ -646,6 +646,14 @@
         <resource-config-dmr name="Bound Address"
                              path="/socket-binding-group=standard-sockets/socket-binding=http"
                              attribute="bound-address" />
+        <resource-config-dmr name="Is Immutable"
+                             path="/subsystem=hawkular-wildfly-agent"
+                             attribute="immutable"
+                             resolve-expressions="true"/>
+        <resource-config-dmr name="In Container"
+                             path="/subsystem=hawkular-wildfly-agent"
+                             attribute="in-container"
+                             resolve-expressions="true"/>
 
         <operation-dmr name="JDR"      internal-name="generate-jdr-report" path="/subsystem=jdr" />
         <operation-dmr name="Reload"   internal-name="reload" modifies="true">
@@ -676,6 +684,14 @@
         <resource-config-dmr name="Version"         attribute="product-version" />
         <resource-config-dmr name="Process Type"    attribute="process-type" /> <!-- (Host|Domain) Controller -->
         <resource-config-dmr name="Local Host Name" attribute="local-host-name" />
+        <resource-config-dmr name="Is Immutable"
+                             path="/subsystem=hawkular-wildfly-agent"
+                             attribute="immutable"
+                             resolve-expressions="true"/>
+        <resource-config-dmr name="In Container"
+                             path="/subsystem=hawkular-wildfly-agent"
+                             attribute="in-container"
+                             resolve-expressions="true"/>
 
         <operation-dmr name="Reload Servers"  internal-name="reload-servers" modifies="true">
           <param name="blocking" type="bool" description="Wait until the servers are stopped before returning from the operation."/>

--- a/hawkular-wildfly-agent-feature-pack/src/main/resources/subsystem-templates/hawkular-wildfly-agent.xml
+++ b/hawkular-wildfly-agent-feature-pack/src/main/resources/subsystem-templates/hawkular-wildfly-agent.xml
@@ -646,7 +646,7 @@
         <resource-config-dmr name="Bound Address"
                              path="/socket-binding-group=standard-sockets/socket-binding=http"
                              attribute="bound-address" />
-        <resource-config-dmr name="Is Immutable"
+        <resource-config-dmr name="Immutable"
                              path="/subsystem=hawkular-wildfly-agent"
                              attribute="immutable"
                              resolve-expressions="true"/>
@@ -684,7 +684,7 @@
         <resource-config-dmr name="Version"         attribute="product-version" />
         <resource-config-dmr name="Process Type"    attribute="process-type" /> <!-- (Host|Domain) Controller -->
         <resource-config-dmr name="Local Host Name" attribute="local-host-name" />
-        <resource-config-dmr name="Is Immutable"
+        <resource-config-dmr name="Immutable"
                              path="/subsystem=hawkular-wildfly-agent"
                              attribute="immutable"
                              resolve-expressions="true"/>


### PR DESCRIPTION
While both are available at agent level, it is not what users expect and also make it harder for clients to quickly check if the server runs in container and/or is immutable.

This change also adds those 2 properties in the list of properties that the server sends to inventory at the level of the server resource.

<img width="406" alt="bildschirmfoto 2017-02-15 um 10 43 23" src="https://cloud.githubusercontent.com/assets/208246/22968667/a5f4c2a6-f36b-11e6-8caf-9f99855bfb53.png">
