### PR TITLE
HWKAGENT-126 Remove obsolete Deployment operations

### DIFF
--- a/eap6-support/hawkular-javaagent-wildfly-feature-pack-eap6/src/main/resources/featurepack/content/standalone/configuration/hawkular-javaagent-config.yaml
+++ b/eap6-support/hawkular-javaagent-wildfly-feature-pack-eap6/src/main/resources/featurepack/content/standalone/configuration/hawkular-javaagent-config.yaml
@@ -851,16 +851,6 @@ resource-type-set-dmr:
     - Web Subsystem Metrics
     avail-sets:
     - Deployment Status
-    operation-dmr:
-    - name: Redeploy
-      internal-name: redeploy
-      modifies: true
-    - name: Remove
-      internal-name: remove
-      modifies: true
-    - name: Undeploy
-      internal-name: undeploy
-      modifies: true
   - name: SubDeployment
     resource-name-template: "SubDeployment [%-]"
     path: "/subdeployment=*"

--- a/eap6-support/hawkular-wildfly-agent-feature-pack-eap6/src/main/resources/subsystem-templates/hawkular-wildfly-agent.xml
+++ b/eap6-support/hawkular-wildfly-agent-feature-pack-eap6/src/main/resources/subsystem-templates/hawkular-wildfly-agent.xml
@@ -787,9 +787,6 @@
                          parents="WildFly Server,Domain WildFly Server"
                          metric-sets="Web Subsystem Metrics"
                          avail-sets="Deployment Status">
-        <operation-dmr name="Redeploy" internal-name="redeploy" modifies="true" />
-        <operation-dmr name="Remove"   internal-name="remove"   modifies="true" />
-        <operation-dmr name="Undeploy" internal-name="undeploy" modifies="true" />
       </resource-type-dmr>
 
       <resource-type-dmr name="SubDeployment"

--- a/hawkular-javaagent-itest-parent/hawkular-javaagent-all-itests/hawkular-javaagent-cmdgw-itest/src/test/resources/javaagent-wildfly-config.yaml
+++ b/hawkular-javaagent-itest-parent/hawkular-javaagent-all-itests/hawkular-javaagent-cmdgw-itest/src/test/resources/javaagent-wildfly-config.yaml
@@ -984,16 +984,6 @@ resource-type-set-dmr:
     - Undertow Metrics
     avail-sets:
     - Deployment Status
-    operation-dmr:
-    - name: Redeploy
-      internal-name: redeploy
-      modifies: true
-    - name: Remove
-      internal-name: remove
-      modifies: true
-    - name: Undeploy
-      internal-name: undeploy
-      modifies: true
   - name: SubDeployment
     resource-name-template: "SubDeployment [%-]"
     path: "/subdeployment=*"

--- a/hawkular-javaagent-itest-parent/hawkular-javaagent-all-itests/hawkular-javaagent-domain-itest/src/test/resources/javaagent-wildfly-config.yaml
+++ b/hawkular-javaagent-itest-parent/hawkular-javaagent-all-itests/hawkular-javaagent-domain-itest/src/test/resources/javaagent-wildfly-config.yaml
@@ -983,16 +983,6 @@ resource-type-set-dmr:
     - Undertow Metrics
     avail-sets:
     - Deployment Status
-    operation-dmr:
-    - name: Redeploy
-      internal-name: redeploy
-      modifies: true
-    - name: Remove
-      internal-name: remove
-      modifies: true
-    - name: Undeploy
-      internal-name: undeploy
-      modifies: true
   - name: SubDeployment
     resource-name-template: "SubDeployment [%-]"
     path: "/subdeployment=*"

--- a/hawkular-javaagent-wildfly-feature-pack/src/main/resources/featurepack/content/standalone/configuration/hawkular-javaagent-config.yaml
+++ b/hawkular-javaagent-wildfly-feature-pack/src/main/resources/featurepack/content/standalone/configuration/hawkular-javaagent-config.yaml
@@ -1011,16 +1011,6 @@ resource-type-set-dmr:
     - Undertow Metrics
     avail-sets:
     - Deployment Status
-    operation-dmr:
-    - name: Redeploy
-      internal-name: redeploy
-      modifies: true
-    - name: Remove
-      internal-name: remove
-      modifies: true
-    - name: Undeploy
-      internal-name: undeploy
-      modifies: true
   - name: SubDeployment
     resource-name-template: "SubDeployment [%-]"
     path: "/subdeployment=*"

--- a/hawkular-javaagent/src/test/resources/real-config-eap6.yaml
+++ b/hawkular-javaagent/src/test/resources/real-config-eap6.yaml
@@ -848,16 +848,6 @@ resource-type-set-dmr:
     - Web Subsystem Metrics
     avail-sets:
     - Deployment Status
-    operation-dmr:
-    - name: Redeploy
-      internal-name: redeploy
-      modifies: true
-    - name: Remove
-      internal-name: remove
-      modifies: true
-    - name: Undeploy
-      internal-name: undeploy
-      modifies: true
   - name: SubDeployment
     resource-name-template: "SubDeployment [%-]"
     path: "/subdeployment=*"

--- a/hawkular-javaagent/src/test/resources/real-config.yaml
+++ b/hawkular-javaagent/src/test/resources/real-config.yaml
@@ -998,16 +998,6 @@ resource-type-set-dmr:
     - Undertow Metrics
     avail-sets:
     - Deployment Status
-    operation-dmr:
-    - name: Redeploy
-      internal-name: redeploy
-      modifies: true
-    - name: Remove
-      internal-name: remove
-      modifies: true
-    - name: Undeploy
-      internal-name: undeploy
-      modifies: true
   - name: SubDeployment
     resource-name-template: "SubDeployment [%-]"
     path: "/subdeployment=*"

--- a/hawkular-swarm-agents/hawkular-swarm-agent-dists/hawkular-swarm-agent-dist/src/main/resources/hawkular-swarm-agent-config.xml
+++ b/hawkular-swarm-agents/hawkular-swarm-agent-dists/hawkular-swarm-agent-dist/src/main/resources/hawkular-swarm-agent-config.xml
@@ -926,9 +926,6 @@
                            parents="WildFly Server,Domain WildFly Server"
                            metric-sets="Undertow Metrics"
                            avail-sets="Deployment Status">
-          <operation-dmr name="Redeploy" internal-name="redeploy" modifies="true"/>
-          <operation-dmr name="Remove"   internal-name="remove"   modifies="true"/>
-          <operation-dmr name="Undeploy" internal-name="undeploy" modifies="true"/>
         </resource-type-dmr>
 
         <resource-type-dmr name="SubDeployment"

--- a/hawkular-wildfly-agent-feature-pack/src/main/resources/subsystem-templates/hawkular-wildfly-agent.xml
+++ b/hawkular-wildfly-agent-feature-pack/src/main/resources/subsystem-templates/hawkular-wildfly-agent.xml
@@ -867,9 +867,6 @@
                          parents="WildFly Server,Domain WildFly Server"
                          metric-sets="Undertow Metrics"
                          avail-sets="Deployment Status">
-        <operation-dmr name="Redeploy" internal-name="redeploy" modifies="true" />
-        <operation-dmr name="Remove"   internal-name="remove"   modifies="true" />
-        <operation-dmr name="Undeploy" internal-name="undeploy" modifies="true" />
       </resource-type-dmr>
 
       <resource-type-dmr name="SubDeployment"


### PR DESCRIPTION
These operations are performed via Command support, not generically.

@jmazzitelli , if this looks good I can create a PR for the mwm-wildfly branch.