### PR TITLE
Logs agent version on startup

### DIFF
--- a/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/log/MsgLogger.java
+++ b/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/log/MsgLogger.java
@@ -253,4 +253,8 @@ public interface MsgLogger extends BasicLogger {
     @LogMessage(level = Level.ERROR)
     @Message(id = 10083, value = "Failed to store notification: %s")
     void errorFailedToStoreNotification(@Cause Throwable t, String data);
+
+    @LogMessage(level = Level.INFO)
+    @Message(id = 10084, value = "%s version %s")
+    void infoTypeAndVersion(String type, String version);
 }

--- a/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/service/AgentCoreEngine.java
+++ b/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/service/AgentCoreEngine.java
@@ -225,6 +225,11 @@ public abstract class AgentCoreEngine {
         }
 
         try {
+            Package agentPackage = this.getClass().getPackage();
+            if (agentPackage != null) {
+                log.infoTypeAndVersion(agentPackage.getImplementationTitle(), agentPackage.getImplementationVersion());
+            }
+
             log.infoStarting();
 
             // determine the configuration to use


### PR DESCRIPTION
On a Hawkular javaagent it looks like this:
```
14:18:22,592 INFO  ...: Hawkular Agent: Javaagent version 1.0.0.Final-SNAPSHOT
```

On a Hawkular wildfly agent it looks like this:
```
14:11:21,450 INFO  ...: Hawkular Agent: WildFly Agent Subsystem version 1.0.0.Final-SNAPSHOT
```