### PR TITLE
Adding the automation for pushing the docker images by Travis

### DIFF
--- a/.travis.push.docker.images.sh
+++ b/.travis.push.docker.images.sh
@@ -22,6 +22,8 @@ IMAGES="wildfly-hawkular-agent-domain \
         wildfly-hawkular-agent \
         wildfly-hawkular-javaagent"
 
+OWNER="${OWNER:-hawkular}"
+
 if [[ "${TRAVIS_TAG}" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.Final$ ]]; then
 
   # build the images
@@ -34,10 +36,10 @@ if [[ "${TRAVIS_TAG}" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.Final$ ]]; then
 
   # push the latest and ${TRAVIS_TAG} images
   for image in ${IMAGES}; do
-    docker tag $image:latest hawkular/$image:${TRAVIS_TAG}
-    docker tag $image:latest hawkular/$image:latest
-    docker push hawkular/$image:${TRAVIS_TAG}
-    docker push hawkular/$image:latest
+    docker tag $image:latest $OWNER/$image:${TRAVIS_TAG}
+    docker tag $image:latest $OWNER/$image:latest
+    docker push $OWNER/$image:${TRAVIS_TAG}
+    docker push $OWNER/$image:latest
   done
 
   docker logout

--- a/.travis.push.docker.images.sh
+++ b/.travis.push.docker.images.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -xe
+
+IMAGES="wildfly-hawkular-agent-domain \
+        wildfly-hawkular-agent \
+        wildfly-hawkular-javaagent"
+
+if [[ "${TRAVIS_TAG}" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.Final$ ]]; then
+
+  # build the images
+  ./docker-dist/do.sh
+
+  # we don't want to show the credentials in travis
+  set +x
+  docker login -u "${DOCKER_USER}" -p "${DOCKER_PASS}"
+  set -x
+
+  # push the latest and ${TRAVIS_TAG} images
+  for image in ${IMAGES}; do
+    docker tag $image:latest hawkular/$image:${TRAVIS_TAG}
+    docker tag $image:latest hawkular/$image:latest
+    docker push hawkular/$image:${TRAVIS_TAG}
+    docker push hawkular/$image:latest
+  done
+
+  docker logout
+else
+  echo "Not doing the docker push, because the tag '${TRAVIS_TAG}' is not of form x.y.z.Final"
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,10 @@ env:
   global:
   - secure: DOP9OifGr7yBDNdkn1Tl58ur4tJzqFaNzVktmX+KgpjDbWtKE3cqyqf1pElyAbSpTm8kVf/UAxUPyCXdRh/W7jj2jB6Tc5kwBCqM8UHjJ6QuZVGnpih4lO6EImV1MDW2+MNWvun7kdUgtRjCWohaYh4pTPAwOk8v7IfeewH1Ud4=
   - secure: IG9j773bZtof+VCK20doXL6HiMnWfQVPD2MhkPc0wc1sXBi3QPatcsWqnOQSsTODyzZQu2yXrRD7cCsXHBFusYxMPIra08mjN4i16b6D4UdtpEhEucotqYCgawGhbv0kW/iRmGKPphAV4pZn+FNiBKJJQzBthBVnzz6WYkYdz7w=
+  # DOCKER_USER=xyz used by the .travis.push.docker.images.sh
+  - secure: "p7+Sgoow5aTEp9G6bCRQcRklpMmBhYqEjREyswWymqYnkTyrd1TD1oWRYGrt/D3F6om4q71Kv4BN3hJGuKBCxxf6eJMUYBXrl5RY/M3wjGSNk0yFuTbu9c2EkEyf4AsXbeDMU/nXirZv39KikZKeOX0i3VAb161ORy0wwkN7oyI="
+  # DOCKER_PASS=xyz used by the .travis.push.docker.images.sh
+  - secure: "Ys9j6Id5xWbt6AAg6TXpokytGHgqGPN/+T1Abux04u8afTztLY0YrmrQkRLSQlVraYB2sDK+kOkr1wYo4Kr0GveNDbGJMwaXlHC/j2HEmqKy6fxgXgt8Ty93rwjX9w9EHqGYXSkS/O0KKIOpMUB15chhPx1LulNOHYjNo/Bv+qY="
 
 before_cache:
 # Clean the cached directories once their size exceeds the space left on the partition.
@@ -46,4 +50,7 @@ after_success:
 - if [[ "$PROJECT_VERSION" =~ .*SNAPSHOT ]] && [[ "${TRAVIS_BRANCH}" = "master" ]] && [[ "${TRAVIS_PULL_REQUEST}" = "false" ]];
   then
     ./mvnw -s .travis.maven.settings.xml deploy -DskipTests -Dlicense.skip=true;
+  fi
+- if [[ "$TRAVIS_TAG" != ""]] && [[ "${TRAVIS_BRANCH}" = "master" ]] && [[ "${TRAVIS_PULL_REQUEST}" = "false" ]]; then
+    ./.travis.push.docker.images.sh
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,6 @@ after_success:
   then
     ./mvnw -s .travis.maven.settings.xml deploy -DskipTests -Dlicense.skip=true;
   fi
-- if [[ "$TRAVIS_TAG" != ""]] && [[ "${TRAVIS_BRANCH}" = "master" ]] && [[ "${TRAVIS_PULL_REQUEST}" = "false" ]]; then
-    ./.travis.push.docker.images.sh
+- if [[ "$TRAVIS_TAG" != "" ]] && [[ "${TRAVIS_BRANCH}" = "master" ]] && [[ "${TRAVIS_PULL_REQUEST}" = "false" ]]; then
+    ./.travis.push.docker.images.sh;
   fi

--- a/docker-dist/do.sh
+++ b/docker-dist/do.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
 # and other contributors as indicated by the @author tags.
@@ -18,15 +18,16 @@
 
 
 docker > /dev/null 2>&1 || { echo "docker is required, but is not found. Make sure it is accessible."; exit 1; }
+TAG="${1:-latest}"
 
 pushd "$( dirname "${BASH_SOURCE[0]}" )"
 
-echo "Building Docker for Wildfly + Hawkular javaagent."
-docker build -t wildfly-hawkular-javaagent . -f Dockerfile
+echo "Building Docker image for Wildfly + Hawkular javaagent with tag $TAG."
+docker build -t wildfly-hawkular-javaagent:$TAG . -f Dockerfile
 
-echo "Building Docker for Wildfly + Hawkular Wildfly Agent (Standalone)."
-docker build -t wildfly-hawkular-agent -f Dockerfile-wf-agent .
-echo "Building Docker for Wildfly + Hawkular Wildfly Agent (Domain)."
-docker build -t wildfly-hawkular-agent-domain -f Dockerfile-wf-agent-domain .
+echo "Building Docker image for Wildfly + Hawkular Wildfly Agent (Standalone) with tag $TAG."
+docker build -t wildfly-hawkular-agent:$TAG -f Dockerfile-wf-agent .
+echo "Building Docker image for Wildfly + Hawkular Wildfly Agent (Domain) with tag $TAG."
+docker build -t wildfly-hawkular-agent-domain:$TAG -f Dockerfile-wf-agent-domain .
 
 popd


### PR DESCRIPTION
It's done only if there is a new release.

~It's basically done, but I still need to test it.~

@jmazzitelli I tried the script on my local account and it successfully pushed the image (https://hub.docker.com/r/jkremser/wildfly-hawkular-agent/tags/)

btw. the `:latest` tag does not mean the last successful build of the master branch (as in your hosa repo), but it's the highest tag. This will cause less surprises.

It can be used also on its own like this:

```bash
OWNER="jkremser" TRAVIS_TAG="0.0.1.Final" DOCKER_USER="jkremser" DOCKER_PASS="***" ./.travis.push.docker.images.sh
```