### PR TITLE
HWKAGENT-165 Allow the agent to be told to wait

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,7 @@ install:
 # unshallow is needed by license-maven-plugin
 - git fetch origin --unshallow
 script:
-- ./mvnw -s .travis.maven.settings.xml verify -Pitest -Dfailsafe.useFile=false | grep -vF "[INFO] Downloading:" | grep
-  -vF "[INFO] Downloaded:"; test ${PIPESTATUS[0]} -eq 0
+- ./mvnw -s .travis.maven.settings.xml clean verify -Pitest
 env:
   global:
   - secure: DOP9OifGr7yBDNdkn1Tl58ur4tJzqFaNzVktmX+KgpjDbWtKE3cqyqf1pElyAbSpTm8kVf/UAxUPyCXdRh/W7jj2jB6Tc5kwBCqM8UHjJ6QuZVGnpih4lO6EImV1MDW2+MNWvun7kdUgtRjCWohaYh4pTPAwOk8v7IfeewH1Ud4=

--- a/eap6-support/hawkular-wildfly-agent-feature-pack-eap6/src/main/resources/subsystem-templates/hawkular-wildfly-agent.xml
+++ b/eap6-support/hawkular-wildfly-agent-feature-pack-eap6/src/main/resources/subsystem-templates/hawkular-wildfly-agent.xml
@@ -1059,15 +1059,23 @@
                   port="9990"
                   username="adminUser"
                   password="adminPass"
-                  resource-type-sets="Standalone Environment,Deployment,Web Component,EJB,Datasource,XA Datasource,JDBC Driver,Transaction Manager,Messaging,Socket Binding Group,Clustering" />
+                  resource-type-sets="Standalone Environment,Deployment,Web Component,EJB,Datasource,XA Datasource,JDBC Driver,Transaction Manager,Messaging,Socket Binding Group,Clustering">
+        <wait-for name="/" />
+      </remote-dmr>
 
       <local-dmr name="Local"
                  enabled="true"
-                 resource-type-sets="Standalone Environment,Deployment,Web Component,EJB,Datasource,XA Datasource,JDBC Driver,Transaction Manager,Messaging,Socket Binding Group,Clustering,Hawkular" />
+                 resource-type-sets="Standalone Environment,Deployment,Web Component,EJB,Datasource,XA Datasource,JDBC Driver,Transaction Manager,Messaging,Socket Binding Group,Clustering,Hawkular">
+        <wait-for name="/" />
+      </local-dmr>
 
-      <remote-jmx name="Remote JMX" enabled="false" resource-type-sets="MainJMX,MemoryPoolJMX" url="http://localhost:8080/jolokia-war"/>
+      <remote-jmx name="Remote JMX" enabled="false" resource-type-sets="MainJMX,MemoryPoolJMX" url="http://localhost:8080/jolokia-war">
+        <wait-for name="java.lang:type=Runtime" />
+      </remote-jmx>
 
-      <local-jmx name="Local JMX" enabled="false" resource-type-sets="MainJMX,MemoryPoolJMX" />
+      <local-jmx name="Local JMX" enabled="false" resource-type-sets="MainJMX,MemoryPoolJMX">
+        <wait-for name="java.lang:type=Runtime" />
+      </local-jmx>
 
     </managed-servers>
 

--- a/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/config/AgentCoreEngineConfiguration.java
+++ b/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/config/AgentCoreEngineConfiguration.java
@@ -19,6 +19,7 @@ package org.hawkular.agent.monitor.config;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -354,6 +355,22 @@ public class AgentCoreEngineConfiguration {
     }
 
     public static class AbstractEndpointConfiguration {
+
+        public static class WaitFor {
+            private final String resource;
+
+            public WaitFor(String resource) {
+                this.resource = resource;
+            }
+
+            /**
+             * @return The resource to wait for (can be things like a DMR path or JMX object name).
+             */
+            public String getResource() {
+                return this.resource;
+            }
+        }
+
         private final String name;
         private final boolean enabled;
         private final ConnectionData connectionData;
@@ -362,10 +379,11 @@ public class AgentCoreEngineConfiguration {
         private final String metricIdTemplate;
         private final Map<String, String> metricTags;
         private final Map<String, ? extends Object> customData;
+        private final List<WaitFor> waitForResources;
 
         public AbstractEndpointConfiguration(String name, boolean enabled, ConnectionData connectionData,
                 String securityRealm, String tenantId, String metricIdTemplate, Map<String, String> metricTags,
-                Map<String, ? extends Object> customData) {
+                Map<String, ? extends Object> customData, List<WaitFor> waitForResources) {
             super();
             this.name = name;
             this.enabled = enabled;
@@ -375,6 +393,8 @@ public class AgentCoreEngineConfiguration {
             this.metricIdTemplate = metricIdTemplate;
             this.metricTags = metricTags;
             this.customData = (customData != null) ? Collections.unmodifiableMap(customData) : Collections.emptyMap();
+            this.waitForResources = (waitForResources != null) ? Collections.unmodifiableList(waitForResources)
+                    : Collections.emptyList();
         }
 
         public boolean isEnabled() {
@@ -428,6 +448,13 @@ public class AgentCoreEngineConfiguration {
         public boolean isLocal() {
             return connectionData == null;
         }
+
+        /**
+         * @return list of resources to wait for before starting to monitor the endpoint (will not be null)
+         */
+        public List<WaitFor> getWaitForResources() {
+            return waitForResources;
+        }
     }
 
     public static class EndpointConfiguration extends AbstractEndpointConfiguration {
@@ -436,8 +463,10 @@ public class AgentCoreEngineConfiguration {
 
         public EndpointConfiguration(String name, boolean enabled, Collection<Name> resourceTypeSets,
                 ConnectionData connectionData, String securityRealm, Avail setAvailOnShutdown, String tenantId,
-                String metricIdTemplate, Map<String, String> metricTags, Map<String, ? extends Object> customData) {
-            super(name, enabled, connectionData, securityRealm, tenantId, metricIdTemplate, metricTags, customData);
+                String metricIdTemplate, Map<String, String> metricTags, Map<String, ? extends Object> customData,
+                List<WaitFor> waitForResources) {
+            super(name, enabled, connectionData, securityRealm, tenantId, metricIdTemplate, metricTags, customData,
+                    waitForResources);
             this.resourceTypeSets = resourceTypeSets;
             this.setAvailOnShutdown = setAvailOnShutdown;
         }

--- a/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/protocol/LocationResolver.java
+++ b/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/protocol/LocationResolver.java
@@ -29,6 +29,17 @@ import org.hawkular.agent.monitor.inventory.NodeLocation;
  */
 public interface LocationResolver<L> {
     /**
+     * Given a string, this will build a location object L from that string.
+     *
+     * @param path an L location in string form.
+     *
+     * @return a Location object
+     *
+     * @throws Exception if the path is invalid and cannot be converted to a location object
+     */
+    L buildLocation(String path) throws Exception;
+
+    /**
      * Given a multi-target location (e.g. a location with a wildcard) and a single location,
      * this returns that portion of the single location that matches the multi-target wildcard.
      *

--- a/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/protocol/ProtocolService.java
+++ b/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/protocol/ProtocolService.java
@@ -100,6 +100,8 @@ public class ProtocolService<L, S extends Session<L>> {
     }
 
     public void start() {
+        // Note that any endpoint service start method may block!
+        // It may wait for resources to come up first before returning.
         for (EndpointService<L, S> service : getEndpointServices().values()) {
             service.start();
         }

--- a/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/protocol/ProtocolServices.java
+++ b/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/protocol/ProtocolServices.java
@@ -222,10 +222,13 @@ public class ProtocolServices {
     }
 
     public void start() {
+        // Note that any protocol service start method may block!
+        // It may wait for resources to come up first before returning.
         for (ProtocolService<?, ?> service : services) {
             service.start();
         }
 
+        // only start auto discovery after all services have started
         startAutoDiscovery();
     }
 

--- a/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/protocol/dmr/DMREndpointService.java
+++ b/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/protocol/dmr/DMREndpointService.java
@@ -87,6 +87,7 @@ public class DMREndpointService
             return fullId.toString();
         }
     }
+
     private final ModelControllerClientFactory modelControllerClientFactory;
 
     public DMREndpointService(String feedId, MonitoredEndpoint<EndpointConfiguration> endpoint,

--- a/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/protocol/dmr/DMRLocationResolver.java
+++ b/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/protocol/dmr/DMRLocationResolver.java
@@ -43,6 +43,11 @@ public class DMRLocationResolver implements LocationResolver<DMRNodeLocation> {
     }
 
     @Override
+    public DMRNodeLocation buildLocation(String path) throws Exception {
+        return DMRNodeLocation.of(path);
+    }
+
+    @Override
     public String findWildcardMatch(DMRNodeLocation multiTargetLocation, DMRNodeLocation singleLocation)
             throws ProtocolException {
 

--- a/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/protocol/jmx/JMXLocationResolver.java
+++ b/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/protocol/jmx/JMXLocationResolver.java
@@ -30,6 +30,11 @@ import org.hawkular.agent.monitor.protocol.ProtocolException;
 public class JMXLocationResolver implements LocationResolver<JMXNodeLocation> {
 
     @Override
+    public JMXNodeLocation buildLocation(String path) throws Exception {
+        return new JMXNodeLocation(path);
+    }
+
+    @Override
     public String findWildcardMatch(JMXNodeLocation multiTargetLocation, JMXNodeLocation singleLocation)
             throws ProtocolException {
 
@@ -103,7 +108,7 @@ public class JMXLocationResolver implements LocationResolver<JMXNodeLocation> {
         }
 
         return true;
-     }
+    }
 
     @Override
     public boolean matches(JMXNodeLocation query, JMXNodeLocation location) {

--- a/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/protocol/platform/PlatformLocationResolver.java
+++ b/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/protocol/platform/PlatformLocationResolver.java
@@ -29,6 +29,11 @@ import org.hawkular.agent.monitor.protocol.platform.PlatformPath.PathSegment;
 public class PlatformLocationResolver implements LocationResolver<PlatformNodeLocation> {
 
     @Override
+    public PlatformNodeLocation buildLocation(String path) throws Exception {
+        throw new UnsupportedOperationException("Cannot convert string to platform location - not implemented yet");
+    }
+
+    @Override
     public String findWildcardMatch(PlatformNodeLocation multiTargetLocation, PlatformNodeLocation singleLocation)
             throws ProtocolException {
         List<PathSegment> multiTargetPaths = multiTargetLocation.getPlatformPath().getSegments();

--- a/hawkular-agent-core/src/test/java/org/hawkular/agent/monitor/inventory/InventoryIdUtilTest.java
+++ b/hawkular-agent-core/src/test/java/org/hawkular/agent/monitor/inventory/InventoryIdUtilTest.java
@@ -31,7 +31,7 @@ public class InventoryIdUtilTest {
         ResourceIdParts parts;
 
         EndpointConfiguration endpointConfig = new EndpointConfiguration("testmanagedserver", true,
-                Collections.emptyList(), null, null, null, null, null, null, null);
+                Collections.emptyList(), null, null, null, null, null, null, null, null);
         MonitoredEndpoint<EndpointConfiguration> me = MonitoredEndpoint.<EndpointConfiguration> of(endpointConfig,
                 null);
 

--- a/hawkular-javaagent-itest-parent/hawkular-javaagent-all-itests/hawkular-javaagent-cmdgw-itest/pom.xml
+++ b/hawkular-javaagent-itest-parent/hawkular-javaagent-all-itests/hawkular-javaagent-cmdgw-itest/pom.xml
@@ -409,6 +409,28 @@
             </executions>
           </plugin>
 
+          <!-- force kill the app server -->
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>post-integration-test</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <tasks>
+                    <echo>Force kill running app servers...</echo>
+                    <exec executable="pkill">
+                      <arg value="-9" />
+                      <arg value="-f" />
+                      <arg value="java.*jboss" />
+                    </exec>
+                  </tasks>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
         </plugins>
       </build>
     </profile>

--- a/hawkular-javaagent-itest-parent/hawkular-javaagent-all-itests/hawkular-javaagent-cmdgw-itest/src/test/java/org/hawkular/agent/ws/test/UpdateCollectionIntervalsCommandITest.java
+++ b/hawkular-javaagent-itest-parent/hawkular-javaagent-all-itests/hawkular-javaagent-cmdgw-itest/src/test/java/org/hawkular/agent/ws/test/UpdateCollectionIntervalsCommandITest.java
@@ -90,7 +90,7 @@ public class UpdateCollectionIntervalsCommandITest extends AbstractCommandITest 
                         if (m.getInterval().intValue() == expectedVal) {
                             return;
                         } else {
-                            Assert.fail(String.format("Metric type [%s~%s] expected to be [%d] but was [%d]",
+                            Assert.fail(String.format("Metric type [%s~%s] expected to be [%d %s] but was [%d %s]",
                                     setName, metricName,
                                     expectedVal, expectedUnits.name(),
                                     m.getInterval().intValue(), m.getTimeUnits().name()));

--- a/hawkular-javaagent-itest-parent/hawkular-javaagent-all-itests/hawkular-javaagent-domain-itest/pom.xml
+++ b/hawkular-javaagent-itest-parent/hawkular-javaagent-all-itests/hawkular-javaagent-domain-itest/pom.xml
@@ -447,6 +447,28 @@
             </executions>
           </plugin>
 
+          <!-- force kill the app server -->
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>post-integration-test</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <tasks>
+                    <echo>Force kill running app servers...</echo>
+                    <exec executable="pkill">
+                      <arg value="-9" />
+                      <arg value="-f" />
+                      <arg value="java.*jboss" />
+                    </exec>
+                  </tasks>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
         </plugins>
       </build>
     </profile>

--- a/hawkular-javaagent/src/main/java/org/hawkular/agent/javaagent/config/ConfigConverter.java
+++ b/hawkular-javaagent/src/main/java/org/hawkular/agent/javaagent/config/ConfigConverter.java
@@ -29,6 +29,7 @@ import javax.management.ObjectName;
 
 import org.hawkular.agent.monitor.api.Avail;
 import org.hawkular.agent.monitor.config.AgentCoreEngineConfiguration;
+import org.hawkular.agent.monitor.config.AgentCoreEngineConfiguration.AbstractEndpointConfiguration.WaitFor;
 import org.hawkular.agent.monitor.config.AgentCoreEngineConfiguration.DiagnosticsConfiguration;
 import org.hawkular.agent.monitor.config.AgentCoreEngineConfiguration.EndpointConfiguration;
 import org.hawkular.agent.monitor.config.AgentCoreEngineConfiguration.GlobalConfiguration;
@@ -300,7 +301,8 @@ public class ConfigConverter {
                     config.getManagedServers().getLocalDmr().getTenantId(),
                     config.getManagedServers().getLocalDmr().getMetricIdTemplate(),
                     config.getManagedServers().getLocalDmr().getMetricTags(),
-                    null);
+                    null,
+                    asWaitForList(config.getManagedServers().getLocalDmr().getWaitFor()));
             managedServers.put(config.getManagedServers().getLocalDmr().getName(), localDmrEndpointConfig);
         }
 
@@ -327,7 +329,8 @@ public class ConfigConverter {
                         remoteDmr.getTenantId(),
                         remoteDmr.getMetricIdTemplate(),
                         remoteDmr.getMetricTags(),
-                        null);
+                        null,
+                        asWaitForList(remoteDmr.getWaitFor()));
 
                 managedServers.put(remoteDmr.getName(), remoteDmrEndpointConfig);
             }
@@ -465,7 +468,8 @@ public class ConfigConverter {
                     config.getManagedServers().getLocalJmx().getMetricIdTemplate(),
                     config.getManagedServers().getLocalJmx().getMetricTags(),
                     Collections.singletonMap(JMXEndpointService.MBEAN_SERVER_NAME_KEY,
-                            config.getManagedServers().getLocalJmx().getMbeanServerName()));
+                            config.getManagedServers().getLocalJmx().getMbeanServerName()),
+                    asWaitForList(config.getManagedServers().getLocalJmx().getWaitFor()));
             managedServers.put(config.getManagedServers().getLocalJmx().getName(), localJmx);
         }
 
@@ -493,7 +497,8 @@ public class ConfigConverter {
                         remoteJmx.getTenantId(),
                         remoteJmx.getMetricIdTemplate(),
                         remoteJmx.getMetricTags(),
-                        null);
+                        null,
+                        asWaitForList(remoteJmx.getWaitFor()));
 
                 managedServers.put(remoteJmx.getName(), remoteJmxEndpointConfig);
             }
@@ -849,7 +854,8 @@ public class ConfigConverter {
                     null,
                     null,
                     null,
-                    customData);
+                    customData,
+                    null);
             managedServers.put("platform", localPlatform);
         }
 
@@ -912,5 +918,17 @@ public class ConfigConverter {
             names.add(new Name(s));
         }
         return names;
+    }
+
+    private List<WaitFor> asWaitForList(org.hawkular.agent.javaagent.config.WaitFor[] arr) {
+        if (arr == null) {
+            return Collections.emptyList();
+        }
+        List<WaitFor> list = new ArrayList<>(arr.length);
+        for (org.hawkular.agent.javaagent.config.WaitFor arrEle : arr) {
+            WaitFor wf = new WaitFor(arrEle.getName());
+            list.add(wf);
+        }
+        return list;
     }
 }

--- a/hawkular-javaagent/src/main/java/org/hawkular/agent/javaagent/config/WaitFor.java
+++ b/hawkular-javaagent/src/main/java/org/hawkular/agent/javaagent/config/WaitFor.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.agent.javaagent.config;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonAutoDetect( //
+        fieldVisibility = Visibility.NONE, //
+        getterVisibility = Visibility.NONE, //
+        setterVisibility = Visibility.NONE, //
+        isGetterVisibility = Visibility.NONE)
+public class WaitFor implements Validatable {
+
+    @JsonProperty(required = true)
+    private String name;
+
+    public WaitFor() {
+    }
+
+    public WaitFor(WaitFor original) {
+        this.name = original.name;
+    }
+
+    @Override
+    public void validate() throws Exception {
+        if (name == null || name.trim().isEmpty()) {
+            throw new Exception("wait-for name must be specified");
+        }
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/hawkular-javaagent/src/test/java/org/hawkular/agent/javaagent/config/ConfigConverterTest.java
+++ b/hawkular-javaagent/src/test/java/org/hawkular/agent/javaagent/config/ConfigConverterTest.java
@@ -82,21 +82,33 @@ public class ConfigConverterTest {
 
         EndpointConfiguration localDmr = agentConfig.getDmrConfiguration().getEndpoints().get("Test Local DMR");
         Assert.assertEquals(true, localDmr.isEnabled());
+        Assert.assertEquals(2, localDmr.getWaitForResources().size());
+        Assert.assertEquals("/subsystem=undertow", localDmr.getWaitForResources().get(0).getResource());
+        Assert.assertEquals("/", localDmr.getWaitForResources().get(1).getResource());
 
         EndpointConfiguration localJmx = agentConfig.getJmxConfiguration().getEndpoints().get("Test Local JMX");
         Assert.assertEquals(true, localJmx.isEnabled());
+        Assert.assertEquals(2, localJmx.getWaitForResources().size());
+        Assert.assertEquals("java.lang:type=Runtime", localJmx.getWaitForResources().get(0).getResource());
+        Assert.assertEquals("java.lang:type=Memory", localJmx.getWaitForResources().get(1).getResource());
 
         EndpointConfiguration remoteDmr = agentConfig.getDmrConfiguration().getEndpoints().get("Test Remote DMR");
         Assert.assertEquals(true, remoteDmr.isEnabled());
+        Assert.assertEquals(1, remoteDmr.getWaitForResources().size());
+        Assert.assertEquals("/subsystem=undertow", remoteDmr.getWaitForResources().get(0).getResource());
 
         EndpointConfiguration remoteJmx = agentConfig.getJmxConfiguration().getEndpoints().get("Test Remote JMX");
         Assert.assertEquals(true, remoteJmx.isEnabled());
+        Assert.assertEquals(1, remoteJmx.getWaitForResources().size());
+        Assert.assertEquals("java.lang:type=Runtime", remoteJmx.getWaitForResources().get(0).getResource());
 
         EndpointConfiguration remoteDmr2 = agentConfig.getDmrConfiguration().getEndpoints().get("Test Remote DMR 2");
         Assert.assertEquals(true, remoteDmr2.isEnabled());
+        Assert.assertEquals(0, remoteDmr2.getWaitForResources().size());
 
         EndpointConfiguration remoteJmx2 = agentConfig.getJmxConfiguration().getEndpoints().get("Test Remote JMX 2");
         Assert.assertEquals(true, remoteJmx2.isEnabled());
+        Assert.assertEquals(0, remoteJmx2.getWaitForResources().size());
 
         EndpointConfiguration platform = agentConfig.getPlatformConfiguration().getEndpoints().get("platform");
         Assert.assertEquals(true, platform.isEnabled());

--- a/hawkular-javaagent/src/test/resources/real-config-eap6.yaml
+++ b/hawkular-javaagent/src/test/resources/real-config-eap6.yaml
@@ -1243,6 +1243,8 @@ managed-servers:
   local-dmr:
     name: Local DMR
     enabled: false
+    wait-for:
+    - name: /
     resource-type-sets:
     - Standalone Environment
     - Deployment
@@ -1260,6 +1262,8 @@ managed-servers:
   local-jmx:
     name: Local JMX
     enabled: true
+    wait-for:
+    - name: java.lang:type=Runtime
     resource-type-sets:
     - Main
     - Memory Pool
@@ -1273,6 +1277,8 @@ managed-servers:
     port: 9999
     username: adminUser
     password: adminPass
+    wait-for:
+    - name: /
     resource-type-sets:
     - Standalone Environment
     - Deployment
@@ -1290,6 +1296,8 @@ managed-servers:
   - name: Remote Jolokia Server
     enabled: false
     url: http://localhost:8080/jolokia-war
+    wait-for:
+    - name: java.lang:type=Runtime
     resource-type-sets:
     - Main
     - Memory Pool

--- a/hawkular-javaagent/src/test/resources/real-config-jmx.yaml
+++ b/hawkular-javaagent/src/test/resources/real-config-jmx.yaml
@@ -162,6 +162,8 @@ managed-servers:
   local-jmx:
     name: Local JMX
     enabled: true
+    wait-for:
+    - name: java.lang:type=Runtime
     resource-type-sets:
     - Main
     - Memory Pool
@@ -171,6 +173,8 @@ managed-servers:
   - name: Remote Jolokia Server
     enabled: false
     url: http://localhost:8080/jolokia-war
+    wait-for:
+    - name: java.lang:type=Runtime
     resource-type-sets:
     - Main
     - Memory Pool

--- a/hawkular-javaagent/src/test/resources/real-config.yaml
+++ b/hawkular-javaagent/src/test/resources/real-config.yaml
@@ -1405,6 +1405,8 @@ managed-servers:
   local-dmr:
     name: Local DMR
     enabled: true
+    wait-for:
+    - name: /
     resource-type-sets:
     - Standalone Environment
     - Deployment
@@ -1422,6 +1424,8 @@ managed-servers:
   local-jmx:
     name: Local JMX
     enabled: true
+    wait-for:
+    - name: java.lang:type=Runtime
     resource-type-sets:
     - Main
     - Memory Pool
@@ -1434,6 +1438,8 @@ managed-servers:
     port: 9990
     username: adminUser
     password: adminPass
+    wait-for:
+    - name: /
     resource-type-sets:
     - Standalone Environment
     - Deployment
@@ -1451,6 +1457,8 @@ managed-servers:
   - name: Remote Jolokia Server
     enabled: false
     url: http://localhost:8080/jolokia-war
+    wait-for:
+    - name: java.lang:type=Runtime
     resource-type-sets:
     - Main
     - Memory Pool

--- a/hawkular-javaagent/src/test/resources/simple.yaml
+++ b/hawkular-javaagent/src/test/resources/simple.yaml
@@ -102,6 +102,9 @@ managed-servers:
       localdmrtag1: val1
       dmrtag2: val2
     set-avail-on-shutdown: DOWN
+    wait-for:
+    - name: /subsystem=undertow
+    - name: /
 
   remote-dmr:
   - name:                  Remote WildFly
@@ -119,6 +122,8 @@ managed-servers:
       remotedmrtag1: val1
       dmrtag2: val2
     set-avail-on-shutdown: DOWN
+    wait-for:
+    - name: /subsystem=undertow
 
   local-jmx:
     name:                  Local JMX
@@ -133,6 +138,9 @@ managed-servers:
       jmxtag2: val2
     set-avail-on-shutdown: UNKNOWN
     mbean-server-name:     some-mbs-name
+    wait-for:
+    - name: java.lang:type=Runtime
+    - name: java.lang:type=Memory
 
   remote-jmx:
   - name:                  Remote JMX
@@ -148,6 +156,8 @@ managed-servers:
       remotejmxtag1: val1
       jmxtag2: val2
     set-avail-on-shutdown: UNKNOWN
+    wait-for:
+    - name: java.lang:type=Runtime
 
 platform:
   enabled:      true

--- a/hawkular-javaagent/src/test/resources/test-convert.yaml
+++ b/hawkular-javaagent/src/test/resources/test-convert.yaml
@@ -237,6 +237,9 @@ managed-servers:
     resource-type-sets:
     - first resource type set d
     - second resource type set d
+    wait-for:
+    - name: /subsystem=undertow
+    - name: /
 
   local-jmx:
     name:               Test Local JMX
@@ -244,6 +247,9 @@ managed-servers:
     resource-type-sets:
     - first resource type set
     - second resource type set
+    wait-for:
+    - name: java.lang:type=Runtime
+    - name: java.lang:type=Memory
 
   remote-dmr:
   - name:               Test Remote DMR
@@ -255,6 +261,8 @@ managed-servers:
     resource-type-sets:
     - first resource type set d
     - second resource type set d
+    wait-for:
+    - name: /subsystem=undertow
   - name:               Test Remote DMR 2
     enabled:            true
     host:               localhost2
@@ -271,6 +279,8 @@ managed-servers:
     resource-type-sets:
     - first resource type set
     - second resource type set
+    wait-for:
+    - name: java.lang:type=Runtime
   - name:               Test Remote JMX 2
     enabled:            true
     url:                http://localhost:9090/jolokia-war

--- a/hawkular-swarm-agents/hawkular-swarm-agent-dists/hawkular-swarm-agent-dist/src/main/resources/hawkular-swarm-agent-config.xml
+++ b/hawkular-swarm-agents/hawkular-swarm-agent-dists/hawkular-swarm-agent-dist/src/main/resources/hawkular-swarm-agent-config.xml
@@ -1216,7 +1216,9 @@
                     port="${hawkular.dmr.port:9990}"
                     username="${hawkular.dmr.username:admin}"
                     password="${hawkular.dmr.password:admin}"
-                    resource-type-sets="Standalone Environment,Deployment,Web Component,EJB,Datasource,XA Datasource,JDBC Driver,Transaction Manager,Messaging,Socket Binding Group,Clustering,Hawkular"/>
+                    resource-type-sets="Standalone Environment,Deployment,Web Component,EJB,Datasource,XA Datasource,JDBC Driver,Transaction Manager,Messaging,Socket Binding Group,Clustering,Hawkular">
+          <wait-for name="/" />
+        </remote-dmr>
       </managed-servers>
 
       <platform enabled="${hawkular.platform.enabled:true}">

--- a/hawkular-wildfly-agent-feature-pack/src/main/resources/subsystem-templates/hawkular-wildfly-agent.xml
+++ b/hawkular-wildfly-agent-feature-pack/src/main/resources/subsystem-templates/hawkular-wildfly-agent.xml
@@ -1146,15 +1146,23 @@
                   port="9990"
                   username="adminUser"
                   password="adminPass"
-                  resource-type-sets="Standalone Environment,Deployment,Web Component,EJB,Datasource,XA Datasource,JDBC Driver,Transaction Manager,Messaging,Socket Binding Group,Clustering" />
+                  resource-type-sets="Standalone Environment,Deployment,Web Component,EJB,Datasource,XA Datasource,JDBC Driver,Transaction Manager,Messaging,Socket Binding Group,Clustering">
+        <wait-for name="/" />
+      </remote-dmr>
 
       <local-dmr name="Local"
                  enabled="true"
-                 resource-type-sets="Standalone Environment,Deployment,Web Component,EJB,Datasource,XA Datasource,JDBC Driver,Transaction Manager,Messaging,Socket Binding Group,Clustering,Hawkular" />
+                 resource-type-sets="Standalone Environment,Deployment,Web Component,EJB,Datasource,XA Datasource,JDBC Driver,Transaction Manager,Messaging,Socket Binding Group,Clustering,Hawkular">
+        <wait-for name="/" />
+      </local-dmr>
 
-      <remote-jmx name="Remote JMX" enabled="false" resource-type-sets="MainJMX,MemoryPoolJMX" url="http://localhost:8080/jolokia-war"/>
+      <remote-jmx name="Remote JMX" enabled="false" resource-type-sets="MainJMX,MemoryPoolJMX" url="http://localhost:8080/jolokia-war">
+        <wait-for name="java.lang:type=Runtime" />
+      </remote-jmx>
 
-      <local-jmx name="Local JMX" enabled="false" resource-type-sets="MainJMX,MemoryPoolJMX" />
+      <local-jmx name="Local JMX" enabled="false" resource-type-sets="MainJMX,MemoryPoolJMX">
+        <wait-for name="java.lang:type=Runtime" />
+      </local-jmx>
 
     </managed-servers>
 

--- a/hawkular-wildfly-agent-installer/src/main/java/org/hawkular/wildfly/agent/installer/AgentInstaller.java
+++ b/hawkular-wildfly-agent-installer/src/main/java/org/hawkular/wildfly/agent/installer/AgentInstaller.java
@@ -478,7 +478,9 @@ public class AgentInstaller {
                 .append("<local-dmr name=\"" + managedServerName + "\" enabled=\"true\" "
                         + "resource-type-sets=\""
                         + managedServerResourceTypeSets
-                        + "\" />")
+                        + "\">")
+                .append("<wait-for name=\"/\" />")
+                .append("</local-dmr>")
                 .append("</managed-servers>");
 
         // replaces <managed-servers> under urn:org.hawkular.agent:agent:1.0 subsystem with above content

--- a/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-cmdgw-itest/pom.xml
+++ b/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-cmdgw-itest/pom.xml
@@ -381,6 +381,28 @@
             </executions>
           </plugin>
 
+          <!-- force kill the app server -->
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>post-integration-test</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <tasks>
+                    <echo>Force kill running app servers...</echo>
+                    <exec executable="pkill">
+                      <arg value="-9" />
+                      <arg value="-f" />
+                      <arg value="java.*jboss" />
+                    </exec>
+                  </tasks>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
         </plugins>
       </build>
     </profile>

--- a/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-domain-itest/pom.xml
+++ b/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-domain-itest/pom.xml
@@ -437,6 +437,28 @@
             </executions>
           </plugin>
 
+          <!-- force kill the app server -->
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>post-integration-test</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <tasks>
+                    <echo>Force kill running app servers...</echo>
+                    <exec executable="pkill">
+                      <arg value="-9" />
+                      <arg value="-f" />
+                      <arg value="java.*jboss" />
+                    </exec>
+                  </tasks>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
         </plugins>
       </build>
     </profile>

--- a/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-installer-itest/pom.xml
+++ b/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-installer-itest/pom.xml
@@ -430,6 +430,28 @@
             </executions>
           </plugin>
 
+          <!-- force kill the app server -->
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>post-integration-test</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <tasks>
+                    <echo>Force kill running app servers...</echo>
+                    <exec executable="pkill">
+                      <arg value="-9" />
+                      <arg value="-f" />
+                      <arg value="java.*jboss" />
+                    </exec>
+                  </tasks>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
         </plugins>
       </build>
     </profile>

--- a/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-jmx-itest/pom.xml
+++ b/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-all-itests/hawkular-wildfly-agent-jmx-itest/pom.xml
@@ -386,6 +386,28 @@
             </executions>
           </plugin>
 
+          <!-- force kill the app server -->
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>post-integration-test</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <tasks>
+                    <echo>Force kill running app servers...</echo>
+                    <exec executable="pkill">
+                      <arg value="-9" />
+                      <arg value="-f" />
+                      <arg value="java.*jboss" />
+                    </exec>
+                  </tasks>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
         </plugins>
       </build>
     </profile>

--- a/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-example-jndi/src/main/java/org/hawkular/agent/example/MyAppSamplingService.java
+++ b/hawkular-wildfly-agent-itest-parent/hawkular-wildfly-agent-example-jndi/src/main/java/org/hawkular/agent/example/MyAppSamplingService.java
@@ -48,7 +48,7 @@ public class MyAppSamplingService implements SamplingService<MyAppNodeLocation> 
             // this is our endpoint that Hawkular uses to collect metrics and availabilities for our managed resources
             ConnectionData connectionData = new ConnectionData(new URI("myapp:local-uri"), null, null);
             EndpointConfiguration config = new EndpointConfiguration("My App Endpoint", true, Collections.emptyList(),
-                    connectionData, null, null, HawkularWildFlyAgentProvider.TENANT_ID, null, null, null);
+                    connectionData, null, null, HawkularWildFlyAgentProvider.TENANT_ID, null, null, null, null);
             this.endpoint = MonitoredEndpoint.of(config, null);
         } catch (Exception e) {
             throw new IllegalStateException("Cannot create sampling service", e);

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalDMRDefinition.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalDMRDefinition.java
@@ -18,6 +18,7 @@ package org.hawkular.agent.monitor.extension;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 import org.hawkular.agent.monitor.config.AgentCoreEngineConfiguration;
 import org.hawkular.agent.monitor.protocol.EndpointService;
@@ -35,6 +36,7 @@ import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry.Flag;
 import org.jboss.dmr.ModelNode;
@@ -58,6 +60,11 @@ public class LocalDMRDefinition extends MonitorPersistentResourceDefinition {
     @Override
     public Collection<AttributeDefinition> getAttributes() {
         return Arrays.asList(LocalDMRAttributes.ATTRIBUTES);
+    }
+
+    @Override
+    protected List<? extends PersistentResourceDefinition> getChildren() {
+        return Arrays.asList(LocalDMRWaitForDefinition.INSTANCE);
     }
 
     @Override

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalDMRWaitForAdd.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalDMRWaitForAdd.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.agent.monitor.extension;
+
+public class LocalDMRWaitForAdd extends MonitorServiceAddStepHandler {
+    public static final LocalDMRWaitForAdd INSTANCE = new LocalDMRWaitForAdd();
+
+    private LocalDMRWaitForAdd() {
+        super(LocalDMRWaitForAttributes.ATTRIBUTES);
+    }
+}

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalDMRWaitForAttributes.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalDMRWaitForAttributes.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.agent.monitor.extension;
+
+import org.jboss.as.controller.AttributeDefinition;
+
+public interface LocalDMRWaitForAttributes {
+
+    AttributeDefinition[] ATTRIBUTES = {
+    };
+}

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalDMRWaitForDefinition.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalDMRWaitForDefinition.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.agent.monitor.extension;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.registry.OperationEntry.Flag;
+
+public class LocalDMRWaitForDefinition extends MonitorPersistentResourceDefinition {
+
+    public static final LocalDMRWaitForDefinition INSTANCE = new LocalDMRWaitForDefinition();
+
+    static final String WAIT_FOR = "wait-for";
+
+    private LocalDMRWaitForDefinition() {
+        super(PathElement.pathElement(WAIT_FOR),
+                SubsystemExtension.getResourceDescriptionResolver(ManagedServersDefinition.MANAGED_SERVERS,
+                        LocalDMRDefinition.LOCAL_DMR, WAIT_FOR),
+                LocalDMRWaitForAdd.INSTANCE,
+                LocalDMRWaitForRemove.INSTANCE,
+                Flag.RESTART_NONE,
+                Flag.RESTART_NONE);
+    }
+
+    @Override
+    public Collection<AttributeDefinition> getAttributes() {
+        return Arrays.asList(LocalDMRWaitForAttributes.ATTRIBUTES);
+    }
+}

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalDMRWaitForRemove.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalDMRWaitForRemove.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.agent.monitor.extension;
+
+public class LocalDMRWaitForRemove extends MonitorServiceRemoveStepHandler {
+
+    public static final LocalDMRWaitForRemove INSTANCE = new LocalDMRWaitForRemove();
+
+    private LocalDMRWaitForRemove() {
+    }
+}

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalJMXDefinition.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalJMXDefinition.java
@@ -18,6 +18,7 @@ package org.hawkular.agent.monitor.extension;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 import org.hawkular.agent.monitor.config.AgentCoreEngineConfiguration;
 import org.hawkular.agent.monitor.protocol.EndpointService;
@@ -34,6 +35,7 @@ import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry.Flag;
 import org.jboss.dmr.ModelNode;
@@ -57,6 +59,11 @@ public class LocalJMXDefinition extends MonitorPersistentResourceDefinition {
     @Override
     public Collection<AttributeDefinition> getAttributes() {
         return Arrays.asList(LocalJMXAttributes.ATTRIBUTES);
+    }
+
+    @Override
+    protected List<? extends PersistentResourceDefinition> getChildren() {
+        return Arrays.asList(LocalJMXWaitForDefinition.INSTANCE);
     }
 
     @Override

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalJMXWaitForAdd.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalJMXWaitForAdd.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.agent.monitor.extension;
+
+public class LocalJMXWaitForAdd extends MonitorServiceAddStepHandler {
+    public static final LocalJMXWaitForAdd INSTANCE = new LocalJMXWaitForAdd();
+
+    private LocalJMXWaitForAdd() {
+        super(LocalJMXWaitForAttributes.ATTRIBUTES);
+    }
+}

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalJMXWaitForAttributes.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalJMXWaitForAttributes.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.agent.monitor.extension;
+
+import org.jboss.as.controller.AttributeDefinition;
+
+public interface LocalJMXWaitForAttributes {
+
+    AttributeDefinition[] ATTRIBUTES = {
+    };
+}

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalJMXWaitForDefinition.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalJMXWaitForDefinition.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.agent.monitor.extension;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.registry.OperationEntry.Flag;
+
+public class LocalJMXWaitForDefinition extends MonitorPersistentResourceDefinition {
+
+    public static final LocalJMXWaitForDefinition INSTANCE = new LocalJMXWaitForDefinition();
+
+    static final String WAIT_FOR = "wait-for";
+
+    private LocalJMXWaitForDefinition() {
+        super(PathElement.pathElement(WAIT_FOR),
+                SubsystemExtension.getResourceDescriptionResolver(ManagedServersDefinition.MANAGED_SERVERS,
+                        LocalJMXDefinition.LOCAL_JMX, WAIT_FOR),
+                LocalJMXWaitForAdd.INSTANCE,
+                LocalJMXWaitForRemove.INSTANCE,
+                Flag.RESTART_NONE,
+                Flag.RESTART_NONE);
+    }
+
+    @Override
+    public Collection<AttributeDefinition> getAttributes() {
+        return Arrays.asList(LocalJMXWaitForAttributes.ATTRIBUTES);
+    }
+}

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalJMXWaitForRemove.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/LocalJMXWaitForRemove.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.agent.monitor.extension;
+
+public class LocalJMXWaitForRemove extends MonitorServiceRemoveStepHandler {
+
+    public static final LocalJMXWaitForRemove INSTANCE = new LocalJMXWaitForRemove();
+
+    private LocalJMXWaitForRemove() {
+    }
+}

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteDMRDefinition.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteDMRDefinition.java
@@ -18,6 +18,7 @@ package org.hawkular.agent.monitor.extension;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 import org.hawkular.agent.monitor.config.AgentCoreEngineConfiguration;
 import org.hawkular.agent.monitor.protocol.EndpointService;
@@ -35,6 +36,7 @@ import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry.Flag;
 import org.jboss.dmr.ModelNode;
@@ -58,6 +60,11 @@ public class RemoteDMRDefinition extends MonitorPersistentResourceDefinition {
     @Override
     public Collection<AttributeDefinition> getAttributes() {
         return Arrays.asList(RemoteDMRAttributes.ATTRIBUTES);
+    }
+
+    @Override
+    protected List<? extends PersistentResourceDefinition> getChildren() {
+        return Arrays.asList(RemoteDMRWaitForDefinition.INSTANCE);
     }
 
     @Override

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteDMRWaitForAdd.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteDMRWaitForAdd.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.agent.monitor.extension;
+
+public class RemoteDMRWaitForAdd extends MonitorServiceAddStepHandler {
+    public static final RemoteDMRWaitForAdd INSTANCE = new RemoteDMRWaitForAdd();
+
+    private RemoteDMRWaitForAdd() {
+        super(RemoteDMRWaitForAttributes.ATTRIBUTES);
+    }
+}

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteDMRWaitForAttributes.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteDMRWaitForAttributes.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.agent.monitor.extension;
+
+import org.jboss.as.controller.AttributeDefinition;
+
+public interface RemoteDMRWaitForAttributes {
+
+    AttributeDefinition[] ATTRIBUTES = {
+    };
+}

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteDMRWaitForDefinition.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteDMRWaitForDefinition.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.agent.monitor.extension;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.registry.OperationEntry.Flag;
+
+public class RemoteDMRWaitForDefinition extends MonitorPersistentResourceDefinition {
+
+    public static final RemoteDMRWaitForDefinition INSTANCE = new RemoteDMRWaitForDefinition();
+
+    static final String WAIT_FOR = "wait-for";
+
+    private RemoteDMRWaitForDefinition() {
+        super(PathElement.pathElement(WAIT_FOR),
+                SubsystemExtension.getResourceDescriptionResolver(ManagedServersDefinition.MANAGED_SERVERS,
+                        RemoteDMRDefinition.REMOTE_DMR, WAIT_FOR),
+                RemoteDMRWaitForAdd.INSTANCE,
+                RemoteDMRWaitForRemove.INSTANCE,
+                Flag.RESTART_NONE,
+                Flag.RESTART_NONE);
+    }
+
+    @Override
+    public Collection<AttributeDefinition> getAttributes() {
+        return Arrays.asList(RemoteDMRWaitForAttributes.ATTRIBUTES);
+    }
+}

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteDMRWaitForRemove.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteDMRWaitForRemove.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.agent.monitor.extension;
+
+public class RemoteDMRWaitForRemove extends MonitorServiceRemoveStepHandler {
+
+    public static final RemoteDMRWaitForRemove INSTANCE = new RemoteDMRWaitForRemove();
+
+    private RemoteDMRWaitForRemove() {
+    }
+}

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteJMXDefinition.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteJMXDefinition.java
@@ -18,6 +18,7 @@ package org.hawkular.agent.monitor.extension;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 import org.hawkular.agent.monitor.config.AgentCoreEngineConfiguration;
 import org.hawkular.agent.monitor.protocol.EndpointService;
@@ -34,6 +35,7 @@ import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry.Flag;
 import org.jboss.dmr.ModelNode;
@@ -57,6 +59,11 @@ public class RemoteJMXDefinition extends MonitorPersistentResourceDefinition {
     @Override
     public Collection<AttributeDefinition> getAttributes() {
         return Arrays.asList(RemoteJMXAttributes.ATTRIBUTES);
+    }
+
+    @Override
+    protected List<? extends PersistentResourceDefinition> getChildren() {
+        return Arrays.asList(RemoteJMXWaitForDefinition.INSTANCE);
     }
 
     @Override

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteJMXWaitForAdd.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteJMXWaitForAdd.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.agent.monitor.extension;
+
+public class RemoteJMXWaitForAdd extends MonitorServiceAddStepHandler {
+    public static final RemoteJMXWaitForAdd INSTANCE = new RemoteJMXWaitForAdd();
+
+    private RemoteJMXWaitForAdd() {
+        super(RemoteJMXWaitForAttributes.ATTRIBUTES);
+    }
+}

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteJMXWaitForAttributes.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteJMXWaitForAttributes.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.agent.monitor.extension;
+
+import org.jboss.as.controller.AttributeDefinition;
+
+public interface RemoteJMXWaitForAttributes {
+
+    AttributeDefinition[] ATTRIBUTES = {
+    };
+}

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteJMXWaitForDefinition.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteJMXWaitForDefinition.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.agent.monitor.extension;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.registry.OperationEntry.Flag;
+
+public class RemoteJMXWaitForDefinition extends MonitorPersistentResourceDefinition {
+
+    public static final RemoteJMXWaitForDefinition INSTANCE = new RemoteJMXWaitForDefinition();
+
+    static final String WAIT_FOR = "wait-for";
+
+    private RemoteJMXWaitForDefinition() {
+        super(PathElement.pathElement(WAIT_FOR),
+                SubsystemExtension.getResourceDescriptionResolver(ManagedServersDefinition.MANAGED_SERVERS,
+                        RemoteJMXDefinition.REMOTE_JMX, WAIT_FOR),
+                RemoteJMXWaitForAdd.INSTANCE,
+                RemoteJMXWaitForRemove.INSTANCE,
+                Flag.RESTART_NONE,
+                Flag.RESTART_NONE);
+    }
+
+    @Override
+    public Collection<AttributeDefinition> getAttributes() {
+        return Arrays.asList(RemoteJMXWaitForAttributes.ATTRIBUTES);
+    }
+}

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteJMXWaitForRemove.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/RemoteJMXWaitForRemove.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.agent.monitor.extension;
+
+public class RemoteJMXWaitForRemove extends MonitorServiceRemoveStepHandler {
+
+    public static final RemoteJMXWaitForRemove INSTANCE = new RemoteJMXWaitForRemove();
+
+    private RemoteJMXWaitForRemove() {
+    }
+}

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/SubsystemParser.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/SubsystemParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -130,18 +130,34 @@ public class SubsystemParser implements XMLStreamConstants, XMLElementReader<Lis
                                     .addChild(builder(RemoteDMRDefinition.INSTANCE)
                                             .setXmlElementName(RemoteDMRDefinition.REMOTE_DMR)
                                             .addAttributes(RemoteDMRAttributes.ATTRIBUTES)
+                                            .addChild(builder(RemoteDMRWaitForDefinition.INSTANCE)
+                                                    .setXmlElementName(RemoteDMRWaitForDefinition.WAIT_FOR)
+                                                    .addAttributes(RemoteDMRWaitForAttributes.ATTRIBUTES)
+                                            )
                                     )
                                     .addChild(builder(LocalDMRDefinition.INSTANCE)
                                             .setXmlElementName(LocalDMRDefinition.LOCAL_DMR)
                                             .addAttributes(LocalDMRAttributes.ATTRIBUTES)
+                                            .addChild(builder(LocalDMRWaitForDefinition.INSTANCE)
+                                                    .setXmlElementName(LocalDMRWaitForDefinition.WAIT_FOR)
+                                                    .addAttributes(LocalDMRWaitForAttributes.ATTRIBUTES)
+                                            )
                                     )
                                     .addChild(builder(RemoteJMXDefinition.INSTANCE)
                                             .setXmlElementName(RemoteJMXDefinition.REMOTE_JMX)
                                             .addAttributes(RemoteJMXAttributes.ATTRIBUTES)
+                                            .addChild(builder(RemoteJMXWaitForDefinition.INSTANCE)
+                                                    .setXmlElementName(RemoteJMXWaitForDefinition.WAIT_FOR)
+                                                    .addAttributes(RemoteJMXWaitForAttributes.ATTRIBUTES)
+                                            )
                                     )
                                     .addChild(builder(LocalJMXDefinition.INSTANCE)
                                             .setXmlElementName(LocalJMXDefinition.LOCAL_JMX)
                                             .addAttributes(LocalJMXAttributes.ATTRIBUTES)
+                                            .addChild(builder(LocalJMXWaitForDefinition.INSTANCE)
+                                                    .setXmlElementName(LocalJMXWaitForDefinition.WAIT_FOR)
+                                                    .addAttributes(LocalJMXWaitForAttributes.ATTRIBUTES)
+                                            )
                                     )
                             )
 

--- a/hawkular-wildfly-agent/src/main/resources/org/hawkular/agent/monitor/extension/LocalDescriptions.properties
+++ b/hawkular-wildfly-agent/src/main/resources/org/hawkular/agent/monitor/extension/LocalDescriptions.properties
@@ -133,6 +133,10 @@ hawkular-wildfly-agent.managed-servers.remote-dmr.resource-type-sets=Comma-separ
 hawkular-wildfly-agent.managed-servers.remote-dmr.tenant-id=If specified, metrics from this endpoint will be associated with the given tenant ID rather than the agent's tenant ID.
 hawkular-wildfly-agent.managed-servers.remote-dmr.metric-id-template=If specified, all metric IDs for this managed server will be constructed from the given template which can use tokens such as %FeedId, %ManagedServerName, and others. If not specified, a default ID will be generated.
 hawkular-wildfly-agent.managed-servers.remote-dmr.metric-tags=Comma separated list of name=value pairs that will be tags created on the metric definition in Hawkular Metrics.
+hawkular-wildfly-agent.managed-servers.remote-dmr.wait-for=Wait for these resources to be available before starting to monitor the managed server
+hawkular-wildfly-agent.managed-servers.remote-dmr.wait-for.add=unused
+hawkular-wildfly-agent.managed-servers.remote-dmr.wait-for.remove=do not use
+hawkular-wildfly-agent.managed-servers.remote-dmr.wait-for.name=The resource to wait for
 
 hawkular-wildfly-agent.managed-servers.local-dmr=The local WildFly application server
 hawkular-wildfly-agent.managed-servers.local-dmr.add=unused
@@ -144,6 +148,10 @@ hawkular-wildfly-agent.managed-servers.local-dmr.resource-type-sets=Comma-separa
 hawkular-wildfly-agent.managed-servers.local-dmr.tenant-id=If specified, metrics from this endpoint will be associated with the given tenant ID rather than the agent's tenant ID.
 hawkular-wildfly-agent.managed-servers.local-dmr.metric-id-template=If specified, all metric IDs for this managed server will be constructed from the given template which can use tokens such as %FeedId, %ManagedServerName, and others. If not specified, a default ID will be generated.
 hawkular-wildfly-agent.managed-servers.local-dmr.metric-tags=Comma separated list of name=value pairs that will be tags created on the metric definition in Hawkular Metrics.
+hawkular-wildfly-agent.managed-servers.local-dmr.wait-for=Wait for these resources to be available before starting to monitor the managed server
+hawkular-wildfly-agent.managed-servers.local-dmr.wait-for.add=unused
+hawkular-wildfly-agent.managed-servers.local-dmr.wait-for.remove=do not use
+hawkular-wildfly-agent.managed-servers.local-dmr.wait-for.name=The resource to wait for
 
 # MANAGED SERVERS - JMX
 
@@ -161,6 +169,10 @@ hawkular-wildfly-agent.managed-servers.remote-jmx.resource-type-sets=Comma-separ
 hawkular-wildfly-agent.managed-servers.remote-jmx.tenant-id=If specified, metrics from this endpoint will be associated with the given tenant ID rather than the agent's tenant ID.
 hawkular-wildfly-agent.managed-servers.remote-jmx.metric-id-template=If specified, all metric IDs for this managed server will be constructed from the given template which can use tokens such as %FeedId, %ManagedServerName, and others. If not specified, a default ID will be generated.
 hawkular-wildfly-agent.managed-servers.remote-jmx.metric-tags=Comma separated list of name=value pairs that will be tags created on the metric definition in Hawkular Metrics.
+hawkular-wildfly-agent.managed-servers.remote-jmx.wait-for=Wait for these resources to be available before starting to monitor the managed server
+hawkular-wildfly-agent.managed-servers.remote-jmx.wait-for.add=unused
+hawkular-wildfly-agent.managed-servers.remote-jmx.wait-for.remove=do not use
+hawkular-wildfly-agent.managed-servers.remote-jmx.wait-for.name=The resource to wait for
 
 hawkular-wildfly-agent.managed-servers.local-jmx=A local JMX managed server accessed via the standard internal JMX API
 hawkular-wildfly-agent.managed-servers.local-jmx.add=Adds a local JMX managed server
@@ -173,6 +185,10 @@ hawkular-wildfly-agent.managed-servers.local-jmx.resource-type-sets=Comma-separa
 hawkular-wildfly-agent.managed-servers.local-jmx.tenant-id=If specified, metrics from this endpoint will be associated with the given tenant ID rather than the agent's tenant ID.
 hawkular-wildfly-agent.managed-servers.local-jmx.metric-id-template=If specified, all metric IDs for this managed server will be constructed from the given template which can use tokens such as %FeedId, %ManagedServerName, and others. If not specified, a default ID will be generated.
 hawkular-wildfly-agent.managed-servers.local-jmx.metric-tags=Comma separated list of name=value pairs that will be tags created on the metric definition in Hawkular Metrics.
+hawkular-wildfly-agent.managed-servers.local-jmx.wait-for=Wait for these resources to be available before starting to monitor the managed server
+hawkular-wildfly-agent.managed-servers.local-jmx.wait-for.add=unused
+hawkular-wildfly-agent.managed-servers.local-jmx.wait-for.remove=do not use
+hawkular-wildfly-agent.managed-servers.local-jmx.wait-for.name=The resource to wait for
 
 # RESOURCE TYPES
 

--- a/hawkular-wildfly-agent/src/main/resources/schema/hawkular-agent-monitor-subsystem.xsd
+++ b/hawkular-wildfly-agent/src/main/resources/schema/hawkular-agent-monitor-subsystem.xsd
@@ -307,6 +307,9 @@
   </xs:complexType>
 
   <xs:complexType name="localDmrType">
+    <xs:sequence>
+      <xs:element name="wait-for" type="waitForType" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
     <xs:attribute name="name"                  type="xs:string" use="required"/>
     <xs:attribute name="enabled"               type="xs:boolean"/>
     <xs:attribute name="resource-type-sets"    type="xs:string"/>
@@ -317,6 +320,9 @@
   </xs:complexType>
 
   <xs:complexType name="remoteDmrType">
+    <xs:sequence>
+      <xs:element name="wait-for" type="waitForType" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
     <xs:attribute name="name"                  type="xs:string" use="required"/>
     <xs:attribute name="enabled"               type="xs:boolean"/>
     <xs:attribute name="protocol"              type="xs:string"/>
@@ -334,6 +340,9 @@
   </xs:complexType>
 
   <xs:complexType name="remoteJmxType">
+    <xs:sequence>
+      <xs:element name="wait-for" type="waitForType" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
     <xs:attribute name="name"                  type="xs:string" use="required"/>
     <xs:attribute name="enabled"               type="xs:boolean"/>
     <xs:attribute name="url"                   type="xs:string" use="required"/>
@@ -348,6 +357,9 @@
   </xs:complexType>
 
   <xs:complexType name="localJmxType">
+    <xs:sequence>
+      <xs:element name="wait-for" type="waitForType" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
     <xs:attribute name="name"                  type="xs:string" use="required"/>
     <xs:attribute name="enabled"               type="xs:boolean"/>
     <xs:attribute name="mbean-server-name"     type="xs:string"/>
@@ -396,4 +408,9 @@
       <xs:enumeration value="float"/>
     </xs:restriction>
   </xs:simpleType>
+
+  <xs:complexType name="waitForType">
+    <xs:attribute name="name" type="xs:string" use="required"/>
+  </xs:complexType>
+
 </xs:schema>

--- a/hawkular-wildfly-agent/src/test/resources/org/hawkular/agent/monitor/extension/subsystem-xsd-full.xml
+++ b/hawkular-wildfly-agent/src/test/resources/org/hawkular/agent/monitor/extension/subsystem-xsd-full.xml
@@ -148,7 +148,10 @@
                 resource-type-sets="Main"
                 tenant-id=""
                 metric-id-template="%FeedId-%ResourceName-%MetricTypeName"
-                metric-tags="feed=%FeedId,Label One=Value One" />
+                metric-tags="feed=%FeedId,Label One=Value One">
+      <wait-for name="/" />
+      <wait-for name="/subsystem=undertow" />
+    </remote-dmr>
 
     <local-dmr name="Self"
                enabled="true"
@@ -156,7 +159,10 @@
                resource-type-sets="Main"
                tenant-id="tenantOverride"
                metric-id-template="%FeedId-%ResourceName-%MetricTypeName"
-               metric-tags="feed=%FeedId,Label One=Value One" />
+               metric-tags="feed=%FeedId,Label One=Value One">
+      <wait-for name="/" />
+      <wait-for name="/subsystem=undertow" />
+    </local-dmr>
 
     <remote-jmx name="Remote JMX"
                 enabled="true"
@@ -168,7 +174,10 @@
                 resource-type-sets="R Resource Type Set"
                 tenant-id="tenantOverride"
                 metric-id-template="%FeedId-%ResourceName-%MetricTypeName"
-                metric-tags="feed=%FeedId,Label One=Value One" />
+                metric-tags="feed=%FeedId,Label One=Value One">
+      <wait-for name="java.lang:type=Memory" />
+      <wait-for name="java.lang:type=OperatingSystem" />
+    </remote-jmx>
 
     <local-jmx name="Local JMX"
                enabled="true"
@@ -177,7 +186,10 @@
                resource-type-sets="R Resource Type Set"
                tenant-id="tenantOverride"
                metric-id-template="%FeedId-%ResourceName-%MetricTypeName"
-               metric-tags="feed=%FeedId,Label One=Value One" />
+               metric-tags="feed=%FeedId,Label One=Value One">
+      <wait-for name="java.lang:type=Memory" />
+      <wait-for name="java.lang:type=OperatingSystem" />
+    </local-jmx>
 
   </managed-servers>
 


### PR DESCRIPTION
The agent can be asked to wait at startup for one or more resources to exist before beginning its discovery and monitoring. This code supports both DMR and JMX endpoints, as well as when running in Java Agent mode and WildFly Subsystem mode.

The way you do it is you set "wait-for" properties on the local-dmr, remote-dmr, local-jmx, or remote-jmx endpoints. In WildFly subsystem mode it looks like this for example (note this example shows local-dmr but remote-dmr supports the same syntax):

```
    <local-dmr name="Local DMR" ...>
      <wait-for name="/subsystem=my-subsystem/component=foo" />
      <wait-for name="/subsystem=undertow" />
    </local-dmr>
```

For JMX endpoints, you use MBean object names for the wait-for names (again, remote-jmx and local-jmx work the same):

```
    <local-jmx name="Local JMX" ...>
      <wait-for name="my.domain:type=MyMBean" />
      <wait-for name="my.other.domain:type=MyOtherMBean,subtype=foo" />
    </local-jmx>
```

In Java Agent mode, it can look like this for example:

```
local-dmr:
  wait-for:
  - name: /subsystem=my-subsystem/component=foo
  - name: /subsystem=undertow
```

and

```
local-jmx:
  wait-for:
  - name: my.domain:type=MyMBean
  - name: my.other.domain:type=MyOtherMBean,subtype=foo
```