### PR TITLE
Remove 'Hawkular' from local-dmr resource-type-sets.

### DIFF
--- a/eap6-support/hawkular-javaagent-wildfly-feature-pack-eap6/src/main/resources/featurepack/content/standalone/configuration/hawkular-javaagent-config.yaml
+++ b/eap6-support/hawkular-javaagent-wildfly-feature-pack-eap6/src/main/resources/featurepack/content/standalone/configuration/hawkular-javaagent-config.yaml
@@ -1265,7 +1265,6 @@ managed-servers:
     - Messaging
     - Socket Binding Group
     - Clustering
-    - Hawkular
     wait-for:
     - name: /
 

--- a/hawkular-javaagent-wildfly-feature-pack/src/main/resources/featurepack/content/standalone/configuration/hawkular-javaagent-config.yaml
+++ b/hawkular-javaagent-wildfly-feature-pack/src/main/resources/featurepack/content/standalone/configuration/hawkular-javaagent-config.yaml
@@ -1427,7 +1427,6 @@ managed-servers:
     - Messaging
     - Socket Binding Group
     - Clustering
-    - Hawkular
     wait-for:
     - name: /
 


### PR DESCRIPTION
This set is to read the hawkular wildfly agent (subsystem).
Since we are using javaagent, its not needed here.