### PR TITLE
HWKAGENT-182 Adds an AvailChange notification when a watched resource…

### DIFF
--- a/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/api/AvailEvent.java
+++ b/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/api/AvailEvent.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.agent.monitor.api;
+
+import java.util.Map;
+
+import org.hawkular.agent.monitor.inventory.AvailManager;
+import org.hawkular.agent.monitor.inventory.AvailType;
+import org.hawkular.agent.monitor.inventory.MeasurementInstance;
+
+/**
+ * Avail event for avail measurements.
+ *
+ * @author <a href="https://github.com/josejulio">Josejulio Martínez</a>
+ */
+public class AvailEvent<L> {
+
+    private final SamplingService<L> samplingService;
+    private final AvailManager<L> availManager;
+    private final Map<MeasurementInstance<L, AvailType<L>>, Avail> changed;
+
+
+    /**
+     * Creates an avail event.
+     * @param samplingService a service that provides details such as feed ID and endpoint information that helps
+     *                        identify the resources in the event, plus has methods that can be used to monitor
+     *                        the resources in the event.
+     * @param availManager the avails associated with the event
+     * @param changed map of changed avails
+     */
+    private AvailEvent(SamplingService<L> samplingService, AvailManager<L> availManager,
+                      Map<MeasurementInstance<L, AvailType<L>>, Avail> changed) {
+
+        if (samplingService == null) {
+            throw new IllegalArgumentException("Sampling service cannot be null");
+        }
+
+        if (availManager == null) {
+            throw new IllegalArgumentException("Avail manager cannot be null");
+        }
+        this.samplingService = samplingService;
+        this.availManager = availManager;
+        this.changed = changed;
+    }
+
+    public static <L> AvailEvent<L> availChanged(SamplingService<L> samplingService, AvailManager<L> availManager,
+                               Map<MeasurementInstance<L, AvailType<L>>, Avail> changed) {
+        return new AvailEvent<L>(samplingService, availManager, changed);
+    }
+
+    public SamplingService<L> getSamplingService() {
+        return samplingService;
+    }
+
+    public AvailManager<L> getAvailManager() {
+        return availManager;
+    }
+
+    public Map<MeasurementInstance<L, AvailType<L>>, Avail> getChanged() {
+        return changed;
+    }
+}

--- a/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/api/AvailEvent.java
+++ b/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/api/AvailEvent.java
@@ -16,6 +16,7 @@
  */
 package org.hawkular.agent.monitor.api;
 
+import java.util.Collections;
 import java.util.Map;
 
 import org.hawkular.agent.monitor.inventory.AvailManager;
@@ -31,6 +32,7 @@ public class AvailEvent<L> {
 
     private final SamplingService<L> samplingService;
     private final AvailManager<L> availManager;
+    private final Map<MeasurementInstance<L, AvailType<L>>, Avail> started;
     private final Map<MeasurementInstance<L, AvailType<L>>, Avail> changed;
 
 
@@ -43,7 +45,8 @@ public class AvailEvent<L> {
      * @param changed map of changed avails
      */
     private AvailEvent(SamplingService<L> samplingService, AvailManager<L> availManager,
-                      Map<MeasurementInstance<L, AvailType<L>>, Avail> changed) {
+                       Map<MeasurementInstance<L, AvailType<L>>, Avail> started,
+                       Map<MeasurementInstance<L, AvailType<L>>, Avail> changed) {
 
         if (samplingService == null) {
             throw new IllegalArgumentException("Sampling service cannot be null");
@@ -55,11 +58,17 @@ public class AvailEvent<L> {
         this.samplingService = samplingService;
         this.availManager = availManager;
         this.changed = changed;
+        this.started = started;
     }
 
     public static <L> AvailEvent<L> availChanged(SamplingService<L> samplingService, AvailManager<L> availManager,
                                Map<MeasurementInstance<L, AvailType<L>>, Avail> changed) {
-        return new AvailEvent<L>(samplingService, availManager, changed);
+        return new AvailEvent<L>(samplingService, availManager, Collections.emptyMap(), changed);
+    }
+
+    public static <L> AvailEvent<L> availStarted(SamplingService<L> samplingService, AvailManager<L> availManager,
+                                                 Map<MeasurementInstance<L, AvailType<L>>, Avail> started) {
+        return new AvailEvent<L>(samplingService, availManager, started, Collections.emptyMap());
     }
 
     public SamplingService<L> getSamplingService() {
@@ -72,5 +81,9 @@ public class AvailEvent<L> {
 
     public Map<MeasurementInstance<L, AvailType<L>>, Avail> getChanged() {
         return changed;
+    }
+
+    public Map<MeasurementInstance<L, AvailType<L>>, Avail> getStarted() {
+        return started;
     }
 }

--- a/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/api/AvailListener.java
+++ b/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/api/AvailListener.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.agent.monitor.api;
+
+/**
+ * A listener for changes in the availability of resources maintained by the present agent.
+ *
+ * @author <a href="https://github.com/josejulio">Josejulio Martínez</a>
+ */
+public interface AvailListener {
+    <L> void receivedEvent(AvailEvent<L> event);
+}

--- a/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/inventory/AvailManager.java
+++ b/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/inventory/AvailManager.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.agent.monitor.inventory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.hawkular.agent.monitor.api.Avail;
+
+/**
+ * Holds a map between resource ids and avails. Provides methods for retrieve data and update the data in the map.
+ *
+ * @author <a href="https://github.com/josejulio">Josejulio Martínez</a>
+ */
+public final class AvailManager<L> {
+
+    public static class AddResult<L> {
+        public enum Effect {
+            MODIFIED, UNCHANGED
+        }
+        private final MeasurementInstance<L, AvailType<L>> measurementInstance;
+        private final Avail avail;
+        private final Effect effect;
+
+        public AddResult(MeasurementInstance<L, AvailType<L>> measurementInstance, Avail avail, Effect effect) {
+            this.measurementInstance = measurementInstance;
+            this.avail = avail;
+            this.effect = effect;
+        }
+
+        public MeasurementInstance<L, AvailType<L>> getMeasurementInstance() {
+            return measurementInstance;
+        }
+
+        public Avail getAvail() {
+            return avail;
+        }
+
+        public Effect getEffect() {
+            return effect;
+        }
+    }
+
+    private Map<MeasurementInstance<L, AvailType<L>>, Avail> storage = new HashMap<>();
+
+    public AddResult<L> addAvail(MeasurementInstance<L, AvailType<L>> measurementInstance, Avail avail) {
+        AddResult<L> result;
+        Avail previousAvail = storage.get(measurementInstance);
+        if (previousAvail == null || avail == previousAvail) {
+            result = new AddResult<>(measurementInstance, avail, AddResult.Effect.UNCHANGED);
+        } else {
+            result = new AddResult<>(measurementInstance, avail, AddResult.Effect.MODIFIED);
+        }
+        storage.put(measurementInstance, avail);
+        return result;
+    }
+
+}

--- a/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/inventory/AvailManager.java
+++ b/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/inventory/AvailManager.java
@@ -30,7 +30,7 @@ public final class AvailManager<L> {
 
     public static class AddResult<L> {
         public enum Effect {
-            MODIFIED, UNCHANGED
+            MODIFIED, UNCHANGED, STARTING
         }
         private final MeasurementInstance<L, AvailType<L>> measurementInstance;
         private final Avail avail;
@@ -58,15 +58,17 @@ public final class AvailManager<L> {
     private Map<MeasurementInstance<L, AvailType<L>>, Avail> storage = new HashMap<>();
 
     public AddResult<L> addAvail(MeasurementInstance<L, AvailType<L>> measurementInstance, Avail avail) {
-        AddResult<L> result;
         Avail previousAvail = storage.get(measurementInstance);
-        if (previousAvail == null || avail == previousAvail) {
-            result = new AddResult<>(measurementInstance, avail, AddResult.Effect.UNCHANGED);
+        AddResult.Effect effect;
+        if (previousAvail == null) {
+            effect = AddResult.Effect.STARTING;
+        } else if (avail == previousAvail) {
+            effect = AddResult.Effect.UNCHANGED;
         } else {
-            result = new AddResult<>(measurementInstance, avail, AddResult.Effect.MODIFIED);
+            effect = AddResult.Effect.MODIFIED;
         }
         storage.put(measurementInstance, avail);
-        return result;
+        return new AddResult<>(measurementInstance, avail, effect);
     }
 
 }

--- a/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/log/MsgLogger.java
+++ b/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/log/MsgLogger.java
@@ -257,4 +257,8 @@ public interface MsgLogger extends BasicLogger {
     @LogMessage(level = Level.INFO)
     @Message(id = 10084, value = "%s version %s")
     void infoTypeAndVersion(String type, String version);
+
+    @LogMessage(level = Level.ERROR)
+    @Message(id = 10085, value = "Failed to create notification: %s")
+    void errorFailedToCreateNotification(@Cause Throwable t, String notificationName);
 }

--- a/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/protocol/ProtocolService.java
+++ b/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/protocol/ProtocolService.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.hawkular.agent.monitor.api.AvailListener;
 import org.hawkular.agent.monitor.api.InventoryListener;
 import org.hawkular.agent.monitor.inventory.NodeLocation;
 import org.hawkular.agent.monitor.inventory.Resource;
@@ -71,6 +72,7 @@ public class ProtocolService<L, S extends Session<L>> {
 
     // need to remember the listeners in case new endpoints are added after things have started
     private final List<InventoryListener> inventoryListeners = Collections.synchronizedList(new ArrayList<>());
+    private final List<AvailListener> availListeners = Collections.synchronizedList(new ArrayList<>());
 
     public ProtocolService(String name, Map<String, EndpointService<L, S>> endpointServices) {
         this.name = name;
@@ -127,6 +129,20 @@ public class ProtocolService<L, S extends Session<L>> {
         this.inventoryListeners.remove(listener);
     }
 
+    public void addAvailListener(AvailListener listener) {
+        for (EndpointService<L, S> service : getEndpointServices().values()) {
+            service.addAvailListener(listener);
+        }
+        this.availListeners.add(listener);
+    }
+
+    public void removeAvailListener(AvailListener listener) {
+        for (EndpointService<L, S> service : getEndpointServices().values()) {
+            service.removeAvailListener(listener);
+        }
+        this.availListeners.remove(listener);
+    }
+
     /**
      * This will add a new endpoint service to the list. Once added, the new service
      * will immediately be started.
@@ -141,6 +157,12 @@ public class ProtocolService<L, S extends Session<L>> {
         synchronized (this.inventoryListeners) {
             for (InventoryListener listener : this.inventoryListeners) {
                 newEndpointService.addInventoryListener(listener);
+            }
+        }
+
+        synchronized (this.availListeners) {
+            for (AvailListener listener : this.availListeners) {
+                newEndpointService.addAvailListener(listener);
             }
         }
 

--- a/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/protocol/ProtocolServices.java
+++ b/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/protocol/ProtocolServices.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLContext;
 
+import org.hawkular.agent.monitor.api.AvailListener;
 import org.hawkular.agent.monitor.api.InventoryListener;
 import org.hawkular.agent.monitor.config.AgentCoreEngineConfiguration.EndpointConfiguration;
 import org.hawkular.agent.monitor.config.AgentCoreEngineConfiguration.ProtocolConfiguration;
@@ -255,6 +256,18 @@ public class ProtocolServices {
     public void removeInventoryListener(InventoryListener listener) {
         for (ProtocolService<?, ?> service : services) {
             service.removeInventoryListener(listener);
+        }
+    }
+
+    public void addAvailListener(AvailListener listener) {
+        for (ProtocolService<?, ?> service : services) {
+            service.addAvailListener(listener);
+        }
+    }
+
+    public void removeAvailListener(AvailListener listener) {
+        for (ProtocolService<?, ?> service : services) {
+            service.removeAvailListener(listener);
         }
     }
 

--- a/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/service/AgentCoreEngine.java
+++ b/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/service/AgentCoreEngine.java
@@ -358,6 +358,7 @@ public abstract class AgentCoreEngine {
             ps.addInventoryListener(schedulerService);
             if (notificationDispatcher != null) {
                 ps.addInventoryListener(notificationDispatcher);
+                ps.addAvailListener(notificationDispatcher);
             }
             protocolServices = ps;
 
@@ -453,6 +454,7 @@ public abstract class AgentCoreEngine {
                     protocolServices.removeInventoryListener(schedulerService);
                     if (notificationDispatcher != null) {
                         protocolServices.removeInventoryListener(notificationDispatcher);
+                        protocolServices.removeAvailListener(notificationDispatcher);
                     }
                     protocolServices = null;
                 }

--- a/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/storage/NotificationDispatcher.java
+++ b/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/storage/NotificationDispatcher.java
@@ -81,7 +81,7 @@ public class NotificationDispatcher implements InventoryListener, AvailListener 
                 : storageAdapter.getStorageAdapterConfiguration().getTenantId();
 
         processAvailEvents(event.getChanged(), NotificationType.AVAIL_CHANGE, tenantId);
-        processAvailEvents(event.getChanged(), NotificationType.AVAIL_STARTING, tenantId);
+        processAvailEvents(event.getStarted(), NotificationType.AVAIL_STARTING, tenantId);
     }
 
     private <L> void processAvailEvents(Map<MeasurementInstance<L, AvailType<L>>, Avail> avails,

--- a/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/storage/NotificationDispatcher.java
+++ b/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/storage/NotificationDispatcher.java
@@ -85,7 +85,8 @@ public class NotificationDispatcher implements InventoryListener, AvailListener 
                         b.addNotificationType(NotificationType.AVAIL_CHANGE);
                         b.addProperty("resourceType", mi.getResource().getResourceType().getName().getNameString());
                         b.addProperty("resourcePath", cp.toString());
-                        b.addProperty("newAvail", String.valueOf(event.getChanged().get(mi).getNumericValue()));
+                        b.addProperty("availType", mi.getType().getName().getNameString());
+                        b.addProperty("newAvail", event.getChanged().get(mi).name());
                         storageAdapter.store(b, 0);
                     } catch (Exception e) {
 

--- a/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/storage/NotificationDispatcher.java
+++ b/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/storage/NotificationDispatcher.java
@@ -23,6 +23,8 @@ import org.hawkular.agent.monitor.api.InventoryListener;
 import org.hawkular.agent.monitor.api.NotificationPayloadBuilder;
 import org.hawkular.agent.monitor.config.AgentCoreEngineConfiguration.EndpointConfiguration;
 import org.hawkular.agent.monitor.inventory.MonitoredEndpoint;
+import org.hawkular.agent.monitor.log.AgentLoggers;
+import org.hawkular.agent.monitor.log.MsgLogger;
 import org.hawkular.client.api.NotificationType;
 import org.hawkular.inventory.paths.CanonicalPath;
 
@@ -31,6 +33,7 @@ import org.hawkular.inventory.paths.CanonicalPath;
  */
 public class NotificationDispatcher implements InventoryListener, AvailListener {
 
+    private static final MsgLogger log = AgentLoggers.getLogger(NotificationDispatcher.class);
     StorageAdapter storageAdapter;
     String feedId;
 
@@ -60,7 +63,7 @@ public class NotificationDispatcher implements InventoryListener, AvailListener 
                         b.addProperty("resourcePath", cp.toString());
                         storageAdapter.store(b, 0);
                     } catch (Exception e) {
-
+                        log.errorFailedToCreateNotification(e, NotificationType.RESOURCE_ADDED.name());
                     }
                 });
     }
@@ -89,7 +92,7 @@ public class NotificationDispatcher implements InventoryListener, AvailListener 
                         b.addProperty("newAvail", event.getChanged().get(mi).name());
                         storageAdapter.store(b, 0);
                     } catch (Exception e) {
-
+                        log.errorFailedToCreateNotification(e, NotificationType.AVAIL_CHANGE.name());
                     }
                 });
     }

--- a/hawkular-agent-core/src/test/java/org/hawkular/agent/monitor/inventory/AvailManagerTest.java
+++ b/hawkular-agent-core/src/test/java/org/hawkular/agent/monitor/inventory/AvailManagerTest.java
@@ -47,7 +47,7 @@ public class AvailManagerTest {
         result = am.addAvail(measurementInstance, Avail.UP);
         Assert.assertEquals(Avail.UP, result.getAvail());
         Assert.assertEquals(measurementInstance, result.getMeasurementInstance());
-        Assert.assertEquals(AvailManager.AddResult.Effect.UNCHANGED, result.getEffect());
+        Assert.assertEquals(AvailManager.AddResult.Effect.STARTING, result.getEffect());
 
         result = am.addAvail(measurementInstance, Avail.UP);
         Assert.assertEquals(AvailManager.AddResult.Effect.UNCHANGED, result.getEffect());

--- a/hawkular-agent-core/src/test/java/org/hawkular/agent/monitor/inventory/AvailManagerTest.java
+++ b/hawkular-agent-core/src/test/java/org/hawkular/agent/monitor/inventory/AvailManagerTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.agent.monitor.inventory;
+
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+
+import org.hawkular.agent.monitor.api.Avail;
+import org.hawkular.agent.monitor.protocol.dmr.DMRNodeLocation;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AvailManagerTest {
+
+    @Test
+    public void testAddAvail() {
+        AvailManager<DMRNodeLocation> am = new AvailManager<>();
+        MeasurementInstance<DMRNodeLocation, AvailType<DMRNodeLocation>> measurementInstance =
+                new MeasurementInstance<>(
+                        new ID("foo"),
+                        new Name("bar"),
+                        new AttributeLocation<>(DMRNodeLocation.empty(), "foobar"),
+                        new AvailType<>(
+                                new ID("foo-avail"),
+                                new Name("bar-avail"),
+                                new AttributeLocation<>(DMRNodeLocation.empty(),"foobar-avail"),
+                                new Interval(666, TimeUnit.DAYS),
+                                Pattern.compile("foo"),
+                                "foobar-id-template",
+                                null));
+        AvailManager.AddResult result;
+
+        result = am.addAvail(measurementInstance, Avail.UP);
+        Assert.assertEquals(Avail.UP, result.getAvail());
+        Assert.assertEquals(measurementInstance, result.getMeasurementInstance());
+        Assert.assertEquals(AvailManager.AddResult.Effect.UNCHANGED, result.getEffect());
+
+        result = am.addAvail(measurementInstance, Avail.UP);
+        Assert.assertEquals(AvailManager.AddResult.Effect.UNCHANGED, result.getEffect());
+
+        result = am.addAvail(measurementInstance, Avail.DOWN);
+        Assert.assertEquals(Avail.DOWN, result.getAvail());
+        Assert.assertEquals(AvailManager.AddResult.Effect.MODIFIED, result.getEffect());
+    }
+}

--- a/hawkular-javaagent-wildfly-feature-pack/src/main/resources/featurepack/content/standalone/configuration/hawkular-javaagent-config.yaml
+++ b/hawkular-javaagent-wildfly-feature-pack/src/main/resources/featurepack/content/standalone/configuration/hawkular-javaagent-config.yaml
@@ -561,6 +561,7 @@ resource-type-set-dmr:
     notification-dmr:
     - name: resource-added
     - name: avail-changed
+    - name: avail-starting
     metric-sets:
     - WildFly Memory Metrics
     - WildFly Threading Metrics
@@ -656,6 +657,7 @@ resource-type-set-dmr:
     notification-dmr:
     - name: resource-added
     - name: avail-changed
+    - name: avail-starting
     resource-config-dmr:
     - name: Product Name
       attribute: product-name
@@ -797,6 +799,7 @@ resource-type-set-dmr:
     notification-dmr:
     - name: resource-added
     - name: avail-changed
+    - name: avail-starting
     metric-sets:
     - WildFly Memory Metrics
     - WildFly Threading Metrics
@@ -842,6 +845,7 @@ resource-type-set-dmr:
     notification-dmr:
     - name: resource-added
     - name: avail-changed
+    - name: avail-starting
     metric-sets:
     - WildFly Memory Metrics
     - WildFly Threading Metrics
@@ -890,6 +894,7 @@ resource-type-set-dmr:
     notification-dmr:
     - name: resource-added
     - name: avail-changed
+    - name: avail-starting
     resource-config-dmr:
     - name: Name
       attribute: name

--- a/hawkular-javaagent-wildfly-feature-pack/src/main/resources/featurepack/content/standalone/configuration/hawkular-javaagent-config.yaml
+++ b/hawkular-javaagent-wildfly-feature-pack/src/main/resources/featurepack/content/standalone/configuration/hawkular-javaagent-config.yaml
@@ -560,7 +560,7 @@ resource-type-set-dmr:
     resource-name-template: "WildFly Server [%ManagedServerName]"
     notification-dmr:
     - name: resource-added
-    - name: avail-changed
+    - name: avail-change
     - name: avail-starting
     metric-sets:
     - WildFly Memory Metrics
@@ -656,7 +656,7 @@ resource-type-set-dmr:
     resource-name-template: "Host Controller [%ManagedServerName]"
     notification-dmr:
     - name: resource-added
-    - name: avail-changed
+    - name: avail-change
     - name: avail-starting
     resource-config-dmr:
     - name: Product Name
@@ -798,7 +798,7 @@ resource-type-set-dmr:
     - Host Controller
     notification-dmr:
     - name: resource-added
-    - name: avail-changed
+    - name: avail-change
     - name: avail-starting
     metric-sets:
     - WildFly Memory Metrics
@@ -844,7 +844,7 @@ resource-type-set-dmr:
     - Domain Host
     notification-dmr:
     - name: resource-added
-    - name: avail-changed
+    - name: avail-change
     - name: avail-starting
     metric-sets:
     - WildFly Memory Metrics
@@ -893,7 +893,7 @@ resource-type-set-dmr:
     - Domain Host
     notification-dmr:
     - name: resource-added
-    - name: avail-changed
+    - name: avail-change
     - name: avail-starting
     resource-config-dmr:
     - name: Name

--- a/hawkular-javaagent-wildfly-feature-pack/src/main/resources/featurepack/content/standalone/configuration/hawkular-javaagent-config.yaml
+++ b/hawkular-javaagent-wildfly-feature-pack/src/main/resources/featurepack/content/standalone/configuration/hawkular-javaagent-config.yaml
@@ -560,6 +560,7 @@ resource-type-set-dmr:
     resource-name-template: "WildFly Server [%ManagedServerName]"
     notification-dmr:
     - name: resource-added
+    - name: avail-changed
     metric-sets:
     - WildFly Memory Metrics
     - WildFly Threading Metrics
@@ -654,6 +655,7 @@ resource-type-set-dmr:
     resource-name-template: "Host Controller [%ManagedServerName]"
     notification-dmr:
     - name: resource-added
+    - name: avail-changed
     resource-config-dmr:
     - name: Product Name
       attribute: product-name
@@ -794,6 +796,7 @@ resource-type-set-dmr:
     - Host Controller
     notification-dmr:
     - name: resource-added
+    - name: avail-changed
     metric-sets:
     - WildFly Memory Metrics
     - WildFly Threading Metrics
@@ -838,6 +841,7 @@ resource-type-set-dmr:
     - Domain Host
     notification-dmr:
     - name: resource-added
+    - name: avail-changed
     metric-sets:
     - WildFly Memory Metrics
     - WildFly Threading Metrics
@@ -885,6 +889,7 @@ resource-type-set-dmr:
     - Domain Host
     notification-dmr:
     - name: resource-added
+    - name: avail-changed
     resource-config-dmr:
     - name: Name
       attribute: name

--- a/hawkular-wildfly-agent-feature-pack/src/main/resources/subsystem-templates/hawkular-wildfly-agent.xml
+++ b/hawkular-wildfly-agent-feature-pack/src/main/resources/subsystem-templates/hawkular-wildfly-agent.xml
@@ -628,6 +628,7 @@
                          metric-sets="WildFly Memory Metrics,WildFly Threading Metrics,WildFly Aggregated Web Metrics"
                          avail-sets="Server Availability">
         <notification-dmr name="resource-added" />
+        <notification-dmr name="avail-change" />
 
         <resource-config-dmr name="Name"          attribute="name"/>
         <resource-config-dmr name="Product Name"  attribute="product-name" />
@@ -675,6 +676,7 @@
                          resource-name-template="Host Controller [%ManagedServerName]"
                          path="/">
         <notification-dmr name="resource-added" />
+        <notification-dmr name="avail-change" />
 
         <resource-config-dmr name="Product Name"    attribute="product-name" />
         <resource-config-dmr name="Version"         attribute="product-version" />
@@ -743,6 +745,7 @@
                          parents="Host Controller"
                          metric-sets="WildFly Memory Metrics,WildFly Threading Metrics">
         <notification-dmr name="resource-added" />
+        <notification-dmr name="avail-change" />
 
         <resource-config-dmr name="Name"                 attribute="name"/>
         <resource-config-dmr name="Product Name"         attribute="product-name" />
@@ -770,6 +773,7 @@
                          metric-sets="WildFly Memory Metrics,WildFly Threading Metrics,WildFly Aggregated Web Metrics"
                          avail-sets="Server Availability">
         <notification-dmr name="resource-added" />
+        <notification-dmr name="avail-change" />
 
         <resource-config-dmr name="Name"           attribute="name"/>
         <resource-config-dmr name="Host"           attribute="host"/>
@@ -800,6 +804,7 @@
                          path="/server-config=*"
                          parents="Domain Host">
         <notification-dmr name="resource-added" />
+        <notification-dmr name="avail-change" />
 
         <resource-config-dmr name="Name"         attribute="name"/>
         <resource-config-dmr name="Server Group" attribute="group"/>

--- a/hawkular-wildfly-agent-feature-pack/src/main/resources/subsystem-templates/hawkular-wildfly-agent.xml
+++ b/hawkular-wildfly-agent-feature-pack/src/main/resources/subsystem-templates/hawkular-wildfly-agent.xml
@@ -629,6 +629,7 @@
                          avail-sets="Server Availability">
         <notification-dmr name="resource-added" />
         <notification-dmr name="avail-change" />
+        <notification-dmr name="avail-starting" />
 
         <resource-config-dmr name="Name"          attribute="name"/>
         <resource-config-dmr name="Product Name"  attribute="product-name" />
@@ -677,6 +678,7 @@
                          path="/">
         <notification-dmr name="resource-added" />
         <notification-dmr name="avail-change" />
+        <notification-dmr name="avail-starting" />
 
         <resource-config-dmr name="Product Name"    attribute="product-name" />
         <resource-config-dmr name="Version"         attribute="product-version" />
@@ -746,6 +748,7 @@
                          metric-sets="WildFly Memory Metrics,WildFly Threading Metrics">
         <notification-dmr name="resource-added" />
         <notification-dmr name="avail-change" />
+        <notification-dmr name="avail-starting" />
 
         <resource-config-dmr name="Name"                 attribute="name"/>
         <resource-config-dmr name="Product Name"         attribute="product-name" />
@@ -774,6 +777,7 @@
                          avail-sets="Server Availability">
         <notification-dmr name="resource-added" />
         <notification-dmr name="avail-change" />
+        <notification-dmr name="avail-starting" />
 
         <resource-config-dmr name="Name"           attribute="name"/>
         <resource-config-dmr name="Host"           attribute="host"/>
@@ -805,6 +809,7 @@
                          parents="Domain Host">
         <notification-dmr name="resource-added" />
         <notification-dmr name="avail-change" />
+        <notification-dmr name="avail-starting" />
 
         <resource-config-dmr name="Name"         attribute="name"/>
         <resource-config-dmr name="Server Group" attribute="group"/>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <version.com.samskivert.jmustache>1.11</version.com.samskivert.jmustache>
     <version.io.dropwizard.metrics>3.1.2</version.io.dropwizard.metrics>
     <version.org.hamcrest>1.3</version.org.hamcrest>
-    <version.org.hawkular.commons>0.9.6.Final</version.org.hawkular.commons>
+    <version.org.hawkular.commons>0.9.6.Final-SRC-revision-47755c3d21f2ee5f8b7b31b11d7a76e94f911f2c</version.org.hawkular.commons>
     <version.org.hawkular.metrics>0.26.1.Final</version.org.hawkular.metrics>
 
     <version.org.jboss.aesh>0.66.7</version.org.jboss.aesh>


### PR DESCRIPTION
… change any of its availabilites

This PR adds an `AvailManager` to keep track of last resources availability value.
An `AvailEvent` is sent by `EndpointService` whenever a change on availability is detected. 
`NotificationDispatcher` now also listens to these events. A notification is fired when the resource has `AVAIL_CHANGE` on its notifications list with the `resourceType`, `resourcePath`, availType` and `newAvail`.

Depends on https://github.com/hawkular/hawkular-commons/pull/108