### PR TITLE
When using javaagent, add system properties to JAVA_OPTS.

### DIFF
--- a/docker-dist/src/main/resources/run_hawkular_javaagent.sh
+++ b/docker-dist/src/main/resources/run_hawkular_javaagent.sh
@@ -29,10 +29,11 @@ import_hawkular_services_public_key() {
 }
 
 run_hawkular_agent() {
-    ${JBOSS_HOME}/bin/standalone.sh -b 0.0.0.0 \
+    JAVA_OPTS="${JAVA_OPTS} \
     -Dhawkular.rest.host=${HAWKULAR_SERVER_PROTOCOL}://${HAWKULAR_SERVER_ADDR}:${HAWKULAR_SERVER_PORT} \
     -Dhawkular.rest.user=${HAWKULAR_AGENT_USER} -Dhawkular.rest.password=${HAWKULAR_AGENT_PASSWORD} \
-    -Dhawkular.agent.immutable=${HAWKULAR_IMMUTABLE} -Dhawkular.agent.in-container=${HAWKULAR_IMMUTABLE}
+    -Dhawkular.agent.immutable=${HAWKULAR_IMMUTABLE} -Dhawkular.agent.in-container=${HAWKULAR_IMMUTABLE}"
+    ${JBOSS_HOME}/bin/standalone.sh -b 0.0.0.0
 }
 
 main() {


### PR DESCRIPTION
Every param specified after standalone.sh is sent to main method args
e.g. main(String ... args)

The reason it works sometimes, is because wildfly takes the -D params
and [sets](https://github.com/wildfly/wildfly/blob/master/appclient/src/main/java/org/jboss/as/appclient/subsystem/Main.java#L245-L256) them. When using javaagent, we run the startup code in a
thread. So depending on your luck (most of the times bad luck fo me)
your agent wouldn't *catch* the those params and you would end up
wondering why.

On an agent as subsystem it worked well because wildfly starts
the subsystem after it set everything up.