### PR TITLE
Replace slf4j-nop with logback-classic.   slf4j-nop causes problems in SpringBoot apps where logback is used.

### DIFF
--- a/hawkular-javaagent/pom.xml
+++ b/hawkular-javaagent/pom.xml
@@ -59,9 +59,9 @@
     <!-- Some third-party libraries (e.g. okhttp3) use SLF4J logging API.
          To avoid errors spitting out, we need to include an SLF4J binding -->
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-nop</artifactId>
-      <version>1.7.21</version>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.2.1</version>
       <scope>compile</scope>
     </dependency>
 


### PR DESCRIPTION
slf4j-nop is causing problems when I try to attach the agent to SpringBoot applications - I see the following stack : 

https://gist.github.com/cunningt/a0f30ebc22164c44394da40e7cbdc945

Open to solutions here, but one possible solution seems to be replacing slf4j-nop with logback-classic.    Seems to work for me when I attach the agent to SpringBoot apps or non-SpringBoot apps . 

Using the logback implementation might require additional logging configuration.  