### PR TITLE
Adding a way to override the immutability flag in docker containers

### DIFF
--- a/docker-dist/Dockerfile
+++ b/docker-dist/Dockerfile
@@ -28,6 +28,7 @@ ENV HAWKULAR_SERVER_PROTOCOL http
 ENV HAWKULAR_SERVER_ADDR hawkular
 ENV HAWKULAR_SERVER_PORT 8080
 ENV HAWKULAR_AGENT_USER=jdoe HAWKULAR_AGENT_PASSWORD=password
+ENV HAWKULAR_IMMUTABLE=true
 ENV JAVA_OPTS="-Xmx256m -Djava.net.preferIPv4Stack=true -Djava.awt.headless=true -XX:MaxMetaspaceSize=256m"
 
 EXPOSE 8080 9090
@@ -40,4 +41,4 @@ USER jboss
 CMD /opt/jboss/wildfly/bin/standalone.sh -b 0.0.0.0 \
 -Dhawkular.rest.host=${HAWKULAR_SERVER_PROTOCOL}://${HAWKULAR_SERVER_ADDR}:${HAWKULAR_SERVER_PORT} \
 -Dhawkular.rest.user=${HAWKULAR_AGENT_USER} -Dhawkular.rest.password=${HAWKULAR_AGENT_PASSWORD} \
--Dhawkular.agent.immutable=true -Dhawkular.agent.in-container=true
+-Dhawkular.agent.immutable=${HAWKULAR_IMMUTABLE} -Dhawkular.agent.in-container=${HAWKULAR_IMMUTABLE}

--- a/docker-dist/Dockerfile-wf-agent
+++ b/docker-dist/Dockerfile-wf-agent
@@ -27,6 +27,7 @@ ENV HAWKULAR_SERVER_PROTOCOL http
 ENV HAWKULAR_SERVER_ADDR hawkular
 ENV HAWKULAR_SERVER_PORT 8080
 ENV HAWKULAR_AGENT_USER=jdoe HAWKULAR_AGENT_PASSWORD=password
+ENV HAWKULAR_IMMUTABLE=true
 ENV JAVA_OPTS="-Xmx256m -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true -XX:MaxMetaspaceSize=256m"
 
 EXPOSE 8080 9090
@@ -45,4 +46,3 @@ RUN chown -R jboss:0 /opt/jboss/wildfly/standalone && \
 
 USER jboss
 CMD /opt/jboss/wildfly/bin/standalone.sh
-

--- a/docker-dist/Dockerfile-wf-agent-domain
+++ b/docker-dist/Dockerfile-wf-agent-domain
@@ -26,6 +26,7 @@ ENV HAWKULAR_SERVER_PROTOCOL http
 ENV HAWKULAR_SERVER_ADDR hawkular
 ENV HAWKULAR_SERVER_PORT 8080
 ENV HAWKULAR_AGENT_USER=jdoe HAWKULAR_AGENT_PASSWORD=password
+ENV HAWKULAR_IMMUTABLE=true
 ENV JAVA_OPTS="-Xmx256m -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true -XX:MaxMetaspaceSize=256m"
 
 EXPOSE 8080 9090

--- a/docker-dist/src/main/resources/domain.conf
+++ b/docker-dist/src/main/resources/domain.conf
@@ -67,7 +67,7 @@ fi
 
 # How to set hawkular-agent specific things
 JAVA_OPTS="$JAVA_OPTS -Dhawkular.agent.machine.id=`hostname` -Djboss.server.name=${HOSTNAME} "
-JAVA_OPTS="$JAVA_OPTS -Dhawkular.agent.in-container=true -Dhawkular.agent.immutable=true"
+JAVA_OPTS="$JAVA_OPTS -Dhawkular.agent.in-container=${HAWKULAR_IMMUTABLE} -Dhawkular.agent.immutable=${HAWKULAR_IMMUTABLE}"
 
 # Use JBoss Modules lockless mode
 #JAVA_OPTS="$JAVA_OPTS -Djboss.modules.lockless=true"

--- a/docker-dist/src/main/resources/standalone.conf
+++ b/docker-dist/src/main/resources/standalone.conf
@@ -73,7 +73,7 @@ fi
 
 # How to set hawkular-agent specific things
 JAVA_OPTS="$JAVA_OPTS -Dhawkular.agent.machine.id=`hostname` -Djboss.server.name=${HOSTNAME} "
-JAVA_OPTS="$JAVA_OPTS -Dhawkular.agent.in-container=true -Dhawkular.agent.immutable=true"
+JAVA_OPTS="$JAVA_OPTS -Dhawkular.agent.in-container=${HAWKULAR_IMMUTABLE} -Dhawkular.agent.immutable=${HAWKULAR_IMMUTABLE}"
 
 # Sample JPDA settings for remote socket debugging
 #JAVA_OPTS="$JAVA_OPTS -agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=n"


### PR DESCRIPTION
Now, when running the docker containers with env variable `HAWKULAR_IMMUTABLE=false`, it'll be possible to invoke operations. This is handy only for testing purposes.