### PR TITLE
HAWKULAR-1283: Fix problem access local DRM connection in OpenShift

### DIFF
--- a/docker-dist/Dockerfile
+++ b/docker-dist/Dockerfile
@@ -39,7 +39,8 @@ RUN yum install --quiet -y openssl && \
     rm -rf /var/cache/yum && \
     chown -RH jboss:0 $JBOSS_HOME/standalone $JAVA_HOME/jre/lib/security/cacerts /opt/hawkular && \
     chmod -R ug+rw $JBOSS_HOME/standalone $JAVA_HOME/jre/lib/security/cacerts /opt/hawkular && \
-    chmod -R a+rw /opt/hawkular/
+    chmod -R a+rw /opt/hawkular/ && \
+    chmod -R a+x $JBOSS_HOME
 
 USER jboss
 CMD /opt/hawkular/bin/run_hawkular_agent.sh

--- a/docker-dist/build.sh
+++ b/docker-dist/build.sh
@@ -19,7 +19,7 @@
 
 docker > /dev/null 2>&1 || { echo "docker is required, but is not found. Make sure it is accessible."; exit 1; }
 TAG="${1:-latest}"
-IMAGE="${2:-wildfly-hawkular-javaagent}"
+IMAGE="${2:-hawkular/wildfly-hawkular-javaagent}"
 
 pushd "$( dirname "${BASH_SOURCE[0]}" )"
 

--- a/docker-dist/hawkular-javaagent-example.yaml
+++ b/docker-dist/hawkular-javaagent-example.yaml
@@ -31,8 +31,7 @@ spec:
     spec:
       containers:
       - name: hawkular-javaagent-example
-        image: wildfly-hawkular-javaagent:latest
-        imagePullPolicy: Never
+        image: hawkular/wildfly-hawkular-javaagent:hawkular-1259
         ports:
         - containerPort: 8080
         env:


### PR DESCRIPTION
Fixes HAWKULAR-1283, we could not access the local DMR connection due to a file permission issue.

Also updates our OpenShift template to use the pre-built docker images available in docker hub.