### PR TITLE
put feed id in resource ids, but not resource type ids

### DIFF
--- a/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/inventory/InventoryIdUtil.java
+++ b/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/inventory/InventoryIdUtil.java
@@ -26,12 +26,18 @@ import org.hawkular.agent.monitor.config.AgentCoreEngineConfiguration.AbstractEn
 public class InventoryIdUtil {
     public static class ResourceIdParts {
 
+        private final String feedId;
         private final String managedServerName;
         private final String idPart;
 
-        private ResourceIdParts(String managedServerName, String idPart) {
+        private ResourceIdParts(String feedId, String managedServerName, String idPart) {
+            this.feedId = feedId;
             this.managedServerName = managedServerName;
             this.idPart = idPart;
+        }
+
+        public String getFeedId() {
+            return feedId;
         }
 
         public String getManagedServerName() {
@@ -44,7 +50,7 @@ public class InventoryIdUtil {
     }
 
     /**
-     * Given a resource ID generated via {@link InventoryIdUtil#generateResourceId(ManagedServer, String)}
+     * Given a resource ID generated via {@link InventoryIdUtil#generateResourceId}
      * this returns the different parts that make up that resource ID.
      *
      * @param resourceId the full resource ID to be parsed
@@ -55,11 +61,11 @@ public class InventoryIdUtil {
             throw new IllegalArgumentException("Invalid resource ID - cannot be null");
         }
 
-        String[] parts = resourceId.split("~", 2);
-        if (parts.length != 2) {
+        String[] parts = resourceId.split("~", 3);
+        if (parts.length != 3) {
             throw new IllegalArgumentException("Cannot parse invalid ID: " + resourceId);
         }
-        return new ResourceIdParts(parts[0], parts[1]);
+        return new ResourceIdParts(parts[0], parts[1], parts[2]);
     }
 
     /**
@@ -71,9 +77,11 @@ public class InventoryIdUtil {
      *
      * @return the resource ID
      */
-    public static ID generateResourceId(MonitoredEndpoint<? extends AbstractEndpointConfiguration> endpoint,
+    public static ID generateResourceId(
+            String feedId,
+            MonitoredEndpoint<? extends AbstractEndpointConfiguration> endpoint,
             String idPart) {
-        ID id = new ID(String.format("%s~%s", endpoint.getName(), idPart));
+        ID id = new ID(String.format("%s~%s~%s", feedId, endpoint.getName(), idPart));
         return id;
     }
 

--- a/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/protocol/Discovery.java
+++ b/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/protocol/Discovery.java
@@ -78,7 +78,10 @@ public final class Discovery<L> {
                 L location = entry.getKey(); // this is the unique DMR address for this resource
                 String resourceName = session.getLocationResolver().applyTemplate(childType.getResourceNameTemplate(),
                         location, session.getEndpoint().getName());
-                ID id = InventoryIdUtil.generateResourceId(session.getEndpoint(), location.toString());
+                ID id = InventoryIdUtil.generateResourceId(
+                        session.getFeedId(),
+                        session.getEndpoint(),
+                        location.toString());
                 Builder<L> builder = Resource.<L> builder()
                         .id(id)
                         .name(new Name(resourceName))

--- a/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/storage/AsyncInventoryStorage.java
+++ b/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/storage/AsyncInventoryStorage.java
@@ -166,7 +166,7 @@ public class AsyncInventoryStorage implements InventoryStorage {
         } else {
             id = no.getID().getIDString();
         }
-        return feedId + "~" + id;
+        return id;
     }
 
     private <L> void addResourceToImport(Resource<L> r, List<org.hawkular.inventory.model.Resource> importResources) {

--- a/hawkular-agent-core/src/test/java/org/hawkular/agent/monitor/inventory/InventoryIdUtilTest.java
+++ b/hawkular-agent-core/src/test/java/org/hawkular/agent/monitor/inventory/InventoryIdUtilTest.java
@@ -35,16 +35,18 @@ public class InventoryIdUtilTest {
         MonitoredEndpoint<EndpointConfiguration> me = MonitoredEndpoint.<EndpointConfiguration> of(endpointConfig,
                 null);
 
-        id = InventoryIdUtil.generateResourceId(me, "/test/id/path");
-        Assert.assertEquals("testmanagedserver~/test/id/path", id.toString());
+        id = InventoryIdUtil.generateResourceId("fid", me, "/test/id/path");
+        Assert.assertEquals("fid~testmanagedserver~/test/id/path", id.toString());
         parts = InventoryIdUtil.parseResourceId(id.getIDString());
+        Assert.assertEquals("fid", parts.getFeedId());
         Assert.assertEquals("testmanagedserver", parts.getManagedServerName());
         Assert.assertEquals("/test/id/path", parts.getIdPart());
 
         // test that you can have ~ in the last part of the ID
-        id = InventoryIdUtil.generateResourceId(me, "~/~test/~id/~path");
-        Assert.assertEquals("testmanagedserver~~/~test/~id/~path", id.toString());
+        id = InventoryIdUtil.generateResourceId("fid", me, "~/~test/~id/~path");
+        Assert.assertEquals("fid~testmanagedserver~~/~test/~id/~path", id.toString());
         parts = InventoryIdUtil.parseResourceId(id.getIDString());
+        Assert.assertEquals("fid", parts.getFeedId());
         Assert.assertEquals("testmanagedserver", parts.getManagedServerName());
         Assert.assertEquals("~/~test/~id/~path", parts.getIdPart());
     }


### PR DESCRIPTION
resource type ids are back to the way they were, which is just the type name