### PR TITLE
Allows a dockerized agent to connect to https hawkular-services

### DIFF
--- a/docker-dist/Dockerfile
+++ b/docker-dist/Dockerfile
@@ -24,6 +24,8 @@ ADD target/hawkular-javaagent-wildfly-dist/bin/standalone.conf $JBOSS_HOME/bin
 ADD target/hawkular-javaagent-wildfly-dist/bin/hawkular-javaagent.jar $JBOSS_HOME/bin
 ADD target/hawkular-javaagent-wildfly-dist/standalone/configuration/hawkular-javaagent-config.yaml $JBOSS_HOME/standalone/configuration/
 
+ADD src/main/resources/run_hawkular_javaagent.sh /opt/hawkular/bin/run_hawkular_agent.sh
+
 ENV HAWKULAR_SERVER_PROTOCOL http
 ENV HAWKULAR_SERVER_ADDR hawkular
 ENV HAWKULAR_SERVER_PORT 8080
@@ -34,11 +36,10 @@ ENV JAVA_OPTS="-Xmx256m -Djava.net.preferIPv4Stack=true -Djava.awt.headless=true
 EXPOSE 8080 9090
 
 USER root
-RUN chown -R jboss:0 /opt/jboss/wildfly/standalone && \
-    chmod -R ug+rw /opt/jboss/wildfly/standalone
+RUN yum install --quiet -y openssl && \
+    rm -rf /var/cache/yum && \
+    chown -RH jboss:0 $JBOSS_HOME/standalone $JAVA_HOME/jre/lib/security/cacerts /opt/hawkular && \
+    chmod -R ug+rw $JBOSS_HOME/standalone $JAVA_HOME/jre/lib/security/cacerts /opt/hawkular
 
 USER jboss
-CMD /opt/jboss/wildfly/bin/standalone.sh -b 0.0.0.0 \
--Dhawkular.rest.host=${HAWKULAR_SERVER_PROTOCOL}://${HAWKULAR_SERVER_ADDR}:${HAWKULAR_SERVER_PORT} \
--Dhawkular.rest.user=${HAWKULAR_AGENT_USER} -Dhawkular.rest.password=${HAWKULAR_AGENT_PASSWORD} \
--Dhawkular.agent.immutable=${HAWKULAR_IMMUTABLE} -Dhawkular.agent.in-container=${HAWKULAR_IMMUTABLE}
+CMD /opt/hawkular/bin/run_hawkular_agent.sh

--- a/docker-dist/Dockerfile-wf-agent
+++ b/docker-dist/Dockerfile-wf-agent
@@ -20,8 +20,11 @@ FROM jboss/wildfly:10.1.0.Final
 MAINTAINER Hawkular project <hawkular-dev@lists.jboss.org>
 
 ADD target/hawkular-wildfly-agent-installer-full.jar /tmp/installer.jar
+ADD src/main/resources/hawkular_wildfly_agent_setup.sh /tmp/hawkular_wildfly_agent_setup.sh
 # ADD test-simple.war /opt/jboss/wildfly/standalone/deployments/
-ADD src/main/resources/standalone.conf /opt/jboss/wildfly/bin
+ADD src/main/resources/standalone.conf $JBOSS_HOME/bin
+
+ADD src/main/resources/run_hawkular_wildfly_agent.sh /opt/hawkular/bin/run_hawkular_agent.sh
 
 ENV HAWKULAR_SERVER_PROTOCOL http
 ENV HAWKULAR_SERVER_ADDR hawkular
@@ -34,15 +37,17 @@ EXPOSE 8080 9090
 
 WORKDIR /tmp
 
-RUN java -jar installer.jar --enabled true --server-url '${env.HAWKULAR_SERVER_PROTOCOL}://${env.HAWKULAR_SERVER_ADDR}:${env.HAWKULAR_SERVER_PORT}' \
-  --module-dist classpath:hawkular-wildfly-agent-wf-extension.zip --username '${env.HAWKULAR_AGENT_USER}' \
-  --password '${env.HAWKULAR_AGENT_PASSWORD}' --target-location /opt/jboss/wildfly \
-  --feed-id='${hawkular.agent.machine.id}'
+RUN source ./hawkular_wildfly_agent_setup.sh && \
+    generate_empty_keystore && \
+    run_hawkular_agent_standalone_install
 
 USER root
-RUN chown -R jboss:0 /opt/jboss/wildfly/standalone && \
-    chmod -R ug+rw /opt/jboss/wildfly/standalone && \
-    rm /tmp/installer.jar
+RUN yum install --quiet -y openssl && \
+    rm -rf /var/cache/yum && \
+    chown -RH jboss:0 $JBOSS_HOME/standalone /opt/hawkular && \
+    chmod -R ug+rw $JBOSS_HOME/standalone /opt/hawkular && \
+    rm /tmp/installer.jar && \
+    rm /tmp/hawkular_wildfly_agent_setup.sh
 
 USER jboss
-CMD /opt/jboss/wildfly/bin/standalone.sh
+CMD /opt/hawkular/bin/run_hawkular_agent.sh "standalone"

--- a/docker-dist/Dockerfile-wf-agent
+++ b/docker-dist/Dockerfile-wf-agent
@@ -50,4 +50,6 @@ RUN yum install --quiet -y openssl && \
     rm /tmp/hawkular_wildfly_agent_setup.sh
 
 USER jboss
+
+WORKDIR /opt
 CMD /opt/hawkular/bin/run_hawkular_agent.sh "standalone"

--- a/docker-dist/Dockerfile-wf-agent-domain
+++ b/docker-dist/Dockerfile-wf-agent-domain
@@ -20,7 +20,10 @@ FROM jboss/wildfly:10.1.0.Final
 MAINTAINER Hawkular project <hawkular-dev@lists.jboss.org>
 
 ADD target/hawkular-wildfly-agent-installer-full.jar /tmp/installer.jar
-ADD src/main/resources/domain.conf /opt/jboss/wildfly/bin
+ADD src/main/resources/hawkular_wildfly_agent_setup.sh /tmp/hawkular_wildfly_agent_setup.sh
+ADD src/main/resources/domain.conf $JBOSS_HOME/bin
+
+ADD src/main/resources/run_hawkular_wildfly_agent.sh /opt/hawkular/bin/run_hawkular_agent.sh
 
 ENV HAWKULAR_SERVER_PROTOCOL http
 ENV HAWKULAR_SERVER_ADDR hawkular
@@ -33,15 +36,17 @@ EXPOSE 8080 9090
 
 WORKDIR /tmp
 
-RUN java -jar installer.jar --enabled true --server-url '${env.HAWKULAR_SERVER_PROTOCOL}://${env.HAWKULAR_SERVER_ADDR}:${env.HAWKULAR_SERVER_PORT}' \
-  --module-dist classpath:hawkular-wildfly-agent-wf-extension.zip --username '${env.HAWKULAR_AGENT_USER}' \
-  --target-config=/opt/jboss/wildfly/domain/configuration/host.xml \
-  --password '${env.HAWKULAR_AGENT_PASSWORD}' --target-location /opt/jboss/wildfly
+RUN source ./hawkular_wildfly_agent_setup.sh && \
+    generate_empty_keystore && \
+    run_hawkular_agent_domain_install
 
 USER root
-RUN chown -R jboss:0 /opt/jboss/wildfly/domain && \
-    chmod -R ug+rw /opt/jboss/wildfly/domain && \
-    rm /tmp/installer.jar
+RUN yum install --quiet -y openssl && \
+    rm -rf /var/cache/yum && \
+    chown -RH jboss:0 $JBOSS_HOME/domain /opt/hawkular && \
+    chmod -R ug+rw $JBOSS_HOME/domain /opt/hawkular && \
+    rm /tmp/installer.jar && \
+    rm /tmp/hawkular_wildfly_agent_setup.sh
 
 USER jboss
-CMD /opt/jboss/wildfly/bin/domain.sh
+CMD /opt/hawkular/bin/run_hawkular_agent.sh "domain"

--- a/docker-dist/Dockerfile-wf-agent-domain
+++ b/docker-dist/Dockerfile-wf-agent-domain
@@ -49,4 +49,5 @@ RUN yum install --quiet -y openssl && \
     rm /tmp/hawkular_wildfly_agent_setup.sh
 
 USER jboss
+WORKDIR /opt
 CMD /opt/hawkular/bin/run_hawkular_agent.sh "domain"

--- a/docker-dist/README.adoc
+++ b/docker-dist/README.adoc
@@ -4,9 +4,54 @@ This builds a WF 10 server with an agent installed
 
 == Build
 
-$ sh do.sh
+This command will build three docker images:
+
+. `wildfly-hawkular-javaagent` - Hawkular Javaagent running along Wildfly in standalone mode.
+. `wildfly-hawkular-agent` - Wildfly 10 running with Hawkular Wildfly Agent subsystem in standalone mode.
+. `wildfly-hawkular-agent-domain` - Wildfly 10 running with Hawkular Wildfly Agent subsystem in domain mode.
+
+```bash
+sh do.sh
+```
 
 == Run
 
-docker run -p 8081:8080 --link 2271bcd4adca:hawkular pilhuhn/hawkfly
+Select the type of Hawkular agent you would like to run, once you have a running Hawkular Services you can run it like:
 
+```bash
+docker run -p 8081:8080 --link hawkular -e  {selected hawkular agent}
+```
+
+It will connect to http://hawkular:8080 using username `jdoe` and password `password`.
+
+You can configure the endpoint, username and password passing the following environment variables.
+
+
+* HAWKULAR_SERVER_PROTOCOL defaults to `http`
+* HAWKULAR_SERVER_ADDR defaults to `hawkular`
+* HAWKULAR_SERVER_PORT defaults to `8080`
+* HAWKULAR_AGENT_USER defaults to `jdoe`
+* HAWKULAR_AGENT_PASSWORD defaults to `password`
+
+e.g.
+```bash
+docker run -p 8081:8080 --link 2271bcd4adca:hawkular-services -e HAWKULAR_AGENT_PASSWORD=hard-to-guess -e HAWKULAR_SERVER_ADDR=hawkular-services wildfly-hawkular-javaagent
+```
+
+=== Connecting to a secured Hawkular Services
+
+You might also use these docker instances to when connecting to a secured (https) Hawkular Services.
+You need to provide Hawkular Services public certificate in PEM format into `/client-secrets/hawkular-services-public.pem` of your docker Hawkular Agent
+and set `HAWKULAR_SERVER_PROTOCOL` to `https`.
+
+WARNING: You need to make sure that the domain name or IP stored in the certificate matches the `HAWKULAR_SERVER_ADDR`
+else it will be rejected when trying to connect.
+
+Below is a full example running Cassandra 3.0.9, Hawkular Services and wildfly-hawkular-javaagent.
+
+```bash
+mkdir $HOME/hawkular-certificates
+docker run --name hawkular-cassandra -e CASSANDRA_START_RPC=true -d cassandra:3.0.9
+docker run --name hawkular-services --link=hawkular-cassandra -e CASSANDRA_NODES=hawkular-cassandra -e HAWKULAR_HOSTNAME=hawkular-services -e HAWKULAR_USE_SSL=true -p 8443:8443 -v $HOME/hawkular-certificates:/client-secrets/ hawkular/hawkular-services
+docker run --name hawkular-agent-01 --link=hawkular-services -e HAWKULAR_SERVER_PROTOCOL=https -e HAWKULAR_SERVER_ADDR=hawkular-services -e HAWKULAR_SERVER_PORT=8443 -v $HOME/hawkular-certificates:/client-secrets/ wildfly-hawkular-javaagent
+```

--- a/docker-dist/src/main/resources/hawkular_wildfly_agent_setup.sh
+++ b/docker-dist/src/main/resources/hawkular_wildfly_agent_setup.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+_HAWKULAR_SERVICES_TRUSTSTORE='hawkular-services.truststore'
+
+generate_empty_keystore() {
+  keytool -genkeypair -keyalg RSA -alias dummy -dname "CN=localhost" -keypass hawkular -storepass hawkular \
+    -keystore $_HAWKULAR_SERVICES_TRUSTSTORE
+  keytool -delete -alias dummy -storepass hawkular -keystore $_HAWKULAR_SERVICES_TRUSTSTORE
+}
+
+run_hawkular_agent_standalone_install() {
+  java -jar installer.jar --enabled true --server-url '${env.HAWKULAR_SERVER_PROTOCOL}://${env.HAWKULAR_SERVER_ADDR}:${env.HAWKULAR_SERVER_PORT}' \
+    --module-dist classpath:hawkular-wildfly-agent-wf-extension.zip --username '${env.HAWKULAR_AGENT_USER}' \
+    --password '${env.HAWKULAR_AGENT_PASSWORD}' --target-location "$JBOSS_HOME" \
+    --feed-id='${hawkular.agent.machine.id}' \
+    --keystore-path $_HAWKULAR_SERVICES_TRUSTSTORE --keystore-password hawkular
+}
+
+run_hawkular_agent_domain_install() {
+  java -jar installer.jar --enabled true --server-url '${env.HAWKULAR_SERVER_PROTOCOL}://${env.HAWKULAR_SERVER_ADDR}:${env.HAWKULAR_SERVER_PORT}' \
+    --module-dist classpath:hawkular-wildfly-agent-wf-extension.zip --username '${env.HAWKULAR_AGENT_USER}' \
+    --target-config="$JBOSS_HOME/domain/configuration/host.xml" \
+    --password '${env.HAWKULAR_AGENT_PASSWORD}' --target-location "$JBOSS_HOME" \
+    --keystore-path $_HAWKULAR_SERVICES_TRUSTSTORE --keystore-password hawkular
+}

--- a/docker-dist/src/main/resources/run_hawkular_javaagent.sh
+++ b/docker-dist/src/main/resources/run_hawkular_javaagent.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+PUBLIC_KEY="/client-secrets/hawkular-services-public.pem"
+
+import_hawkular_services_public_key() {
+    local PUBLIC_KEY_DER="/tmp/hawkular-services-public.cert"
+    if [[ -f ${PUBLIC_KEY} ]] && [[ -s ${PUBLIC_KEY} ]]; then
+        openssl x509 -inform pem -in ${PUBLIC_KEY} -out ${PUBLIC_KEY_DER}
+        keytool -import -keystore ${JAVA_HOME}/jre/lib/security/cacerts -storepass changeit \
+        -file ${PUBLIC_KEY_DER} -noprompt
+        rm -f ${PUBLIC_KEY_DER}
+    fi
+}
+
+run_hawkular_agent() {
+    ${JBOSS_HOME}/bin/standalone.sh -b 0.0.0.0 \
+    -Dhawkular.rest.host=${HAWKULAR_SERVER_PROTOCOL}://${HAWKULAR_SERVER_ADDR}:${HAWKULAR_SERVER_PORT} \
+    -Dhawkular.rest.user=${HAWKULAR_AGENT_USER} -Dhawkular.rest.password=${HAWKULAR_AGENT_PASSWORD} \
+    -Dhawkular.agent.immutable=${HAWKULAR_IMMUTABLE} -Dhawkular.agent.in-container=${HAWKULAR_IMMUTABLE}
+}
+
+main() {
+  import_hawkular_services_public_key
+  run_hawkular_agent "$@"
+}
+
+main "$@"

--- a/docker-dist/src/main/resources/run_hawkular_wildfly_agent.sh
+++ b/docker-dist/src/main/resources/run_hawkular_wildfly_agent.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+PUBLIC_KEY="/client-secrets/hawkular-services-public.pem"
+
+import_hawkular_services_public_key() {
+  local PUBLIC_KEY_DER="/tmp/hawkular-services-public.cert"
+  if [[ -f ${PUBLIC_KEY} ]] && [[ -s ${PUBLIC_KEY} ]]; then
+    openssl x509 -inform pem -in ${PUBLIC_KEY} -out ${PUBLIC_KEY_DER}
+    keytool -import -keystore "$JBOSS_HOME/$1/configuration/hawkular-services.truststore" -storepass hawkular \
+    -file ${PUBLIC_KEY_DER} -noprompt
+    rm -f ${PUBLIC_KEY_DER}
+  fi
+}
+
+run_hawkular_agent() {
+  ${JBOSS_HOME}/bin/$1.sh
+}
+
+main() {
+  import_hawkular_services_public_key $1
+  run_hawkular_agent "$@"
+}
+
+main "$@"


### PR DESCRIPTION
There was no way to connect to an secure hawkular services by the dockerized agents, this provide a way to pass a public key (the hawkular-services certificate) to trust (and allow) the communication.

On the javaagent this key is added to the cacerts, on the wildfly subsystem (standalone and domain) a keystore is created and handed to the hawkular wildfly installer.

There seems to be a problem with the domain mode, not sure if related to the installer or to this work. I have to check that.

```
[Host Controller] 22:28:36,671 ERROR [org.jboss.as.controller.management-operation] (Controller Boot Thread) WFLYCTL0013: Operation ("add") failed - address: ([
[Host Controller]     ("host" => "master"),
[Host Controller]     ("subsystem" => "hawkular-wildfly-agent")
[Host Controller] ]) - failure description: {
[Host Controller]     "WFLYCTL0180: Services with missing/unavailable dependencies" => undefined,
[Host Controller]     "WFLYCTL0288: One or more services were unable to start due to one or more indirect dependencies not being available." => {
[Host Controller]         "Services that were unable to start:" => ["\"org.hawkular.agent.\".hawkular-wildfly-agent"],
[Host Controller]         "Services that may be the cause:" => ["jboss.server.path.\"jboss.server.config.dir\""]
[Host Controller]     }
[Host Controller] }
[Host Controller] 22:28:36,683 INFO  [org.jboss.as.controller] (Controller Boot Thread) WFLYCTL0183: Service status report
[Host Controller] WFLYCTL0184:    New missing/unsatisfied dependencies:
[Host Controller]       service jboss.server.controller.management.security_realm.HawkularRealm.ssl-context (missing) dependents: [service jboss.server.controller.management.security_realm.HawkularRealm] 
[Host Controller]       service jboss.server.controller.management.security_realm.HawkularRealm.ssl-context-trust-only (missing) dependents: [service "org.hawkular.agent.".hawkular-wildfly-agent] 
[Host Controller]       service jboss.server.controller.management.security_realm.HawkularRealm.trust-manager (missing) dependents: [service jboss.server.controller.management.security_realm.HawkularRealm.ssl-context-trust-only] 
[Host Controller]       service jboss.server.path."jboss.server.config.dir" (missing) dependents: [service jboss.server.controller.management.security_realm.HawkularRealm.trust-manager] 
[Host Controller] 

```