### PR TITLE
Put semicolons here so travis doesn't spit out error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,8 @@ before_cache:
 - cachedBytes=$(du -cs "${CACHED_DIRECTORIES[@]}" | tail -1 | awk '{print $1}')
 - echo "Checking if the size of directories to cache ${cachedBytes} Bytes exceeds the free space ${availBytes} Bytes left on the current partition"
 - if [ "${cachedBytes}" -gt "${availBytes}" ] ; then
-    echo "Cleaning the cached dirs (${cachedBytes} Bytes) because their size exceeds the free space (${availBytes} Bytes) left on the current partition"
-    rm -Rf "$HOME/.m2"
+    echo "Cleaning the cached dirs (${cachedBytes} Bytes) because their size exceeds the free space (${availBytes} Bytes) left on the current partition";
+    rm -Rf "$HOME/.m2";
   fi
 
 after_success:


### PR DESCRIPTION
if [ "${cachedBytes}" -gt "${availBytes}" ] ; then echo "Cleaning the cached dirs (${cachedBytes} Bytes) because their size exceeds the free space (${availBytes} Bytes) left on the current partition" rm -Rf "$HOME/.m2" fi
/home/travis/.travis/job_stages: eval: line 54: syntax error: unexpected end of file