### PR TITLE
Add missing code to load NotificationType on javaagent

### DIFF
--- a/hawkular-javaagent/src/main/java/org/hawkular/agent/javaagent/config/DMRNotification.java
+++ b/hawkular-javaagent/src/main/java/org/hawkular/agent/javaagent/config/DMRNotification.java
@@ -20,7 +20,6 @@ import org.hawkular.client.api.NotificationType;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -38,44 +37,31 @@ import com.fasterxml.jackson.annotation.JsonProperty;
         isGetterVisibility = Visibility.NONE)
 public class DMRNotification implements Validatable {
 
-    @JsonProperty(required = true)
-    private String name;
-
-    @JsonIgnore
-    NotificationType notificationType;
+    @JsonProperty(value="name", required = true)
+    private NotificationTypeJsonProperty notificationType;
 
     public DMRNotification() {
     }
 
     public DMRNotification(DMRNotification original) {
-        setName(original.name);
+        this.notificationType = original.notificationType == null? null : new NotificationTypeJsonProperty(original.notificationType);
     }
 
     @Override
     public void validate() throws Exception {
-        if (name == null || name.trim().isEmpty()) {
-            throw new Exception("notification name must be specified");
-        }
-
-        if (null == notificationType) {
-            throw new Exception("notification name [" + name + "] is an unknown notification type");
-        }
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-        try {
-            this.notificationType = NotificationType.valueOf(name.trim().replace("-", "_").toUpperCase());
-        } catch (Exception e) {
-            // ignore, will be reported in validate
-        }
+        // NotificationType validates itself
     }
 
     public NotificationType getNotificationType() {
-        return notificationType;
+        return notificationType == null ? null : notificationType.get();
     }
+
+    public void setNotificationType(NotificationType nt) {
+        if (notificationType != null) {
+            notificationType.set(nt);
+        } else {
+            notificationType = new NotificationTypeJsonProperty(nt);
+        }
+    }
+
 }

--- a/hawkular-javaagent/src/main/java/org/hawkular/agent/javaagent/config/DMRResourceType.java
+++ b/hawkular-javaagent/src/main/java/org/hawkular/agent/javaagent/config/DMRResourceType.java
@@ -92,6 +92,12 @@ public class DMRResourceType implements Validatable {
             throw new Exception("resource-type-dmr [" + name + "] path [" + path + "] is invalid", e);
         }
 
+        if (dmrNotifications != null) {
+            for (DMRNotification o : dmrNotifications) {
+                o.validate();
+            }
+        }
+
         if (dmrResourceConfigs != null) {
             for (DMRResourceConfig o : dmrResourceConfigs) {
                 o.validate();

--- a/hawkular-javaagent/src/main/java/org/hawkular/agent/javaagent/config/NotificationTypeJsonProperty.java
+++ b/hawkular-javaagent/src/main/java/org/hawkular/agent/javaagent/config/NotificationTypeJsonProperty.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.agent.javaagent.config;
+
+import org.hawkular.client.api.NotificationType;
+
+public class NotificationTypeJsonProperty extends AbstractStringifiedProperty<NotificationType> {
+
+    public NotificationTypeJsonProperty() {
+        super();
+    }
+
+    public NotificationTypeJsonProperty(NotificationType initialValue) {
+        super(initialValue);
+    }
+
+    public NotificationTypeJsonProperty(String valueAsString) {
+        super(valueAsString);
+    }
+
+    public NotificationTypeJsonProperty(NotificationTypeJsonProperty original) {
+        super(original);
+    }
+
+    @Override
+    protected NotificationType deserialize(String valueAsString) {
+        if (valueAsString != null) {
+            return NotificationType.valueOf(valueAsString.trim().replace("-", "_").toUpperCase());
+        } else {
+            throw new IllegalArgumentException("Notification type is not specified");
+        }
+    }
+
+    @Override
+    protected String serialize(NotificationType value) {
+        if (value != null) {
+            return value.name().toLowerCase().replace("_", "-");
+        } else {
+            throw new IllegalArgumentException("Notification type is not specified");
+        }
+    }
+}


### PR DESCRIPTION
notificationType was always null on javaagent because the method `setName` was never called.
It didn't show any errors because `validate` was never called either.

In this PR I call `validate` method from within `DMRResourceType` and create a new NotificationTypeJsonProperty to handle the serialization and deserialization of `NotificationType`.