### PR TITLE
Sets correct relative-to path depending if using standalone/domain

### DIFF
--- a/hawkular-wildfly-agent-installer/src/main/java/org/hawkular/wildfly/agent/installer/AgentInstaller.java
+++ b/hawkular-wildfly-agent-installer/src/main/java/org/hawkular/wildfly/agent/installer/AgentInstaller.java
@@ -304,7 +304,7 @@ public class AgentInstaller {
                     Files.copy(Paths.get(keystoreSrcFile.getAbsolutePath()), keystoreDst);
                 }
 
-                String securityRealm = createSecurityRealm(keystoreSrcFile.getName(), keystorePass);
+                String securityRealm = createSecurityRealm(keystoreSrcFile.getName(), keystorePass, targetConfigInfo.getRelativeTo());
                 configurationBldr.addXmlEdit(new XmlEdit(targetConfigInfo.getSecurityRealmsXPath(), securityRealm));
             }
 
@@ -373,11 +373,11 @@ public class AgentInstaller {
      * @param keystorePass the password to access the keystore file
      * @return XML snippet
      */
-    private static String createSecurityRealm(String keystoreFile, String keystorePass) {
+    private static String createSecurityRealm(String keystoreFile, String keystorePass, String relativeTo) {
         return new StringBuilder("<security-realm name=\"" + SECURITY_REALM_NAME + "\">")
                 .append("<authentication>")
                 .append("<truststore path=\"" + keystoreFile + "\"")
-                .append(" relative-to=\"jboss.server.config.dir\"")
+                .append(" relative-to=\"" + relativeTo + "\"")
                 .append(" keystore-password=\"" + keystorePass + "\"")
                 .append(" /></authentication></security-realm>").toString();
     }

--- a/hawkular-wildfly-agent-installer/src/main/java/org/hawkular/wildfly/agent/installer/DomainTargetConfigInfo.java
+++ b/hawkular-wildfly-agent-installer/src/main/java/org/hawkular/wildfly/agent/installer/DomainTargetConfigInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -54,5 +54,10 @@ public class DomainTargetConfigInfo implements TargetConfigInfo {
                 .append("Clustering,")
                 .append("Hawkular")
                 .toString();
+    }
+
+    @Override
+    public String getRelativeTo() {
+        return "jboss.domain.config.dir";
     }
 }

--- a/hawkular-wildfly-agent-installer/src/main/java/org/hawkular/wildfly/agent/installer/HostTargetConfigInfo.java
+++ b/hawkular-wildfly-agent-installer/src/main/java/org/hawkular/wildfly/agent/installer/HostTargetConfigInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -49,5 +49,10 @@ public class HostTargetConfigInfo implements TargetConfigInfo {
                 .append("Clustering,")
                 .append("Hawkular")
                 .toString();
+    }
+
+    @Override
+    public String getRelativeTo() {
+        return "jboss.domain.config.dir";
     }
 }

--- a/hawkular-wildfly-agent-installer/src/main/java/org/hawkular/wildfly/agent/installer/StandaloneTargetConfigInfo.java
+++ b/hawkular-wildfly-agent-installer/src/main/java/org/hawkular/wildfly/agent/installer/StandaloneTargetConfigInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -49,5 +49,10 @@ public class StandaloneTargetConfigInfo implements TargetConfigInfo {
                 .append("Clustering,")
                 .append("Hawkular")
                 .toString();
+    }
+
+    @Override
+    public String getRelativeTo() {
+        return "jboss.server.config.dir";
     }
 }

--- a/hawkular-wildfly-agent-installer/src/main/java/org/hawkular/wildfly/agent/installer/TargetConfigInfo.java
+++ b/hawkular-wildfly-agent-installer/src/main/java/org/hawkular/wildfly/agent/installer/TargetConfigInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,4 +36,9 @@ public interface TargetConfigInfo {
      * @return the resource type sets that should be associated with the managed server definition
      */
     String getManagedServerResourceTypeSets();
+
+    /**
+     * @return relative-to property for the target config
+     */
+    String getRelativeTo();
 }


### PR DESCRIPTION
When installing on domain mode, sets the correct `relative-to` path.

Host doesn't know anything about `jboss.server.config.dir`
```
[domain@localhost:9990 /] /host=master/:resolve-expression(expression=${jboss.server.config.dir})
{
    "outcome" => "failed",
    "failure-description" => "WFLYCTL0211: Cannot resolve expression '${jboss.server.config.dir}'",
    "rolled-back" => true
}
```

But is well aware of `jboss.domain.config.dir`
```
[domain@localhost:9990 /] /host=master/:resolve-expression(expression=${jboss.domain.config.dir})
{
    "outcome" => "success",
    "result" => "/home/josejulio/Aplicaciones/redhat/jboss-eap-7.0/domain/configuration"
}
```
