### PR TITLE
[travis] Removing the check $TRAVIS_BRANCH == 'master'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,6 @@ after_success:
   then
     ./mvnw -s .travis.maven.settings.xml deploy -DskipTests -Dlicense.skip=true;
   fi
-- if [[ "$TRAVIS_TAG" != "" ]] && [[ "${TRAVIS_BRANCH}" = "master" ]] && [[ "${TRAVIS_PULL_REQUEST}" = "false" ]]; then
+- if [[ "${TRAVIS_TAG}" != "" ]] && [[ "${TRAVIS_PULL_REQUEST}" = "false" ]]; then
     ./.travis.push.docker.images.sh;
   fi


### PR DESCRIPTION
because it's actually being set to the same value as $TRAVIS_TAG
(https://github.com/travis-ci/travis-ci/issues/4645)

I hope that's why the release was not performed this time: the very end of [this log](https://s3.amazonaws.com/archive.travis-ci.org/jobs/226856669/log.txt?X-Amz-Expires=30&X-Amz-Date=20170428T164449Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJRYRXRSVGNKPKO5A/20170428/us-east-1/s3/aws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=3cf4696c4eacff7d05788e9d80d533950da9c32d6e6883d4f904308ed1f96238)


ps. I released the images "manually" here 