### PR TITLE
HAWKULAR-1289 - Build a single docker image that supports both standalone and domain

### DIFF
--- a/docker-dist/Dockerfile
+++ b/docker-dist/Dockerfile
@@ -15,28 +15,32 @@
 # limitations under the License.
 #
 
-FROM jboss/wildfly:10.1.0.Final
+FROM jboss/wildfly:11.0.0.Final
 
 MAINTAINER Hawkular project <hawkular-dev@lists.jboss.org>
 
 # ADD test-simple.war /opt/jboss/wildfly/standalone/deployments/
 COPY target/hawkular-javaagent.jar $JBOSS_HOME/bin/
-COPY target/hawkular-javaagent-config.yaml $JBOSS_HOME/standalone/configuration/
+COPY target/hawkular-javaagent-config.yaml /opt/hawkular/configuration/
 
 ADD src/main/resources/run_hawkular_javaagent.sh /opt/hawkular/bin/run_hawkular_agent.sh
 
 ENV HAWKULAR_URL=http://hawkular:8080 \
     HAWKULAR_AGENT_USER=jdoe \
     HAWKULAR_AGENT_PASSWORD=password \
-    HAWKULAR_IMMUTABLE=true
+    HAWKULAR_IMMUTABLE=true \
+    HAWKULAR_MODE=standalone
 
 EXPOSE 8080 9090
 
 USER root
-RUN echo 'JAVA_OPTS="$JAVA_OPTS -Djboss.modules.system.pkgs=org.jboss.byteman,org.jboss.logmanager -Djava.util.logging.manager=org.jboss.logmanager.LogManager -javaagent:$JBOSS_HOME/bin/hawkular-javaagent.jar=config=$JBOSS_HOME/standalone/configuration/hawkular-javaagent-config.yaml,delay=10"' >> $JBOSS_HOME/bin/standalone.conf
-RUN echo 'JAVA_OPTS="$JAVA_OPTS ' \
-'-Dhawkular.rest.host=${HAWKULAR_URL} ' \
-'-Dhawkular.agent.immutable=${HAWKULAR_IMMUTABLE} -Dhawkular.agent.in-container=${HAWKULAR_IMMUTABLE}"' >> $JBOSS_HOME/bin/standalone.conf
+RUN printf 'JAVA_OPTS="$JAVA_OPTS' >> $JBOSS_HOME/bin/standalone.conf
+RUN printf 'HOST_CONTROLLER_JAVA_OPTS="$HOST_CONTROLLER_JAVA_OPTS' >> $JBOSS_HOME/bin/domain.conf
+RUN printf ' -Djboss.modules.system.pkgs=org.jboss.byteman,org.jboss.logmanager -Djava.util.logging.manager=org.jboss.logmanager.LogManager -javaagent:$JBOSS_HOME/bin/hawkular-javaagent.jar=config=/opt/hawkular/configuration/hawkular-javaagent-config.yaml,delay=10' \
+| tee -a $JBOSS_HOME/bin/standalone.conf $JBOSS_HOME/bin/domain.conf  > /dev/null
+RUN printf ' -Djboss.host.server-excluded-properties=jboss.modules.system.pkgs,java.util.logging.manager' >> $JBOSS_HOME/bin/domain.conf
+RUN printf ' -Dhawkular.rest.url=${HAWKULAR_URL} -Dhawkular.agent.immutable=${HAWKULAR_IMMUTABLE} -Dhawkular.agent.in-container=${HAWKULAR_IMMUTABLE}"\n' \
+| tee -a $JBOSS_HOME/bin/standalone.conf $JBOSS_HOME/bin/domain.conf  > /dev/null
 
 
 RUN yum install --quiet -y openssl && \

--- a/docker-dist/README.adoc
+++ b/docker-dist/README.adoc
@@ -1,6 +1,6 @@
 = Containers: Docker, OpenShift & Kubernetes
 
-The following instructions outline how to build a docker image which contains Wildfly 10.1 with the Hawkular Javaagent installed as well as how to deploy in Docker and on OpenShift or Kubernetes.
+The following instructions outline how to build a docker image which contains Wildfly 11.0 with the Hawkular Javaagent installed as well as how to deploy in Docker and on OpenShift or Kubernetes.
 
 == Building
 
@@ -27,6 +27,9 @@ build.sh devel hawkular/wildfly-javaagent
 You will typically need three pieces of information when connecting to a remote Hawkular Services server: the URL for the Hawkular Services server, a username and a password.
 
 This information can be passed to the docker image via environment properties: 'HAWKULAR_URL', 'HAWKULAR_AGENT_USER', 'HAWKULAR_AGENT_PASSWORD'
+
+By default, the docker image will start a Wildfly in standalone mode. You can control if you want to start a Wildfly
+in domain mode by setting the environment property 'HAWKULAR_MODE' to 'domain'.
 
 NOTE: For security reasons, it is recommend to only pass secret information such as usernames and passwords via an property file and not as normal parameters.
 
@@ -64,9 +67,9 @@ oc create hawkular-javaagent-example.yaml
 
 This should create a deployment in your current project with a single replica.
 
-NOTE: if your Hawkular Services server is being accessed over https and is using untrusted https certificates, please see the 'Running with untrused certificates' section below.
+NOTE: if your Hawkular Services server is being accessed over https and is using untrusted https certificates, please see the 'Running with untrusted certificates' section below.
 
-== Running with untrused certificates (https)
+== Running with untrusted certificates (https)
 
 Running your Hawkular Services server with self signed or untrusted certificates will mean that the agent will not be able to trust and connect to the server.
 

--- a/docker-dist/src/main/resources/run_hawkular_javaagent.sh
+++ b/docker-dist/src/main/resources/run_hawkular_javaagent.sh
@@ -29,10 +29,18 @@ import_hawkular_services_public_key() {
 }
 
 run_hawkular_agent() {
-    ${JBOSS_HOME}/bin/standalone.sh -b 0.0.0.0
+    ${JBOSS_HOME}/bin/${HAWKULAR_MODE}.sh -b 0.0.0.0
 }
 
 main() {
+  HAWKULAR_MODE=`echo ${HAWKULAR_MODE} | tr '[:upper:]' '[:lower:]'`
+  if [[ "${HAWKULAR_MODE}" != "standalone" ]] && [[ "${HAWKULAR_MODE}" != "domain" ]]; then
+    echo 'HAWKULAR_MODE must be set to "standalone" or "domain", found:' ${HAWKULAR_MODE}
+    exit
+  fi
+  if [[ "${HAWKULAR_MODE}" == "domain" ]]; then
+    sed -i "s|- Standalone Environment|- Domain Environment|g" /opt/hawkular/configuration/hawkular-javaagent-config.yaml
+  fi
   import_hawkular_services_public_key
   run_hawkular_agent "$@"
 }


### PR DESCRIPTION
By setting env HAWKULAR_MODE one can run it in standalone or domain.
 If HAWKULAR_MODE is not set, it defaults to standalone.
```bash
   docker run -e HAWKULAR_MODE=standalone hawkular/wildfly-hawkular-javaagent
   docker run -e HAWKULAR_MODE=domain hawkular/wildfly-hawkular-javaagent
```

Depends on #381 