### PR TITLE
prometheus metrics are now linked to inventory via metric general properties

### DIFF
--- a/eap6-support/hawkular-javaagent-wildfly-feature-pack-eap6/src/main/resources/featurepack/content/standalone/configuration/hawkular-javaagent-config.yaml
+++ b/eap6-support/hawkular-javaagent-wildfly-feature-pack-eap6/src/main/resources/featurepack/content/standalone/configuration/hawkular-javaagent-config.yaml
@@ -50,373 +50,447 @@ metric-set-dmr:
     metric-type:  gauge
     path:         /core-service=platform-mbean/type=memory
     attribute:    heap-memory-usage#used
-    metric-family: TODO
+    metric-family: jvm_memory_bytes_used
+    metric-labels:
+      area: heap
   - name: Heap Committed
     metric-units: bytes
     metric-type:  gauge
     path:         /core-service=platform-mbean/type=memory
     attribute:    heap-memory-usage#committed
-    metric-family: TODO
+    metric-family: jvm_memory_bytes_committed
+    metric-labels:
+      area: heap
   - name: Heap Max
     metric-units: bytes
     metric-type:  gauge
     path:         /core-service=platform-mbean/type=memory
     attribute:    heap-memory-usage#max
-    metric-family: TODO
+    metric-family: jvm_memory_bytes_max
+    metric-labels:
+      area: heap
   - name: NonHeap Used
     metric-units: bytes
     path:         /core-service=platform-mbean/type=memory
     attribute:    non-heap-memory-usage#used
-    metric-family: TODO
+    metric-family: jvm_memory_bytes_used
+    metric-labels:
+      area: nonheap
   - name: NonHeap Committed
     metric-units: bytes
     path:         /core-service=platform-mbean/type=memory
     attribute:    non-heap-memory-usage#committed
-    metric-family: TODO
+    metric-family: jvm_memory_bytes_committed
+    metric-labels:
+      area: nonheap
+  - name: NonHeap Max
+    metric-units: bytes
+    path:         /core-service=platform-mbean/type=memory
+    attribute:    non-heap-memory-usage#max
+    metric-family: jvm_memory_bytes_max
+    metric-labels:
+      area: nonheap
   - name: Accumulated GC Duration
-    metric-units: milliseconds
+    metric-units: seconds
     metric-type:  counter
     path:         "/core-service=platform-mbean/type=garbage-collector/name=*"
     attribute:    collection-time
-    metric-family: TODO
+    metric-family: jvm_gc_collection_seconds_sum
+    # no metric-labels because we want to aggregate across all of them
 - name: WildFly Threading Metrics
   metric-dmr:
   - name: Thread Count
     metric-type:  gauge
     path:         /core-service=platform-mbean/type=threading
     attribute:    thread-count
-    metric-family: TODO
+    metric-family: jvm_threads_current
 - name: WildFly Aggregated Web Metrics
   metric-dmr:
   - name: Aggregated Active Web Sessions
     path:       "/deployment=*/subsystem=web"
     attribute:  active-sessions
-    metric-family: TODO
+    metric-family: wildfly_deployment_active_sessions
   - name: Aggregated Max Active Web Sessions
     path:       "/deployment=*/subsystem=web"
     attribute:  max-active-sessions
-    metric-family: TODO
+    metric-family: wildfly_deployment_max_active_sessions
   - name: Aggregated Expired Web Sessions
     path:       "/deployment=*/subsystem=web"
     attribute:  expired-sessions
-    metric-family: TODO
+    metric-family: wildfly_deployment_expired_sessions
   - name: Aggregated Rejected Web Sessions
     path:       "/deployment=*/subsystem=web"
     attribute:  rejected-sessions
-    metric-family: TODO
+    metric-family: wildfly_deployment_rejected_sessions
   - name: Aggregated Servlet Request Time
     path:       "/deployment=*/subsystem=web/servlet=*"
     attribute:  processingTime
-    metric-family: TODO
+    metric-family: wildfly_servlet_total_processing_time
   - name: Aggregated Servlet Request Count
     path:       "/deployment=*/subsystem=web/servlet=*"
     attribute:  requestCount
-    metric-family: TODO
+    metric-family: wildfly_servlet_request_count
 - name: Web Subsystem Metrics
   metric-dmr:
   - name: Active Sessions
     path:       "/subsystem=web"
     attribute:  active-sessions
-    metric-family: TODO
+    metric-family: wildfly_deployment_active_sessions
   - name: Sessions Created
     path:       "/subsystem=web"
     attribute:  sessions-created
     metric-type: counter
-    metric-family: TODO
+    metric-family: wildfly_deployment_sessions_created
   - name: Expired Sessions
     path:       "/subsystem=web"
     attribute:  expired-sessions
     metric-type: counter
-    metric-family: TODO
+    metric-family: wildfly_deployment_expired_sessions
   - name: Rejected Sessions
     path:       "/subsystem=web"
     attribute:  rejected-sessions
     metric-type: counter
-    metric-family: TODO
+    metric-family: wildfly_deployment_rejected_sessions
   - name: Max Active Sessions
     path:       "/subsystem=web"
     attribute:  max-active-sessions
-    metric-family: TODO
+    metric-family: wildfly_deployment_max_active_sessions
 - name: Servlet Metrics
   metric-dmr:
   - name: Max Request Time
     attribute:    maxTime
     metric-units: milliseconds
-    metric-family: TODO
+    metric-family: wildfly_servlet_max_time
   - name: Min Request Time
     attribute:    min-time
     metric-units: milliseconds
-    metric-family: TODO
+    metric-family: wildfly_servlet_min_time
   - name: Total Request Time
     attribute:    processingTime
     metric-units: milliseconds
-    metric-family: TODO
+    metric-family: wildfly_servlet_total_request_time
   - name: Request Count
     attribute:    requestCount
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_servlet_request_time
 - name: Singleton EJB Metrics
   metric-dmr:
   - name: Execution Time
     attribute:    execution-time
-    metric-family: TODO
+    metric-family: wildfly_ejb_execution_time
+    metric-labels:
+      type: singleton
   - name: Invocations
     attribute:    invocations
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_ejb_invocations
+    metric-labels:
+      type: singleton
   - name: Peak Concurrent Invocations
     attribute:    peak-concurrent-invocations
-    metric-family: TODO
+    metric-family: wildfly_ejb_peak_concurrent_invocations
+    metric-labels:
+      type: singleton
   - name: Wait Time
     attribute:    wait-time
-    metric-family: TODO
+    metric-family: wildfly_ejb_wait_time
+    metric-labels:
+      type: singleton
 - name: Message Driven EJB Metrics
   metric-dmr:
   - name: Execution Time
     attribute:    execution-time
-    metric-family: TODO
+    metric-family: wildfly_ejb_execution_time
+    metric-labels:
+      type: message-driven
   - name: Invocations
     attribute:    invocations
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_ejb_invocations
+    metric-labels:
+      type: message-driven
   - name: Peak Concurrent Invocations
     attribute:    peak-concurrent-invocations
-    metric-family: TODO
+    metric-family: wildfly_ejb_peak_concurrent_invocations
+    metric-labels:
+      type: message-driven
   - name: Wait Time
     attribute:    wait-time
-    metric-family: TODO
+    metric-family: wildfly_ejb_wait_time
+    metric-labels:
+      type: message-driven
   - name: Pool Available Count
     attribute:    pool-available-count
-    metric-family: TODO
+    metric-family: wildfly_ejb_pool_available_count
+    metric-labels:
+      type: message-driven
   - name: Pool Create Count
     attribute:    pool-create-count
-    metric-family: TODO
+    metric-family: wildfly_ejb_pool_create_count
+    metric-labels:
+      type: message-driven
   - name: Pool Current Size
     attribute:    pool-current-size
-    metric-family: TODO
+    metric-family: wildfly_ejb_pool_current_size
+    metric-labels:
+      type: message-driven
   - name: Pool Max Size
     attribute:    pool-max-size
-    metric-family: TODO
+    metric-family: wildfly_ejb_pool_max_size
+    metric-labels:
+      type: message-driven
   - name: Pool Remove Count
     attribute:    pool-remove-count
-    metric-family: TODO
+    metric-family: wildfly_ejb_pool_remove_count
+    metric-labels:
+      type: message-driven
 - name: Stateless Session EJB Metrics
   metric-dmr:
   - name: Execution Time
     attribute:    execution-time
-    metric-family: TODO
+    metric-family: wildfly_ejb_execution_time
+    metric-labels:
+      type: stateless-session
   - name: Invocations
     attribute:    invocations
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_ejb_invocations
+    metric-labels:
+      type: stateless-session
   - name: Peak Concurrent Invocations
     attribute:    peak-concurrent-invocations
-    metric-family: TODO
+    metric-family: wildfly_ejb_peak_concurrent_invocations
+    metric-labels:
+      type: stateless-session
   - name: Wait Time
     attribute:    wait-time
-    metric-family: TODO
+    metric-family: wildfly_ejb_wait_time
+    metric-labels:
+      type: stateless-session
   - name: Pool Available Count
     attribute:    pool-available-count
-    metric-family: TODO
+    metric-family: wildfly_ejb_pool_available_count
+    metric-labels:
+      type: stateless-session
   - name: Pool Create Count
     attribute:    pool-create-count
-    metric-family: TODO
+    metric-family: wildfly_ejb_pool_create_count
+    metric-labels:
+      type: stateless-session
   - name: Pool Current Size
     attribute:    pool-current-size
-    metric-family: TODO
+    metric-family: wildfly_ejb_pool_current_size
+    metric-labels:
+      type: stateless-session
   - name: Pool Max Size
     attribute:    pool-max-size
-    metric-family: TODO
+    metric-family: wildfly_ejb_pool_max_size
+    metric-labels:
+      type: stateless-session
   - name: Pool Remove Count
     attribute:    pool-remove-count
-    metric-family: TODO
+    metric-family: wildfly_ejb_pool_remove_count
+    metric-labels:
+      type: stateless-session
 - name: Stateful Session EJB Metrics
   metric-dmr:
   - name: Execution Time
     attribute:    execution-time
-    metric-family: TODO
+    metric-family: wildfly_ejb_execution_time
+    metric-labels:
+      type: stateful-session
   - name: Invocations
     attribute:    invocations
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_ejb_invocations
+    metric-labels:
+      type: stateful-session
   - name: Peak Concurrent Invocations
     attribute:    peak-concurrent-invocations
-    metric-family: TODO
+    metric-family: wildfly_ejb_peak_concurrent_invocations
+    metric-labels:
+      type: stateful-session
   - name: Wait Time
     attribute:    wait-time
-    metric-family: TODO
+    metric-family: wildfly_ejb_wait_time
+    metric-labels:
+      type: stateful-session
   - name: Cache Size
     attribute:    cache-size
     metric-family: TODO
+    metric-labels:
+      type: stateful-session
   - name: Total Size
     attribute:    total-size
     metric-family: TODO
+    metric-labels:
+      type: stateful-session
 - name: Datasource JDBC Metrics
   metric-dmr:
   - name: Prepared Statement Cache Access Count
     path:         "/statistics=jdbc"
     attribute:    PreparedStatementCacheAccessCount
-    metric-family: TODO
+    metric-family: wildfly_datasource_jdbc_prepared_statement_cache_access_count
   - name: Prepared Statement Cache Add Count
     path:         "/statistics=jdbc"
     attribute:    PreparedStatementCacheAddCount
-    metric-family: TODO
+    metric-family: wildfly_datasource_jdbc_prepared_statement_cache_add_count
   - name: Prepared Statement Cache Current Size
     path:         "/statistics=jdbc"
     attribute:    PreparedStatementCacheCurrentSize
-    metric-family: TODO
+    metric-family: wildfly_datasource_jdbc_prepared_statement_cache_current_size
   - name: Prepared Statement Cache Delete Count
     path:         "/statistics=jdbc"
     attribute:    PreparedStatementCacheDeleteCount
-    metric-family: TODO
+    metric-family: wildfly_datasource_jdbc_prepared_statement_cache_delete_count
   - name: Prepared Statement Cache Hit Count
     path:         "/statistics=jdbc"
     attribute:    PreparedStatementCacheHitCount
-    metric-family: TODO
+    metric-family: wildfly_datasource_jdbc_prepared_statement_cache_hit_count
   - name: Prepared Statement Cache Miss Count
     path:         "/statistics=jdbc"
     attribute:    PreparedStatementCacheMissCount
-    metric-family: TODO
+    metric-family: wildfly_datasource_jdbc_prepared_statement_cache_miss_count
 - name: Datasource Pool Metrics
   metric-dmr:
   - name: Active Count
     path:         "/statistics=pool"
     attribute:    ActiveCount
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_active_count
   - name: Available Count
     path:         "/statistics=pool"
     attribute:    AvailableCount
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_available_count
   - name: Average Blocking Time
     path:         "/statistics=pool"
     attribute:    AverageBlockingTime
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_average_blocking_time
   - name: Average Creation Time
     path:         "/statistics=pool"
     attribute:    AverageCreationTime
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_average_creation_time
   - name: Created Count
     path:         "/statistics=pool"
     attribute:    CreatedCount
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_created_count
   - name: Destroyed Count
     path:         "/statistics=pool"
     attribute:    DestroyedCount
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_destroyed_count
   - name: In Use Count
     path:         "/statistics=pool"
     attribute:    InUseCount
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_in_use_count
   - name: Max Creation Time
     path:         "/statistics=pool"
     attribute:    MaxCreationTime
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_max_creation_time
   - name: Max Used Count
     path:         "/statistics=pool"
     attribute:    MaxUsedCount
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_max_used_count
   - name: Max Wait Count
     path:         "/statistics=pool"
     attribute:    MaxWaitCount
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_max_wait_count
   - name: Max Wait Time
     path:         "/statistics=pool"
     attribute:    MaxWaitTime
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_max_wait_time
   - name: Timed Out
     path:         "/statistics=pool"
     attribute:    TimedOut
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_timed_out
   - name: Total Blocking Time
     path:         "/statistics=pool"
     attribute:    TotalBlockingTime
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_total_blocking_time
   - name: Total Creation Time
     path:         "/statistics=pool"
     attribute:    TotalCreationTime
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_total_creation_time
 - name: Transactions Metrics
   metric-dmr:
   - name: Number of Aborted Transactions
     attribute:    number-of-aborted-transactions
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_transactions_aborted_transactions
   - name: Number of Application Rollbacks
     attribute:    number-of-application-rollbacks
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_transactions_application_rollbacks
   - name: Number of Committed Transactions
     attribute:    number-of-committed-transactions
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_transactions_committed_transactions
   - name: Number of Heuristics
     attribute:    number-of-heuristics
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_transactions_heuristics
   - name: Number of In-Flight Transactions
     attribute:    number-of-inflight-transactions
-    metric-family: TODO
+    metric-family: wildfly_transactions_inflight_transactions
   - name: Number of Nested Transactions
     attribute:    number-of-nested-transactions
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_transactions_nested_transactions
   - name: Number of Resource Rollbacks
     attribute:    number-of-resource-rollbacks
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_transactions_resource_rollbacks
   - name: Number of Timed Out Transactions
     attribute:    number-of-timed-out-transactions
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_transactions_timed_out_transactions
   - name: Number of Transactions
     attribute:    number-of-transactions
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_transactions_transactions
 - name: JMS Queue Metrics
   metric-dmr:
   - name: Consumer Count
     attribute:    consumer-count
-    metric-family: TODO
+    metric-family: wildfly_messaging_consumer_count
   - name: Delivering Count
     attribute:    delivering-count
-    metric-family: TODO
+    metric-family: wildfly_messaging_delivering_count
   - name: Message Count
     attribute:    message-count
-    metric-family: TODO
+    metric-family: wildfly_messaging_message_count
   - name: Messages Added
     attribute:    messages-added
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_messaging_messages_added
   - name: Scheduled Count
     attribute:    scheduled-count
-    metric-family: TODO
+    metric-family: wildfly_messaging_scheduled_count
 - name: JMS Topic Metrics
   metric-dmr:
   - name: Durable Message Count
     attribute:    durable-message-count
-    metric-family: TODO
+    metric-family: wildfly_messaging_durable_message_count
   - name: Durable Subscription Count
     attribute:    durable-subscription-count
-    metric-family: TODO
+    metric-family: wildfly_messaging_durable_subscription_count
   - name: Delivering Count
     attribute:    delivering-count
-    metric-family: TODO
+    metric-family: wildfly_messaging_delivering_count
   - name: Message Count
     attribute:    message-count
-    metric-family: TODO
+    metric-family: wildfly_messaging_message_count
   - name: Messages Added
     attribute:    messages-added
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_messaging_messages_added
   - name: Non-Durable Message Count
     attribute:    non-durable-message-count
-    metric-family: TODO
+    metric-family: wildfly_messaging_non_durable_message_count
   - name: Non-Durable Subscription Count
     attribute:    non-durable-subscription-count
-    metric-family: TODO
+    metric-family: wildfly_messaging_non_durable_subscription_count
   - name: Subscription Count
     attribute:    subscription-count
-    metric-family: TODO
+    metric-family: wildfly_messaging_subscription_count
 
 resource-type-set-dmr:
 - name: Standalone Environment
@@ -740,6 +814,8 @@ resource-type-set-dmr:
     - Domain WildFly Server
     metric-sets:
     - Web Subsystem Metrics
+    metric-labels:
+      deployment: "%-"
   - name: SubDeployment
     resource-name-template: "%-"
     path: "/subdeployment=*"
@@ -747,6 +823,8 @@ resource-type-set-dmr:
     - Deployment
     metric-sets:
     - Web Subsystem Metrics
+    metric-labels:
+      subdeployment: "%-"
 
 - name: Web Component
   resource-type-dmr:
@@ -758,6 +836,8 @@ resource-type-set-dmr:
     - SubDeployment
     metric-sets:
     - Servlet Metrics
+    metric-labels:
+      name: "%-"
 
 - name: EJB
   resource-type-dmr:
@@ -769,6 +849,8 @@ resource-type-set-dmr:
     - SubDeployment
     metric-sets:
     - Singleton EJB Metrics
+    metric-labels:
+      name: "%-"
   - name: Message Driven EJB
     resource-name-template: "%-"
     path: "/subsystem=ejb3/message-driven-bean=*"
@@ -777,6 +859,8 @@ resource-type-set-dmr:
     - SubDeployment
     metric-sets:
     - Message Driven EJB Metrics
+    metric-labels:
+      name: "%-"
   - name: Stateless Session EJB
     resource-name-template: "%-"
     path: "/subsystem=ejb3/stateless-session-bean=*"
@@ -785,6 +869,8 @@ resource-type-set-dmr:
     - SubDeployment
     metric-sets:
     - Stateless Session EJB Metrics
+    metric-labels:
+      name: "%-"
   - name: Stateful Session EJB
     resource-name-template: "%-"
     path: "/subsystem=ejb3/stateful-session-bean=*"
@@ -793,6 +879,8 @@ resource-type-set-dmr:
     - SubDeployment
     metric-sets:
     - Stateful Session EJB Metrics
+    metric-labels:
+      name: "%-"
 
 - name: Datasource
   resource-type-dmr:
@@ -805,6 +893,8 @@ resource-type-set-dmr:
     metric-sets:
     - Datasource Pool Metrics
     - Datasource JDBC Metrics
+    metric-labels:
+      name: "%-"
     resource-config-dmr:
     - name: Connection URL
       attribute: connection-url
@@ -840,6 +930,8 @@ resource-type-set-dmr:
     metric-sets:
     - Datasource Pool Metrics
     - Datasource JDBC Metrics
+    metric-labels:
+      name: "%-"
     resource-config-dmr:
     - name: Driver Name
       attribute: driver-name
@@ -903,6 +995,8 @@ resource-type-set-dmr:
     - Messaging Server
     metric-sets:
     - JMS Queue Metrics
+    metric-labels:
+      name: "%-"
   - name: JMS Topic
     resource-name-template: "%-"
     path: "/jms-topic=*"
@@ -910,6 +1004,8 @@ resource-type-set-dmr:
     - Messaging Server
     metric-sets:
     - JMS Topic Metrics
+    metric-labels:
+      name: "%-"
 
 - name: Socket Binding Group
   resource-type-dmr:
@@ -1012,12 +1108,14 @@ metric-set-jmx:
     attribute:    HeapMemoryUsage#used
     metric-units: bytes
     metric-type:  gauge
-    metric-family: TODO
+    metric-family: jvm_memory_bytes_used
+    metric-labels:
+      area: heap
   - name: Aggregate GC Collection Time
     object-name:  "java.lang:type=GarbageCollector,name=*"
     attribute:    CollectionTime
-    metric-units: milliseconds
-    metric-family: TODO
+    metric-units: seconds
+    metric-family: jvm_gc_collection_seconds_sum
 - name: Memory Pool Metrics
   metric-jmx:
   - name: Initial
@@ -1029,17 +1127,17 @@ metric-set-jmx:
     attribute:    Usage#used
     metric-units: bytes
     metric-type:  gauge
-    metric-family: TODO
+    metric-family: jvm_memory_pool_bytes_used
   - name: Committed
     attribute:    Usage#committed
     metric-units: bytes
     metric-type:  gauge
-    metric-family: TODO
+    metric-family: jvm_memory_pool_bytes_committed
   - name: Max
     attribute:    Usage#max
     metric-units: bytes
     metric-type:  gauge
-    metric-family: TODO
+    metric-family: jvm_memory_pool_bytes_max
 
 resource-type-set-jmx:
 - name: Main
@@ -1109,6 +1207,8 @@ managed-servers:
     - Clustering
     wait-for:
     - name: /
+    metric-labels:
+      feed-id: "%FeedId"
 
   local-jmx:
     name: Local JMX
@@ -1119,6 +1219,8 @@ managed-servers:
     - Hawkular
     wait-for:
     - name: java.lang:type=Runtime
+    metric-labels:
+      feed-id: "%FeedId"
 
   remote-dmr:
   - name: Remote DMR EAP6
@@ -1142,6 +1244,8 @@ managed-servers:
     - Clustering
     wait-for:
     - name: /
+    metric-labels:
+      feed-id: "%FeedId"
 
   remote-jmx:
   - name: Remote Jolokia Server
@@ -1152,6 +1256,8 @@ managed-servers:
     - Memory Pool
     wait-for:
     - name: java.lang:type=Runtime
+    metric-labels:
+      feed-id: "%FeedId"
 
 platform:
   enabled:      true

--- a/hawkular-javaagent-itest-parent/hawkular-javaagent-all-itests/hawkular-javaagent-cmdgw-itest/src/test/resources/hawkular-javaagent-itest-config.yaml
+++ b/hawkular-javaagent-itest-parent/hawkular-javaagent-all-itests/hawkular-javaagent-cmdgw-itest/src/test/resources/hawkular-javaagent-itest-config.yaml
@@ -50,397 +50,471 @@ metric-set-dmr:
     metric-type:  gauge
     path:         /core-service=platform-mbean/type=memory
     attribute:    heap-memory-usage#used
-    metric-family: TODO
+    metric-family: jvm_memory_bytes_used
+    metric-labels:
+      area: heap
   - name: Heap Committed
     metric-units: bytes
     metric-type:  gauge
     path:         /core-service=platform-mbean/type=memory
     attribute:    heap-memory-usage#committed
-    metric-family: TODO
+    metric-family: jvm_memory_bytes_committed
+    metric-labels:
+      area: heap
   - name: Heap Max
     metric-units: bytes
     metric-type:  gauge
     path:         /core-service=platform-mbean/type=memory
     attribute:    heap-memory-usage#max
-    metric-family: TODO
+    metric-family: jvm_memory_bytes_max
+    metric-labels:
+      area: heap
   - name: NonHeap Used
     metric-units: bytes
     path:         /core-service=platform-mbean/type=memory
     attribute:    non-heap-memory-usage#used
-    metric-family: TODO
+    metric-family: jvm_memory_bytes_used
+    metric-labels:
+      area: nonheap
   - name: NonHeap Committed
     metric-units: bytes
     path:         /core-service=platform-mbean/type=memory
     attribute:    non-heap-memory-usage#committed
-    metric-family: TODO
+    metric-family: jvm_memory_bytes_committed
+    metric-labels:
+      area: nonheap
+  - name: NonHeap Max
+    metric-units: bytes
+    path:         /core-service=platform-mbean/type=memory
+    attribute:    non-heap-memory-usage#max
+    metric-family: jvm_memory_bytes_max
+    metric-labels:
+      area: nonheap
   - name: Accumulated GC Duration
-    metric-units: milliseconds
+    metric-units: seconds
     metric-type:  counter
     path:         "/core-service=platform-mbean/type=garbage-collector/name=*"
     attribute:    collection-time
-    metric-family: TODO
+    metric-family: jvm_gc_collection_seconds_sum
+    # no metric-labels because we want to aggregate across all of them
 - name: WildFly Threading Metrics
   metric-dmr:
   - name: Thread Count
     metric-type:  gauge
     path:         /core-service=platform-mbean/type=threading
     attribute:    thread-count
-    metric-family: TODO
+    metric-family: jvm_threads_current
 - name: WildFly Aggregated Web Metrics
   metric-dmr:
   - name: Aggregated Active Web Sessions
     path:       "/deployment=*/subsystem=undertow"
     attribute:  active-sessions
-    metric-family: TODO
+    metric-family: wildfly_deployment_active_sessions
   - name: Aggregated Max Active Web Sessions
     path:       "/deployment=*/subsystem=undertow"
     attribute:  max-active-sessions
-    metric-family: TODO
+    metric-family: wildfly_deployment_max_active_sessions
   - name: Aggregated Expired Web Sessions
     path:       "/deployment=*/subsystem=undertow"
     attribute:  expired-sessions
-    metric-family: TODO
+    metric-family: wildfly_deployment_expired_sessions
   - name: Aggregated Rejected Web Sessions
     path:       "/deployment=*/subsystem=undertow"
     attribute:  rejected-sessions
-    metric-family: TODO
+    metric-family: wildfly_deployment_rejected_sessions
   - name: Aggregated Servlet Request Time
     path:       "/deployment=*/subsystem=undertow/servlet=*"
     attribute:  total-request-time
-    metric-family: TODO
+    metric-family: wildfly_servlet_total_request_time
   - name: Aggregated Servlet Request Count
     path:       "/deployment=*/subsystem=undertow/servlet=*"
     attribute:  request-count
-    metric-family: TODO
+    metric-family: wildfly_servlet_request_count
 - name: Undertow Metrics
   metric-dmr:
   - name: Active Sessions
     path:       "/subsystem=undertow"
     attribute:  active-sessions
-    metric-family: TODO
+    metric-family: wildfly_deployment_active_sessions
   - name: Sessions Created
     path:       "/subsystem=undertow"
     attribute:  sessions-created
     metric-type: counter
-    metric-family: TODO
+    metric-family: wildfly_deployment_sessions_created
   - name: Expired Sessions
     path:       "/subsystem=undertow"
     attribute:  expired-sessions
     metric-type: counter
-    metric-family: TODO
+    metric-family: wildfly_deployment_expired_sessions
   - name: Rejected Sessions
     path:       "/subsystem=undertow"
     attribute:  rejected-sessions
     metric-type: counter
-    metric-family: TODO
+    metric-family: wildfly_deployment_rejected_sessions
   - name: Max Active Sessions
     path:       "/subsystem=undertow"
     attribute:  max-active-sessions
-    metric-family: TODO
+    metric-family: wildfly_deployment_max_active_sessions
 - name: Servlet Metrics
   metric-dmr:
   - name: Max Request Time
     attribute:    max-request-time
     metric-units: milliseconds
-    metric-family: TODO
+    metric-family: wildfly_servlet_max_request_time
   - name: Min Request Time
     attribute:    min-request-time
     metric-units: milliseconds
-    metric-family: TODO
+    metric-family: wildfly_servlet_min_request_time
   - name: Total Request Time
     attribute:    total-request-time
     metric-units: milliseconds
-    metric-family: TODO
+    metric-family: wildfly_servlet_total_request_time
   - name: Request Count
     attribute:    request-count
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_servlet_request_count
 - name: Singleton EJB Metrics
   metric-dmr:
   - name: Execution Time
     attribute:    execution-time
-    metric-family: TODO
+    metric-family: wildfly_ejb_execution_time
+    metric-labels:
+      type: singleton
   - name: Invocations
     attribute:    invocations
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_ejb_invocations
+    metric-labels:
+      type: singleton
   - name: Peak Concurrent Invocations
     attribute:    peak-concurrent-invocations
-    metric-family: TODO
+    metric-family: wildfly_ejb_peak_concurrent_invocations
+    metric-labels:
+      type: singleton
   - name: Wait Time
     attribute:    wait-time
-    metric-family: TODO
+    metric-family: wildfly_ejb_wait_time
+    metric-labels:
+      type: singleton
 - name: Message Driven EJB Metrics
   metric-dmr:
   - name: Execution Time
     attribute:    execution-time
-    metric-family: TODO
+    metric-family: wildfly_ejb_execution_time
+    metric-labels:
+      type: message-driven
   - name: Invocations
     attribute:    invocations
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_ejb_invocations
+    metric-labels:
+      type: message-driven
   - name: Peak Concurrent Invocations
     attribute:    peak-concurrent-invocations
-    metric-family: TODO
+    metric-family: wildfly_ejb_peak_concurrent_invocations
+    metric-labels:
+      type: message-driven
   - name: Wait Time
     attribute:    wait-time
-    metric-family: TODO
+    metric-family: wildfly_ejb_wait_time
+    metric-labels:
+      type: message-driven
   - name: Pool Available Count
     attribute:    pool-available-count
-    metric-family: TODO
+    metric-family: wildfly_ejb_pool_available_count
+    metric-labels:
+      type: message-driven
   - name: Pool Create Count
     attribute:    pool-create-count
-    metric-family: TODO
+    metric-family: wildfly_ejb_pool_create_count
+    metric-labels:
+      type: message-driven
   - name: Pool Current Size
     attribute:    pool-current-size
-    metric-family: TODO
+    metric-family: wildfly_ejb_pool_current_size
+    metric-labels:
+      type: message-driven
   - name: Pool Max Size
     attribute:    pool-max-size
-    metric-family: TODO
+    metric-family: wildfly_ejb_pool_max_size
+    metric-labels:
+      type: message-driven
   - name: Pool Remove Count
     attribute:    pool-remove-count
-    metric-family: TODO
+    metric-family: wildfly_ejb_pool_remove_count
+    metric-labels:
+      type: message-driven
 - name: Stateless Session EJB Metrics
   metric-dmr:
   - name: Execution Time
     attribute:    execution-time
-    metric-family: TODO
+    metric-family: wildfly_ejb_execution_time
+    metric-labels:
+      type: stateless-session
   - name: Invocations
     attribute:    invocations
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_ejb_invocations
+    metric-labels:
+      type: stateless-session
   - name: Peak Concurrent Invocations
     attribute:    peak-concurrent-invocations
-    metric-family: TODO
+    metric-family: wildfly_ejb_peak_concurrent_invocations
+    metric-labels:
+      type: stateless-session
   - name: Wait Time
     attribute:    wait-time
-    metric-family: TODO
+    metric-family: wildfly_ejb_wait_time
+    metric-labels:
+      type: stateless-session
   - name: Pool Available Count
     attribute:    pool-available-count
-    metric-family: TODO
+    metric-family: wildfly_ejb_pool_available_count
+    metric-labels:
+      type: stateless-session
   - name: Pool Create Count
     attribute:    pool-create-count
-    metric-family: TODO
+    metric-family: wildfly_ejb_pool_create_count
+    metric-labels:
+      type: stateless-session
   - name: Pool Current Size
     attribute:    pool-current-size
-    metric-family: TODO
+    metric-family: wildfly_ejb_pool_current_size
+    metric-labels:
+      type: stateless-session
   - name: Pool Max Size
     attribute:    pool-max-size
-    metric-family: TODO
+    metric-family: wildfly_ejb_pool_max_size
+    metric-labels:
+      type: stateless-session
   - name: Pool Remove Count
     attribute:    pool-remove-count
-    metric-family: TODO
+    metric-family: wildfly_ejb_pool_remove_count
+    metric-labels:
+      type: stateless-session
 - name: Stateful Session EJB Metrics
   metric-dmr:
   - name: Execution Time
     attribute:    execution-time
-    metric-family: TODO
+    metric-family: wildfly_ejb_execution_time
+    metric-labels:
+      type: stateful-session
   - name: Invocations
     attribute:    invocations
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_ejb_invocations
+    metric-labels:
+      type: stateful-session
   - name: Peak Concurrent Invocations
     attribute:    peak-concurrent-invocations
-    metric-family: TODO
+    metric-family: wildfly_ejb_peak_concurrent_invocations
+    metric-labels:
+      type: stateful-session
   - name: Wait Time
     attribute:    wait-time
-    metric-family: TODO
+    metric-family: wildfly_ejb_wait_time
+    metric-labels:
+      type: stateful-session
   - name: Cache Size
     attribute:    cache-size
     metric-family: TODO
+    metric-labels:
+      type: stateful-session
   - name: Total Size
     attribute:    total-size
     metric-family: TODO
+    metric-labels:
+      type: stateful-session
 - name: Datasource JDBC Metrics
   metric-dmr:
   - name: Prepared Statement Cache Access Count
     path:         "/statistics=jdbc"
     attribute:    PreparedStatementCacheAccessCount
-    metric-family: TODO
+    metric-family: wildfly_datasource_jdbc_prepared_statement_cache_access_count
   - name: Prepared Statement Cache Add Count
     path:         "/statistics=jdbc"
     attribute:    PreparedStatementCacheAddCount
-    metric-family: TODO
+    metric-family: wildfly_datasource_jdbc_prepared_statement_cache_add_count
   - name: Prepared Statement Cache Current Size
     path:         "/statistics=jdbc"
     attribute:    PreparedStatementCacheCurrentSize
-    metric-family: TODO
+    metric-family: wildfly_datasource_jdbc_prepared_statement_cache_current_size
   - name: Prepared Statement Cache Delete Count
     path:         "/statistics=jdbc"
     attribute:    PreparedStatementCacheDeleteCount
-    metric-family: TODO
+    metric-family: wildfly_datasource_jdbc_prepared_statement_cache_delete_count
   - name: Prepared Statement Cache Hit Count
     path:         "/statistics=jdbc"
     attribute:    PreparedStatementCacheHitCount
-    metric-family: TODO
+    metric-family: wildfly_datasource_jdbc_prepared_statement_cache_hit_count
   - name: Prepared Statement Cache Miss Count
     path:         "/statistics=jdbc"
     attribute:    PreparedStatementCacheMissCount
-    metric-family: TODO
+    metric-family: wildfly_datasource_jdbc_prepared_statement_cache_miss_count
 - name: Datasource Pool Metrics
   metric-dmr:
   - name: Active Count
     path:         "/statistics=pool"
     attribute:    ActiveCount
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_active_count
   - name: Available Count
     path:         "/statistics=pool"
     attribute:    AvailableCount
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_available_count
   - name: Average Blocking Time
     path:         "/statistics=pool"
     attribute:    AverageBlockingTime
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_average_blocking_time
   - name: Average Creation Time
     path:         "/statistics=pool"
     attribute:    AverageCreationTime
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_average_creation_time
   - name: Average Get Time
     path:         "/statistics=pool"
     attribute:    AverageGetTime
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_average_get_time
   - name: Blocking Failure Count
     path:         "/statistics=pool"
     attribute:    BlockingFailureCount
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_blocking_failure_count
   - name: Created Count
     path:         "/statistics=pool"
     attribute:    CreatedCount
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_created_count
   - name: Destroyed Count
     path:         "/statistics=pool"
     attribute:    DestroyedCount
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_destroyed_count
   - name: Idle Count
     path:         "/statistics=pool"
     attribute:    IdleCount
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_idle_count
   - name: In Use Count
     path:         "/statistics=pool"
     attribute:    InUseCount
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_in_use_count
   - name: Max Creation Time
     path:         "/statistics=pool"
     attribute:    MaxCreationTime
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_max_creation_time
   - name: Max Get Time
     path:         "/statistics=pool"
     attribute:    MaxGetTime
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_max_get_time
   - name: Max Used Count
     path:         "/statistics=pool"
     attribute:    MaxUsedCount
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_max_used_count
   - name: Max Wait Count
     path:         "/statistics=pool"
     attribute:    MaxWaitCount
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_max_wait_count
   - name: Max Wait Time
     path:         "/statistics=pool"
     attribute:    MaxWaitTime
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_max_wait_time
   - name: Timed Out
     path:         "/statistics=pool"
     attribute:    TimedOut
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_timed_out
   - name: Total Blocking Time
     path:         "/statistics=pool"
     attribute:    TotalBlockingTime
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_total_blocking_time
   - name: Total Creation Time
     path:         "/statistics=pool"
     attribute:    TotalCreationTime
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_total_creation_time
   - name: Total Get Time
     path:         "/statistics=pool"
     attribute:    TotalGetTime
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_total_get_time
   - name: Wait Count
     path:         "/statistics=pool"
     attribute:    WaitCount
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_wait_count
 - name: Transactions Metrics
   metric-dmr:
   - name: Number of Aborted Transactions
     attribute:    number-of-aborted-transactions
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_transactions_aborted_transactions
   - name: Number of Application Rollbacks
     attribute:    number-of-application-rollbacks
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_transactions_application_rollbacks
   - name: Number of Committed Transactions
     attribute:    number-of-committed-transactions
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_transactions_committed_transactions
   - name: Number of Heuristics
     attribute:    number-of-heuristics
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_transactions_heuristics
   - name: Number of In-Flight Transactions
     attribute:    number-of-inflight-transactions
-    metric-family: TODO
+    metric-family: wildfly_transactions_inflight_transactions
   - name: Number of Nested Transactions
     attribute:    number-of-nested-transactions
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_transactions_nested_transactions
   - name: Number of Resource Rollbacks
     attribute:    number-of-resource-rollbacks
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_transactions_resource_rollbacks
   - name: Number of Timed Out Transactions
     attribute:    number-of-timed-out-transactions
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_transactions_timed_out_transactions
   - name: Number of Transactions
     attribute:    number-of-transactions
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_transactions_transactions
 - name: JMS Queue Metrics
   metric-dmr:
   - name: Consumer Count
     attribute:    consumer-count
-    metric-family: TODO
+    metric-family: wildfly_messaging_consumer_count
   - name: Delivering Count
     attribute:    delivering-count
-    metric-family: TODO
+    metric-family: wildfly_messaging_delivering_count
   - name: Message Count
     attribute:    message-count
-    metric-family: TODO
+    metric-family: wildfly_messaging_message_count
   - name: Messages Added
     attribute:    messages-added
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_messaging_messages_added
   - name: Scheduled Count
     attribute:    scheduled-count
-    metric-family: TODO
+    metric-family: wildfly_messaging_scheduled_count
 - name: JMS Topic Metrics
   metric-dmr:
   - name: Durable Message Count
     attribute:    durable-message-count
-    metric-family: TODO
+    metric-family: wildfly_messaging_durable_message_count
   - name: Durable Subscription Count
     attribute:    durable-subscription-count
-    metric-family: TODO
+    metric-family: wildfly_messaging_durable_subscription_count
   - name: Delivering Count
     attribute:    delivering-count
-    metric-family: TODO
+    metric-family: wildfly_messaging_delivering_count
   - name: Message Count
     attribute:    message-count
-    metric-family: TODO
+    metric-family: wildfly_messaging_message_count
   - name: Messages Added
     attribute:    messages-added
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_messaging_messages_added
   - name: Non-Durable Message Count
     attribute:    non-durable-message-count
-    metric-family: TODO
+    metric-family: wildfly_messaging_non_durable_message_count
   - name: Non-Durable Subscription Count
     attribute:    non-durable-subscription-count
-    metric-family: TODO
+    metric-family: wildfly_messaging_non_durable_subscription_count
   - name: Subscription Count
     attribute:    subscription-count
-    metric-family: TODO
+    metric-family: wildfly_messaging_subscription_count
 
 resource-type-set-dmr:
 - name: Standalone Environment
@@ -856,6 +930,8 @@ resource-type-set-dmr:
     - Domain WildFly Server
     metric-sets:
     - Undertow Metrics
+    metric-labels:
+      deployment: "%-"
   - name: SubDeployment
     resource-name-template: "%-"
     path: "/subdeployment=*"
@@ -863,6 +939,8 @@ resource-type-set-dmr:
     - Deployment
     metric-sets:
     - Undertow Metrics
+    metric-labels:
+      subdeployment: "%-"
 
 - name: Web Component
   resource-type-dmr:
@@ -874,6 +952,8 @@ resource-type-set-dmr:
     - SubDeployment
     metric-sets:
     - Servlet Metrics
+    metric-labels:
+      name: "%-"
 
 - name: EJB
   resource-type-dmr:
@@ -885,6 +965,8 @@ resource-type-set-dmr:
     - SubDeployment
     metric-sets:
     - Singleton EJB Metrics
+    metric-labels:
+      name: "%-"
   - name: Message Driven EJB
     resource-name-template: "%-"
     path: "/subsystem=ejb3/message-driven-bean=*"
@@ -893,6 +975,8 @@ resource-type-set-dmr:
     - SubDeployment
     metric-sets:
     - Message Driven EJB Metrics
+    metric-labels:
+      name: "%-"
   - name: Stateless Session EJB
     resource-name-template: "%-"
     path: "/subsystem=ejb3/stateless-session-bean=*"
@@ -901,6 +985,8 @@ resource-type-set-dmr:
     - SubDeployment
     metric-sets:
     - Stateless Session EJB Metrics
+    metric-labels:
+      name: "%-"
   - name: Stateful Session EJB
     resource-name-template: "%-"
     path: "/subsystem=ejb3/stateful-session-bean=*"
@@ -909,6 +995,8 @@ resource-type-set-dmr:
     - SubDeployment
     metric-sets:
     - Stateful Session EJB Metrics
+    metric-labels:
+      name: "%-"
 
 - name: Datasource
   resource-type-dmr:
@@ -921,6 +1009,8 @@ resource-type-set-dmr:
     metric-sets:
     - Datasource Pool Metrics
     - Datasource JDBC Metrics
+    metric-labels:
+      name: "%-"
     resource-config-dmr:
     - name: Connection URL
       attribute: connection-url
@@ -956,6 +1046,8 @@ resource-type-set-dmr:
     metric-sets:
     - Datasource Pool Metrics
     - Datasource JDBC Metrics
+    metric-labels:
+      name: "%-"
     resource-config-dmr:
     - name: Driver Name
       attribute: driver-name
@@ -1019,6 +1111,8 @@ resource-type-set-dmr:
     - Messaging Server
     metric-sets:
     - JMS Queue Metrics
+    metric-labels:
+      name: "%-"
   - name: JMS Topic
     resource-name-template: "%-"
     path: "/jms-topic=*"
@@ -1026,6 +1120,8 @@ resource-type-set-dmr:
     - Messaging Server
     metric-sets:
     - JMS Topic Metrics
+    metric-labels:
+      name: "%-"
 
 - name: Socket Binding Group
   resource-type-dmr:
@@ -1140,12 +1236,14 @@ metric-set-jmx:
     attribute:    HeapMemoryUsage#used
     metric-units: bytes
     metric-type:  gauge
-    metric-family: TODO
+    metric-family: jvm_memory_bytes_used
+    metric-labels:
+      area: heap
   - name: Aggregate GC Collection Time
     object-name:  "java.lang:type=GarbageCollector,name=*"
     attribute:    CollectionTime
-    metric-units: milliseconds
-    metric-family: TODO
+    metric-units: seconds
+    metric-family: jvm_gc_collection_seconds_sum
 - name: Memory Pool Metrics
   metric-jmx:
   - name: Initial
@@ -1157,17 +1255,17 @@ metric-set-jmx:
     attribute:    Usage#used
     metric-units: bytes
     metric-type:  gauge
-    metric-family: TODO
+    metric-family: jvm_memory_pool_bytes_used
   - name: Committed
     attribute:    Usage#committed
     metric-units: bytes
     metric-type:  gauge
-    metric-family: TODO
+    metric-family: jvm_memory_pool_bytes_committed
   - name: Max
     attribute:    Usage#max
     metric-units: bytes
     metric-type:  gauge
-    metric-family: TODO
+    metric-family: jvm_memory_pool_bytes_max
 
 resource-type-set-jmx:
 - name: Main
@@ -1340,6 +1438,8 @@ managed-servers:
     - Clustering
     wait-for:
     - name: /
+    metric-labels:
+      feed-id: "%FeedId"
 
   local-jmx:
     name: Local JMX
@@ -1351,6 +1451,8 @@ managed-servers:
     - For Integration Test
     wait-for:
     - name: java.lang:type=Runtime
+    metric-labels:
+      feed-id: "%FeedId"
 
   remote-dmr:
   - name: Local DMR
@@ -1373,6 +1475,8 @@ managed-servers:
     - Clustering
     wait-for:
     - name: /
+    metric-labels:
+      feed-id: "%FeedId"
 
   remote-jmx:
   - name: Remote JMX
@@ -1384,6 +1488,8 @@ managed-servers:
     - For Integration Test
     wait-for:
     - name: java.lang:type=Runtime
+    metric-labels:
+      feed-id: "%FeedId"
 
 platform:
   enabled:      true

--- a/hawkular-javaagent-itest-parent/hawkular-javaagent-all-itests/hawkular-javaagent-domain-itest/src/test/resources/hawkular-javaagent-itest-config.yaml
+++ b/hawkular-javaagent-itest-parent/hawkular-javaagent-all-itests/hawkular-javaagent-domain-itest/src/test/resources/hawkular-javaagent-itest-config.yaml
@@ -50,397 +50,471 @@ metric-set-dmr:
     metric-type:  gauge
     path:         /core-service=platform-mbean/type=memory
     attribute:    heap-memory-usage#used
-    metric-family: TODO
+    metric-family: jvm_memory_bytes_used
+    metric-labels:
+      area: heap
   - name: Heap Committed
     metric-units: bytes
     metric-type:  gauge
     path:         /core-service=platform-mbean/type=memory
     attribute:    heap-memory-usage#committed
-    metric-family: TODO
+    metric-family: jvm_memory_bytes_committed
+    metric-labels:
+      area: heap
   - name: Heap Max
     metric-units: bytes
     metric-type:  gauge
     path:         /core-service=platform-mbean/type=memory
     attribute:    heap-memory-usage#max
-    metric-family: TODO
+    metric-family: jvm_memory_bytes_max
+    metric-labels:
+      area: heap
   - name: NonHeap Used
     metric-units: bytes
     path:         /core-service=platform-mbean/type=memory
     attribute:    non-heap-memory-usage#used
-    metric-family: TODO
+    metric-family: jvm_memory_bytes_used
+    metric-labels:
+      area: nonheap
   - name: NonHeap Committed
     metric-units: bytes
     path:         /core-service=platform-mbean/type=memory
     attribute:    non-heap-memory-usage#committed
-    metric-family: TODO
+    metric-family: jvm_memory_bytes_committed
+    metric-labels:
+      area: nonheap
+  - name: NonHeap Max
+    metric-units: bytes
+    path:         /core-service=platform-mbean/type=memory
+    attribute:    non-heap-memory-usage#max
+    metric-family: jvm_memory_bytes_max
+    metric-labels:
+      area: nonheap
   - name: Accumulated GC Duration
-    metric-units: milliseconds
+    metric-units: seconds
     metric-type:  counter
     path:         "/core-service=platform-mbean/type=garbage-collector/name=*"
     attribute:    collection-time
-    metric-family: TODO
+    metric-family: jvm_gc_collection_seconds_sum
+    # no metric-labels because we want to aggregate across all of them
 - name: WildFly Threading Metrics
   metric-dmr:
   - name: Thread Count
     metric-type:  gauge
     path:         /core-service=platform-mbean/type=threading
     attribute:    thread-count
-    metric-family: TODO
+    metric-family: jvm_threads_current
 - name: WildFly Aggregated Web Metrics
   metric-dmr:
   - name: Aggregated Active Web Sessions
     path:       "/deployment=*/subsystem=undertow"
     attribute:  active-sessions
-    metric-family: TODO
+    metric-family: wildfly_deployment_active_sessions
   - name: Aggregated Max Active Web Sessions
     path:       "/deployment=*/subsystem=undertow"
     attribute:  max-active-sessions
-    metric-family: TODO
+    metric-family: wildfly_deployment_max_active_sessions
   - name: Aggregated Expired Web Sessions
     path:       "/deployment=*/subsystem=undertow"
     attribute:  expired-sessions
-    metric-family: TODO
+    metric-family: wildfly_deployment_expired_sessions
   - name: Aggregated Rejected Web Sessions
     path:       "/deployment=*/subsystem=undertow"
     attribute:  rejected-sessions
-    metric-family: TODO
+    metric-family: wildfly_deployment_rejected_sessions
   - name: Aggregated Servlet Request Time
     path:       "/deployment=*/subsystem=undertow/servlet=*"
     attribute:  total-request-time
-    metric-family: TODO
+    metric-family: wildfly_servlet_total_request_time
   - name: Aggregated Servlet Request Count
     path:       "/deployment=*/subsystem=undertow/servlet=*"
     attribute:  request-count
-    metric-family: TODO
+    metric-family: wildfly_servlet_request_count
 - name: Undertow Metrics
   metric-dmr:
   - name: Active Sessions
     path:       "/subsystem=undertow"
     attribute:  active-sessions
-    metric-family: TODO
+    metric-family: wildfly_deployment_active_sessions
   - name: Sessions Created
     path:       "/subsystem=undertow"
     attribute:  sessions-created
     metric-type: counter
-    metric-family: TODO
+    metric-family: wildfly_deployment_sessions_created
   - name: Expired Sessions
     path:       "/subsystem=undertow"
     attribute:  expired-sessions
     metric-type: counter
-    metric-family: TODO
+    metric-family: wildfly_deployment_expired_sessions
   - name: Rejected Sessions
     path:       "/subsystem=undertow"
     attribute:  rejected-sessions
     metric-type: counter
-    metric-family: TODO
+    metric-family: wildfly_deployment_rejected_sessions
   - name: Max Active Sessions
     path:       "/subsystem=undertow"
     attribute:  max-active-sessions
-    metric-family: TODO
+    metric-family: wildfly_deployment_max_active_sessions
 - name: Servlet Metrics
   metric-dmr:
   - name: Max Request Time
     attribute:    max-request-time
     metric-units: milliseconds
-    metric-family: TODO
+    metric-family: wildfly_servlet_max_request_time
   - name: Min Request Time
     attribute:    min-request-time
     metric-units: milliseconds
-    metric-family: TODO
+    metric-family: wildfly_servlet_min_request_time
   - name: Total Request Time
     attribute:    total-request-time
     metric-units: milliseconds
-    metric-family: TODO
+    metric-family: wildfly_servlet_total_request_time
   - name: Request Count
     attribute:    request-count
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_servlet_request_count
 - name: Singleton EJB Metrics
   metric-dmr:
   - name: Execution Time
     attribute:    execution-time
-    metric-family: TODO
+    metric-family: wildfly_ejb_execution_time
+    metric-labels:
+      type: singleton
   - name: Invocations
     attribute:    invocations
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_ejb_invocations
+    metric-labels:
+      type: singleton
   - name: Peak Concurrent Invocations
     attribute:    peak-concurrent-invocations
-    metric-family: TODO
+    metric-family: wildfly_ejb_peak_concurrent_invocations
+    metric-labels:
+      type: singleton
   - name: Wait Time
     attribute:    wait-time
-    metric-family: TODO
+    metric-family: wildfly_ejb_wait_time
+    metric-labels:
+      type: singleton
 - name: Message Driven EJB Metrics
   metric-dmr:
   - name: Execution Time
     attribute:    execution-time
-    metric-family: TODO
+    metric-family: wildfly_ejb_execution_time
+    metric-labels:
+      type: message-driven
   - name: Invocations
     attribute:    invocations
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_ejb_invocations
+    metric-labels:
+      type: message-driven
   - name: Peak Concurrent Invocations
     attribute:    peak-concurrent-invocations
-    metric-family: TODO
+    metric-family: wildfly_ejb_peak_concurrent_invocations
+    metric-labels:
+      type: message-driven
   - name: Wait Time
     attribute:    wait-time
-    metric-family: TODO
+    metric-family: wildfly_ejb_wait_time
+    metric-labels:
+      type: message-driven
   - name: Pool Available Count
     attribute:    pool-available-count
-    metric-family: TODO
+    metric-family: wildfly_ejb_pool_available_count
+    metric-labels:
+      type: message-driven
   - name: Pool Create Count
     attribute:    pool-create-count
-    metric-family: TODO
+    metric-family: wildfly_ejb_pool_create_count
+    metric-labels:
+      type: message-driven
   - name: Pool Current Size
     attribute:    pool-current-size
-    metric-family: TODO
+    metric-family: wildfly_ejb_pool_current_size
+    metric-labels:
+      type: message-driven
   - name: Pool Max Size
     attribute:    pool-max-size
-    metric-family: TODO
+    metric-family: wildfly_ejb_pool_max_size
+    metric-labels:
+      type: message-driven
   - name: Pool Remove Count
     attribute:    pool-remove-count
-    metric-family: TODO
+    metric-family: wildfly_ejb_pool_remove_count
+    metric-labels:
+      type: message-driven
 - name: Stateless Session EJB Metrics
   metric-dmr:
   - name: Execution Time
     attribute:    execution-time
-    metric-family: TODO
+    metric-family: wildfly_ejb_execution_time
+    metric-labels:
+      type: stateless-session
   - name: Invocations
     attribute:    invocations
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_ejb_invocations
+    metric-labels:
+      type: stateless-session
   - name: Peak Concurrent Invocations
     attribute:    peak-concurrent-invocations
-    metric-family: TODO
+    metric-family: wildfly_ejb_peak_concurrent_invocations
+    metric-labels:
+      type: stateless-session
   - name: Wait Time
     attribute:    wait-time
-    metric-family: TODO
+    metric-family: wildfly_ejb_wait_time
+    metric-labels:
+      type: stateless-session
   - name: Pool Available Count
     attribute:    pool-available-count
-    metric-family: TODO
+    metric-family: wildfly_ejb_pool_available_count
+    metric-labels:
+      type: stateless-session
   - name: Pool Create Count
     attribute:    pool-create-count
-    metric-family: TODO
+    metric-family: wildfly_ejb_pool_create_count
+    metric-labels:
+      type: stateless-session
   - name: Pool Current Size
     attribute:    pool-current-size
-    metric-family: TODO
+    metric-family: wildfly_ejb_pool_current_size
+    metric-labels:
+      type: stateless-session
   - name: Pool Max Size
     attribute:    pool-max-size
-    metric-family: TODO
+    metric-family: wildfly_ejb_pool_max_size
+    metric-labels:
+      type: stateless-session
   - name: Pool Remove Count
     attribute:    pool-remove-count
-    metric-family: TODO
+    metric-family: wildfly_ejb_pool_remove_count
+    metric-labels:
+      type: stateless-session
 - name: Stateful Session EJB Metrics
   metric-dmr:
   - name: Execution Time
     attribute:    execution-time
-    metric-family: TODO
+    metric-family: wildfly_ejb_execution_time
+    metric-labels:
+      type: stateful-session
   - name: Invocations
     attribute:    invocations
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_ejb_invocations
+    metric-labels:
+      type: stateful-session
   - name: Peak Concurrent Invocations
     attribute:    peak-concurrent-invocations
-    metric-family: TODO
+    metric-family: wildfly_ejb_peak_concurrent_invocations
+    metric-labels:
+      type: stateful-session
   - name: Wait Time
     attribute:    wait-time
-    metric-family: TODO
+    metric-family: wildfly_ejb_wait_time
+    metric-labels:
+      type: stateful-session
   - name: Cache Size
     attribute:    cache-size
     metric-family: TODO
+    metric-labels:
+      type: stateful-session
   - name: Total Size
     attribute:    total-size
     metric-family: TODO
+    metric-labels:
+      type: stateful-session
 - name: Datasource JDBC Metrics
   metric-dmr:
   - name: Prepared Statement Cache Access Count
     path:         "/statistics=jdbc"
     attribute:    PreparedStatementCacheAccessCount
-    metric-family: TODO
+    metric-family: wildfly_datasource_jdbc_prepared_statement_cache_access_count
   - name: Prepared Statement Cache Add Count
     path:         "/statistics=jdbc"
     attribute:    PreparedStatementCacheAddCount
-    metric-family: TODO
+    metric-family: wildfly_datasource_jdbc_prepared_statement_cache_add_count
   - name: Prepared Statement Cache Current Size
     path:         "/statistics=jdbc"
     attribute:    PreparedStatementCacheCurrentSize
-    metric-family: TODO
+    metric-family: wildfly_datasource_jdbc_prepared_statement_cache_current_size
   - name: Prepared Statement Cache Delete Count
     path:         "/statistics=jdbc"
     attribute:    PreparedStatementCacheDeleteCount
-    metric-family: TODO
+    metric-family: wildfly_datasource_jdbc_prepared_statement_cache_delete_count
   - name: Prepared Statement Cache Hit Count
     path:         "/statistics=jdbc"
     attribute:    PreparedStatementCacheHitCount
-    metric-family: TODO
+    metric-family: wildfly_datasource_jdbc_prepared_statement_cache_hit_count
   - name: Prepared Statement Cache Miss Count
     path:         "/statistics=jdbc"
     attribute:    PreparedStatementCacheMissCount
-    metric-family: TODO
+    metric-family: wildfly_datasource_jdbc_prepared_statement_cache_miss_count
 - name: Datasource Pool Metrics
   metric-dmr:
   - name: Active Count
     path:         "/statistics=pool"
     attribute:    ActiveCount
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_active_count
   - name: Available Count
     path:         "/statistics=pool"
     attribute:    AvailableCount
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_available_count
   - name: Average Blocking Time
     path:         "/statistics=pool"
     attribute:    AverageBlockingTime
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_average_blocking_time
   - name: Average Creation Time
     path:         "/statistics=pool"
     attribute:    AverageCreationTime
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_average_creation_time
   - name: Average Get Time
     path:         "/statistics=pool"
     attribute:    AverageGetTime
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_average_get_time
   - name: Blocking Failure Count
     path:         "/statistics=pool"
     attribute:    BlockingFailureCount
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_blocking_failure_count
   - name: Created Count
     path:         "/statistics=pool"
     attribute:    CreatedCount
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_created_count
   - name: Destroyed Count
     path:         "/statistics=pool"
     attribute:    DestroyedCount
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_destroyed_count
   - name: Idle Count
     path:         "/statistics=pool"
     attribute:    IdleCount
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_idle_count
   - name: In Use Count
     path:         "/statistics=pool"
     attribute:    InUseCount
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_in_use_count
   - name: Max Creation Time
     path:         "/statistics=pool"
     attribute:    MaxCreationTime
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_max_creation_time
   - name: Max Get Time
     path:         "/statistics=pool"
     attribute:    MaxGetTime
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_max_get_time
   - name: Max Used Count
     path:         "/statistics=pool"
     attribute:    MaxUsedCount
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_max_used_count
   - name: Max Wait Count
     path:         "/statistics=pool"
     attribute:    MaxWaitCount
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_max_wait_count
   - name: Max Wait Time
     path:         "/statistics=pool"
     attribute:    MaxWaitTime
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_max_wait_time
   - name: Timed Out
     path:         "/statistics=pool"
     attribute:    TimedOut
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_timed_out
   - name: Total Blocking Time
     path:         "/statistics=pool"
     attribute:    TotalBlockingTime
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_total_blocking_time
   - name: Total Creation Time
     path:         "/statistics=pool"
     attribute:    TotalCreationTime
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_total_creation_time
   - name: Total Get Time
     path:         "/statistics=pool"
     attribute:    TotalGetTime
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_total_get_time
   - name: Wait Count
     path:         "/statistics=pool"
     attribute:    WaitCount
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_wait_count
 - name: Transactions Metrics
   metric-dmr:
   - name: Number of Aborted Transactions
     attribute:    number-of-aborted-transactions
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_transactions_aborted_transactions
   - name: Number of Application Rollbacks
     attribute:    number-of-application-rollbacks
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_transactions_application_rollbacks
   - name: Number of Committed Transactions
     attribute:    number-of-committed-transactions
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_transactions_committed_transactions
   - name: Number of Heuristics
     attribute:    number-of-heuristics
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_transactions_heuristics
   - name: Number of In-Flight Transactions
     attribute:    number-of-inflight-transactions
-    metric-family: TODO
+    metric-family: wildfly_transactions_inflight_transactions
   - name: Number of Nested Transactions
     attribute:    number-of-nested-transactions
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_transactions_nested_transactions
   - name: Number of Resource Rollbacks
     attribute:    number-of-resource-rollbacks
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_transactions_resource_rollbacks
   - name: Number of Timed Out Transactions
     attribute:    number-of-timed-out-transactions
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_transactions_timed_out_transactions
   - name: Number of Transactions
     attribute:    number-of-transactions
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_transactions_transactions
 - name: JMS Queue Metrics
   metric-dmr:
   - name: Consumer Count
     attribute:    consumer-count
-    metric-family: TODO
+    metric-family: wildfly_messaging_consumer_count
   - name: Delivering Count
     attribute:    delivering-count
-    metric-family: TODO
+    metric-family: wildfly_messaging_delivering_count
   - name: Message Count
     attribute:    message-count
-    metric-family: TODO
+    metric-family: wildfly_messaging_message_count
   - name: Messages Added
     attribute:    messages-added
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_messaging_messages_added
   - name: Scheduled Count
     attribute:    scheduled-count
-    metric-family: TODO
+    metric-family: wildfly_messaging_scheduled_count
 - name: JMS Topic Metrics
   metric-dmr:
   - name: Durable Message Count
     attribute:    durable-message-count
-    metric-family: TODO
+    metric-family: wildfly_messaging_durable_message_count
   - name: Durable Subscription Count
     attribute:    durable-subscription-count
-    metric-family: TODO
+    metric-family: wildfly_messaging_durable_subscription_count
   - name: Delivering Count
     attribute:    delivering-count
-    metric-family: TODO
+    metric-family: wildfly_messaging_delivering_count
   - name: Message Count
     attribute:    message-count
-    metric-family: TODO
+    metric-family: wildfly_messaging_message_count
   - name: Messages Added
     attribute:    messages-added
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_messaging_messages_added
   - name: Non-Durable Message Count
     attribute:    non-durable-message-count
-    metric-family: TODO
+    metric-family: wildfly_messaging_non_durable_message_count
   - name: Non-Durable Subscription Count
     attribute:    non-durable-subscription-count
-    metric-family: TODO
+    metric-family: wildfly_messaging_non_durable_subscription_count
   - name: Subscription Count
     attribute:    subscription-count
-    metric-family: TODO
+    metric-family: wildfly_messaging_subscription_count
 
 resource-type-set-dmr:
 - name: Standalone Environment
@@ -856,6 +930,8 @@ resource-type-set-dmr:
     - Domain WildFly Server
     metric-sets:
     - Undertow Metrics
+    metric-labels:
+      deployment: "%-"
   - name: SubDeployment
     resource-name-template: "%-"
     path: "/subdeployment=*"
@@ -863,6 +939,8 @@ resource-type-set-dmr:
     - Deployment
     metric-sets:
     - Undertow Metrics
+    metric-labels:
+      subdeployment: "%-"
 
 - name: Web Component
   resource-type-dmr:
@@ -874,6 +952,8 @@ resource-type-set-dmr:
     - SubDeployment
     metric-sets:
     - Servlet Metrics
+    metric-labels:
+      name: "%-"
 
 - name: EJB
   resource-type-dmr:
@@ -885,6 +965,8 @@ resource-type-set-dmr:
     - SubDeployment
     metric-sets:
     - Singleton EJB Metrics
+    metric-labels:
+      name: "%-"
   - name: Message Driven EJB
     resource-name-template: "%-"
     path: "/subsystem=ejb3/message-driven-bean=*"
@@ -893,6 +975,8 @@ resource-type-set-dmr:
     - SubDeployment
     metric-sets:
     - Message Driven EJB Metrics
+    metric-labels:
+      name: "%-"
   - name: Stateless Session EJB
     resource-name-template: "%-"
     path: "/subsystem=ejb3/stateless-session-bean=*"
@@ -901,6 +985,8 @@ resource-type-set-dmr:
     - SubDeployment
     metric-sets:
     - Stateless Session EJB Metrics
+    metric-labels:
+      name: "%-"
   - name: Stateful Session EJB
     resource-name-template: "%-"
     path: "/subsystem=ejb3/stateful-session-bean=*"
@@ -909,6 +995,8 @@ resource-type-set-dmr:
     - SubDeployment
     metric-sets:
     - Stateful Session EJB Metrics
+    metric-labels:
+      name: "%-"
 
 - name: Datasource
   resource-type-dmr:
@@ -921,6 +1009,8 @@ resource-type-set-dmr:
     metric-sets:
     - Datasource Pool Metrics
     - Datasource JDBC Metrics
+    metric-labels:
+      name: "%-"
     resource-config-dmr:
     - name: Connection URL
       attribute: connection-url
@@ -956,6 +1046,8 @@ resource-type-set-dmr:
     metric-sets:
     - Datasource Pool Metrics
     - Datasource JDBC Metrics
+    metric-labels:
+      name: "%-"
     resource-config-dmr:
     - name: Driver Name
       attribute: driver-name
@@ -1019,6 +1111,8 @@ resource-type-set-dmr:
     - Messaging Server
     metric-sets:
     - JMS Queue Metrics
+    metric-labels:
+      name: "%-"
   - name: JMS Topic
     resource-name-template: "%-"
     path: "/jms-topic=*"
@@ -1026,6 +1120,8 @@ resource-type-set-dmr:
     - Messaging Server
     metric-sets:
     - JMS Topic Metrics
+    metric-labels:
+      name: "%-"
 
 - name: Socket Binding Group
   resource-type-dmr:
@@ -1140,12 +1236,14 @@ metric-set-jmx:
     attribute:    HeapMemoryUsage#used
     metric-units: bytes
     metric-type:  gauge
-    metric-family: TODO
+    metric-family: jvm_memory_bytes_used
+    metric-labels:
+      area: heap
   - name: Aggregate GC Collection Time
     object-name:  "java.lang:type=GarbageCollector,name=*"
     attribute:    CollectionTime
-    metric-units: milliseconds
-    metric-family: TODO
+    metric-units: seconds
+    metric-family: jvm_gc_collection_seconds_sum
 - name: Memory Pool Metrics
   metric-jmx:
   - name: Initial
@@ -1157,17 +1255,17 @@ metric-set-jmx:
     attribute:    Usage#used
     metric-units: bytes
     metric-type:  gauge
-    metric-family: TODO
+    metric-family: jvm_memory_pool_bytes_used
   - name: Committed
     attribute:    Usage#committed
     metric-units: bytes
     metric-type:  gauge
-    metric-family: TODO
+    metric-family: jvm_memory_pool_bytes_committed
   - name: Max
     attribute:    Usage#max
     metric-units: bytes
     metric-type:  gauge
-    metric-family: TODO
+    metric-family: jvm_memory_pool_bytes_max
 
 resource-type-set-jmx:
 - name: Main
@@ -1340,6 +1438,8 @@ managed-servers:
     - Clustering
     wait-for:
     - name: /
+    metric-labels:
+      feed-id: "%FeedId"
 
   local-jmx:
     name: Local JMX
@@ -1351,6 +1451,8 @@ managed-servers:
     - For Integration Test
     wait-for:
     - name: java.lang:type=Runtime
+    metric-labels:
+      feed-id: "%FeedId"
 
   remote-dmr:
   - name: Local DMR
@@ -1373,6 +1475,8 @@ managed-servers:
     - Clustering
     wait-for:
     - name: /
+    metric-labels:
+      feed-id: "%FeedId"
 
 platform:
   enabled:      true

--- a/hawkular-javaagent-wildfly-feature-pack/src/main/resources/featurepack/content/standalone/configuration/hawkular-javaagent-config.yaml
+++ b/hawkular-javaagent-wildfly-feature-pack/src/main/resources/featurepack/content/standalone/configuration/hawkular-javaagent-config.yaml
@@ -50,397 +50,471 @@ metric-set-dmr:
     metric-type:  gauge
     path:         /core-service=platform-mbean/type=memory
     attribute:    heap-memory-usage#used
-    metric-family: TODO
+    metric-family: jvm_memory_bytes_used
+    metric-labels:
+      area: heap
   - name: Heap Committed
     metric-units: bytes
     metric-type:  gauge
     path:         /core-service=platform-mbean/type=memory
     attribute:    heap-memory-usage#committed
-    metric-family: TODO
+    metric-family: jvm_memory_bytes_committed
+    metric-labels:
+      area: heap
   - name: Heap Max
     metric-units: bytes
     metric-type:  gauge
     path:         /core-service=platform-mbean/type=memory
     attribute:    heap-memory-usage#max
-    metric-family: TODO
+    metric-family: jvm_memory_bytes_max
+    metric-labels:
+      area: heap
   - name: NonHeap Used
     metric-units: bytes
     path:         /core-service=platform-mbean/type=memory
     attribute:    non-heap-memory-usage#used
-    metric-family: TODO
+    metric-family: jvm_memory_bytes_used
+    metric-labels:
+      area: nonheap
   - name: NonHeap Committed
     metric-units: bytes
     path:         /core-service=platform-mbean/type=memory
     attribute:    non-heap-memory-usage#committed
-    metric-family: TODO
+    metric-family: jvm_memory_bytes_committed
+    metric-labels:
+      area: nonheap
+  - name: NonHeap Max
+    metric-units: bytes
+    path:         /core-service=platform-mbean/type=memory
+    attribute:    non-heap-memory-usage#max
+    metric-family: jvm_memory_bytes_max
+    metric-labels:
+      area: nonheap
   - name: Accumulated GC Duration
-    metric-units: milliseconds
+    metric-units: seconds
     metric-type:  counter
     path:         "/core-service=platform-mbean/type=garbage-collector/name=*"
     attribute:    collection-time
-    metric-family: TODO
+    metric-family: jvm_gc_collection_seconds_sum
+    # no metric-labels because we want to aggregate across all of them
 - name: WildFly Threading Metrics
   metric-dmr:
   - name: Thread Count
     metric-type:  gauge
     path:         /core-service=platform-mbean/type=threading
     attribute:    thread-count
-    metric-family: TODO
+    metric-family: jvm_threads_current
 - name: WildFly Aggregated Web Metrics
   metric-dmr:
   - name: Aggregated Active Web Sessions
     path:       "/deployment=*/subsystem=undertow"
     attribute:  active-sessions
-    metric-family: TODO
+    metric-family: wildfly_deployment_active_sessions
   - name: Aggregated Max Active Web Sessions
     path:       "/deployment=*/subsystem=undertow"
     attribute:  max-active-sessions
-    metric-family: TODO
+    metric-family: wildfly_deployment_max_active_sessions
   - name: Aggregated Expired Web Sessions
     path:       "/deployment=*/subsystem=undertow"
     attribute:  expired-sessions
-    metric-family: TODO
+    metric-family: wildfly_deployment_expired_sessions
   - name: Aggregated Rejected Web Sessions
     path:       "/deployment=*/subsystem=undertow"
     attribute:  rejected-sessions
-    metric-family: TODO
+    metric-family: wildfly_deployment_rejected_sessions
   - name: Aggregated Servlet Request Time
     path:       "/deployment=*/subsystem=undertow/servlet=*"
     attribute:  total-request-time
-    metric-family: TODO
+    metric-family: wildfly_servlet_total_request_time
   - name: Aggregated Servlet Request Count
     path:       "/deployment=*/subsystem=undertow/servlet=*"
     attribute:  request-count
-    metric-family: TODO
+    metric-family: wildfly_servlet_request_count
 - name: Undertow Metrics
   metric-dmr:
   - name: Active Sessions
     path:       "/subsystem=undertow"
     attribute:  active-sessions
-    metric-family: TODO
+    metric-family: wildfly_deployment_active_sessions
   - name: Sessions Created
     path:       "/subsystem=undertow"
     attribute:  sessions-created
     metric-type: counter
-    metric-family: TODO
+    metric-family: wildfly_deployment_sessions_created
   - name: Expired Sessions
     path:       "/subsystem=undertow"
     attribute:  expired-sessions
     metric-type: counter
-    metric-family: TODO
+    metric-family: wildfly_deployment_expired_sessions
   - name: Rejected Sessions
     path:       "/subsystem=undertow"
     attribute:  rejected-sessions
     metric-type: counter
-    metric-family: TODO
+    metric-family: wildfly_deployment_rejected_sessions
   - name: Max Active Sessions
     path:       "/subsystem=undertow"
     attribute:  max-active-sessions
-    metric-family: TODO
+    metric-family: wildfly_deployment_max_active_sessions
 - name: Servlet Metrics
   metric-dmr:
   - name: Max Request Time
     attribute:    max-request-time
     metric-units: milliseconds
-    metric-family: TODO
+    metric-family: wildfly_servlet_max_request_time
   - name: Min Request Time
     attribute:    min-request-time
     metric-units: milliseconds
-    metric-family: TODO
+    metric-family: wildfly_servlet_min_request_time
   - name: Total Request Time
     attribute:    total-request-time
     metric-units: milliseconds
-    metric-family: TODO
+    metric-family: wildfly_servlet_total_request_time
   - name: Request Count
     attribute:    request-count
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_servlet_request_count
 - name: Singleton EJB Metrics
   metric-dmr:
   - name: Execution Time
     attribute:    execution-time
-    metric-family: TODO
+    metric-family: wildfly_ejb_execution_time
+    metric-labels:
+      type: singleton
   - name: Invocations
     attribute:    invocations
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_ejb_invocations
+    metric-labels:
+      type: singleton
   - name: Peak Concurrent Invocations
     attribute:    peak-concurrent-invocations
-    metric-family: TODO
+    metric-family: wildfly_ejb_peak_concurrent_invocations
+    metric-labels:
+      type: singleton
   - name: Wait Time
     attribute:    wait-time
-    metric-family: TODO
+    metric-family: wildfly_ejb_wait_time
+    metric-labels:
+      type: singleton
 - name: Message Driven EJB Metrics
   metric-dmr:
   - name: Execution Time
     attribute:    execution-time
-    metric-family: TODO
+    metric-family: wildfly_ejb_execution_time
+    metric-labels:
+      type: message-driven
   - name: Invocations
     attribute:    invocations
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_ejb_invocations
+    metric-labels:
+      type: message-driven
   - name: Peak Concurrent Invocations
     attribute:    peak-concurrent-invocations
-    metric-family: TODO
+    metric-family: wildfly_ejb_peak_concurrent_invocations
+    metric-labels:
+      type: message-driven
   - name: Wait Time
     attribute:    wait-time
-    metric-family: TODO
+    metric-family: wildfly_ejb_wait_time
+    metric-labels:
+      type: message-driven
   - name: Pool Available Count
     attribute:    pool-available-count
-    metric-family: TODO
+    metric-family: wildfly_ejb_pool_available_count
+    metric-labels:
+      type: message-driven
   - name: Pool Create Count
     attribute:    pool-create-count
-    metric-family: TODO
+    metric-family: wildfly_ejb_pool_create_count
+    metric-labels:
+      type: message-driven
   - name: Pool Current Size
     attribute:    pool-current-size
-    metric-family: TODO
+    metric-family: wildfly_ejb_pool_current_size
+    metric-labels:
+      type: message-driven
   - name: Pool Max Size
     attribute:    pool-max-size
-    metric-family: TODO
+    metric-family: wildfly_ejb_pool_max_size
+    metric-labels:
+      type: message-driven
   - name: Pool Remove Count
     attribute:    pool-remove-count
-    metric-family: TODO
+    metric-family: wildfly_ejb_pool_remove_count
+    metric-labels:
+      type: message-driven
 - name: Stateless Session EJB Metrics
   metric-dmr:
   - name: Execution Time
     attribute:    execution-time
-    metric-family: TODO
+    metric-family: wildfly_ejb_execution_time
+    metric-labels:
+      type: stateless-session
   - name: Invocations
     attribute:    invocations
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_ejb_invocations
+    metric-labels:
+      type: stateless-session
   - name: Peak Concurrent Invocations
     attribute:    peak-concurrent-invocations
-    metric-family: TODO
+    metric-family: wildfly_ejb_peak_concurrent_invocations
+    metric-labels:
+      type: stateless-session
   - name: Wait Time
     attribute:    wait-time
-    metric-family: TODO
+    metric-family: wildfly_ejb_wait_time
+    metric-labels:
+      type: stateless-session
   - name: Pool Available Count
     attribute:    pool-available-count
-    metric-family: TODO
+    metric-family: wildfly_ejb_pool_available_count
+    metric-labels:
+      type: stateless-session
   - name: Pool Create Count
     attribute:    pool-create-count
-    metric-family: TODO
+    metric-family: wildfly_ejb_pool_create_count
+    metric-labels:
+      type: stateless-session
   - name: Pool Current Size
     attribute:    pool-current-size
-    metric-family: TODO
+    metric-family: wildfly_ejb_pool_current_size
+    metric-labels:
+      type: stateless-session
   - name: Pool Max Size
     attribute:    pool-max-size
-    metric-family: TODO
+    metric-family: wildfly_ejb_pool_max_size
+    metric-labels:
+      type: stateless-session
   - name: Pool Remove Count
     attribute:    pool-remove-count
-    metric-family: TODO
+    metric-family: wildfly_ejb_pool_remove_count
+    metric-labels:
+      type: stateless-session
 - name: Stateful Session EJB Metrics
   metric-dmr:
   - name: Execution Time
     attribute:    execution-time
-    metric-family: TODO
+    metric-family: wildfly_ejb_execution_time
+    metric-labels:
+      type: stateful-session
   - name: Invocations
     attribute:    invocations
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_ejb_invocations
+    metric-labels:
+      type: stateful-session
   - name: Peak Concurrent Invocations
     attribute:    peak-concurrent-invocations
-    metric-family: TODO
+    metric-family: wildfly_ejb_peak_concurrent_invocations
+    metric-labels:
+      type: stateful-session
   - name: Wait Time
     attribute:    wait-time
-    metric-family: TODO
+    metric-family: wildfly_ejb_wait_time
+    metric-labels:
+      type: stateful-session
   - name: Cache Size
     attribute:    cache-size
     metric-family: TODO
+    metric-labels:
+      type: stateful-session
   - name: Total Size
     attribute:    total-size
     metric-family: TODO
+    metric-labels:
+      type: stateful-session
 - name: Datasource JDBC Metrics
   metric-dmr:
   - name: Prepared Statement Cache Access Count
     path:         "/statistics=jdbc"
     attribute:    PreparedStatementCacheAccessCount
-    metric-family: TODO
+    metric-family: wildfly_datasource_jdbc_prepared_statement_cache_access_count
   - name: Prepared Statement Cache Add Count
     path:         "/statistics=jdbc"
     attribute:    PreparedStatementCacheAddCount
-    metric-family: TODO
+    metric-family: wildfly_datasource_jdbc_prepared_statement_cache_add_count
   - name: Prepared Statement Cache Current Size
     path:         "/statistics=jdbc"
     attribute:    PreparedStatementCacheCurrentSize
-    metric-family: TODO
+    metric-family: wildfly_datasource_jdbc_prepared_statement_cache_current_size
   - name: Prepared Statement Cache Delete Count
     path:         "/statistics=jdbc"
     attribute:    PreparedStatementCacheDeleteCount
-    metric-family: TODO
+    metric-family: wildfly_datasource_jdbc_prepared_statement_cache_delete_count
   - name: Prepared Statement Cache Hit Count
     path:         "/statistics=jdbc"
     attribute:    PreparedStatementCacheHitCount
-    metric-family: TODO
+    metric-family: wildfly_datasource_jdbc_prepared_statement_cache_hit_count
   - name: Prepared Statement Cache Miss Count
     path:         "/statistics=jdbc"
     attribute:    PreparedStatementCacheMissCount
-    metric-family: TODO
+    metric-family: wildfly_datasource_jdbc_prepared_statement_cache_miss_count
 - name: Datasource Pool Metrics
   metric-dmr:
   - name: Active Count
     path:         "/statistics=pool"
     attribute:    ActiveCount
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_active_count
   - name: Available Count
     path:         "/statistics=pool"
     attribute:    AvailableCount
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_available_count
   - name: Average Blocking Time
     path:         "/statistics=pool"
     attribute:    AverageBlockingTime
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_average_blocking_time
   - name: Average Creation Time
     path:         "/statistics=pool"
     attribute:    AverageCreationTime
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_average_creation_time
   - name: Average Get Time
     path:         "/statistics=pool"
     attribute:    AverageGetTime
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_average_get_time
   - name: Blocking Failure Count
     path:         "/statistics=pool"
     attribute:    BlockingFailureCount
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_blocking_failure_count
   - name: Created Count
     path:         "/statistics=pool"
     attribute:    CreatedCount
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_created_count
   - name: Destroyed Count
     path:         "/statistics=pool"
     attribute:    DestroyedCount
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_destroyed_count
   - name: Idle Count
     path:         "/statistics=pool"
     attribute:    IdleCount
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_idle_count
   - name: In Use Count
     path:         "/statistics=pool"
     attribute:    InUseCount
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_in_use_count
   - name: Max Creation Time
     path:         "/statistics=pool"
     attribute:    MaxCreationTime
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_max_creation_time
   - name: Max Get Time
     path:         "/statistics=pool"
     attribute:    MaxGetTime
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_max_get_time
   - name: Max Used Count
     path:         "/statistics=pool"
     attribute:    MaxUsedCount
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_max_used_count
   - name: Max Wait Count
     path:         "/statistics=pool"
     attribute:    MaxWaitCount
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_max_wait_count
   - name: Max Wait Time
     path:         "/statistics=pool"
     attribute:    MaxWaitTime
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_max_wait_time
   - name: Timed Out
     path:         "/statistics=pool"
     attribute:    TimedOut
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_timed_out
   - name: Total Blocking Time
     path:         "/statistics=pool"
     attribute:    TotalBlockingTime
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_total_blocking_time
   - name: Total Creation Time
     path:         "/statistics=pool"
     attribute:    TotalCreationTime
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_total_creation_time
   - name: Total Get Time
     path:         "/statistics=pool"
     attribute:    TotalGetTime
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_total_get_time
   - name: Wait Count
     path:         "/statistics=pool"
     attribute:    WaitCount
-    metric-family: TODO
+    metric-family: wildfly_datasorce_pool_wait_count
 - name: Transactions Metrics
   metric-dmr:
   - name: Number of Aborted Transactions
     attribute:    number-of-aborted-transactions
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_transactions_aborted_transactions
   - name: Number of Application Rollbacks
     attribute:    number-of-application-rollbacks
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_transactions_application_rollbacks
   - name: Number of Committed Transactions
     attribute:    number-of-committed-transactions
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_transactions_committed_transactions
   - name: Number of Heuristics
     attribute:    number-of-heuristics
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_transactions_heuristics
   - name: Number of In-Flight Transactions
     attribute:    number-of-inflight-transactions
-    metric-family: TODO
+    metric-family: wildfly_transactions_inflight_transactions
   - name: Number of Nested Transactions
     attribute:    number-of-nested-transactions
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_transactions_nested_transactions
   - name: Number of Resource Rollbacks
     attribute:    number-of-resource-rollbacks
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_transactions_resource_rollbacks
   - name: Number of Timed Out Transactions
     attribute:    number-of-timed-out-transactions
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_transactions_timed_out_transactions
   - name: Number of Transactions
     attribute:    number-of-transactions
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_transactions_transactions
 - name: JMS Queue Metrics
   metric-dmr:
   - name: Consumer Count
     attribute:    consumer-count
-    metric-family: TODO
+    metric-family: wildfly_messaging_consumer_count
   - name: Delivering Count
     attribute:    delivering-count
-    metric-family: TODO
+    metric-family: wildfly_messaging_delivering_count
   - name: Message Count
     attribute:    message-count
-    metric-family: TODO
+    metric-family: wildfly_messaging_message_count
   - name: Messages Added
     attribute:    messages-added
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_messaging_messages_added
   - name: Scheduled Count
     attribute:    scheduled-count
-    metric-family: TODO
+    metric-family: wildfly_messaging_scheduled_count
 - name: JMS Topic Metrics
   metric-dmr:
   - name: Durable Message Count
     attribute:    durable-message-count
-    metric-family: TODO
+    metric-family: wildfly_messaging_durable_message_count
   - name: Durable Subscription Count
     attribute:    durable-subscription-count
-    metric-family: TODO
+    metric-family: wildfly_messaging_durable_subscription_count
   - name: Delivering Count
     attribute:    delivering-count
-    metric-family: TODO
+    metric-family: wildfly_messaging_delivering_count
   - name: Message Count
     attribute:    message-count
-    metric-family: TODO
+    metric-family: wildfly_messaging_message_count
   - name: Messages Added
     attribute:    messages-added
     metric-type:  counter
-    metric-family: TODO
+    metric-family: wildfly_messaging_messages_added
   - name: Non-Durable Message Count
     attribute:    non-durable-message-count
-    metric-family: TODO
+    metric-family: wildfly_messaging_non_durable_message_count
   - name: Non-Durable Subscription Count
     attribute:    non-durable-subscription-count
-    metric-family: TODO
+    metric-family: wildfly_messaging_non_durable_subscription_count
   - name: Subscription Count
     attribute:    subscription-count
-    metric-family: TODO
+    metric-family: wildfly_messaging_subscription_count
 
 resource-type-set-dmr:
 - name: Standalone Environment
@@ -856,6 +930,8 @@ resource-type-set-dmr:
     - Domain WildFly Server
     metric-sets:
     - Undertow Metrics
+    metric-labels:
+      deployment: "%-"
   - name: SubDeployment
     resource-name-template: "%-"
     path: "/subdeployment=*"
@@ -863,6 +939,8 @@ resource-type-set-dmr:
     - Deployment
     metric-sets:
     - Undertow Metrics
+    metric-labels:
+      subdeployment: "%-"
 
 - name: Web Component
   resource-type-dmr:
@@ -874,6 +952,8 @@ resource-type-set-dmr:
     - SubDeployment
     metric-sets:
     - Servlet Metrics
+    metric-labels:
+      name: "%-"
 
 - name: EJB
   resource-type-dmr:
@@ -885,6 +965,8 @@ resource-type-set-dmr:
     - SubDeployment
     metric-sets:
     - Singleton EJB Metrics
+    metric-labels:
+      name: "%-"
   - name: Message Driven EJB
     resource-name-template: "%-"
     path: "/subsystem=ejb3/message-driven-bean=*"
@@ -893,6 +975,8 @@ resource-type-set-dmr:
     - SubDeployment
     metric-sets:
     - Message Driven EJB Metrics
+    metric-labels:
+      name: "%-"
   - name: Stateless Session EJB
     resource-name-template: "%-"
     path: "/subsystem=ejb3/stateless-session-bean=*"
@@ -901,6 +985,8 @@ resource-type-set-dmr:
     - SubDeployment
     metric-sets:
     - Stateless Session EJB Metrics
+    metric-labels:
+      name: "%-"
   - name: Stateful Session EJB
     resource-name-template: "%-"
     path: "/subsystem=ejb3/stateful-session-bean=*"
@@ -909,6 +995,8 @@ resource-type-set-dmr:
     - SubDeployment
     metric-sets:
     - Stateful Session EJB Metrics
+    metric-labels:
+      name: "%-"
 
 - name: Datasource
   resource-type-dmr:
@@ -921,6 +1009,8 @@ resource-type-set-dmr:
     metric-sets:
     - Datasource Pool Metrics
     - Datasource JDBC Metrics
+    metric-labels:
+      name: "%-"
     resource-config-dmr:
     - name: Connection URL
       attribute: connection-url
@@ -956,6 +1046,8 @@ resource-type-set-dmr:
     metric-sets:
     - Datasource Pool Metrics
     - Datasource JDBC Metrics
+    metric-labels:
+      name: "%-"
     resource-config-dmr:
     - name: Driver Name
       attribute: driver-name
@@ -1019,6 +1111,8 @@ resource-type-set-dmr:
     - Messaging Server
     metric-sets:
     - JMS Queue Metrics
+    metric-labels:
+      name: "%-"
   - name: JMS Topic
     resource-name-template: "%-"
     path: "/jms-topic=*"
@@ -1026,6 +1120,8 @@ resource-type-set-dmr:
     - Messaging Server
     metric-sets:
     - JMS Topic Metrics
+    metric-labels:
+      name: "%-"
 
 - name: Socket Binding Group
   resource-type-dmr:
@@ -1140,12 +1236,14 @@ metric-set-jmx:
     attribute:    HeapMemoryUsage#used
     metric-units: bytes
     metric-type:  gauge
-    metric-family: TODO
+    metric-family: jvm_memory_bytes_used
+    metric-labels:
+      area: heap
   - name: Aggregate GC Collection Time
     object-name:  "java.lang:type=GarbageCollector,name=*"
     attribute:    CollectionTime
-    metric-units: milliseconds
-    metric-family: TODO
+    metric-units: seconds
+    metric-family: jvm_gc_collection_seconds_sum
 - name: Memory Pool Metrics
   metric-jmx:
   - name: Initial
@@ -1157,17 +1255,17 @@ metric-set-jmx:
     attribute:    Usage#used
     metric-units: bytes
     metric-type:  gauge
-    metric-family: TODO
+    metric-family: jvm_memory_pool_bytes_used
   - name: Committed
     attribute:    Usage#committed
     metric-units: bytes
     metric-type:  gauge
-    metric-family: TODO
+    metric-family: jvm_memory_pool_bytes_committed
   - name: Max
     attribute:    Usage#max
     metric-units: bytes
     metric-type:  gauge
-    metric-family: TODO
+    metric-family: jvm_memory_pool_bytes_max
 
 resource-type-set-jmx:
 - name: Main
@@ -1237,6 +1335,8 @@ managed-servers:
     - Clustering
     wait-for:
     - name: /
+    metric-labels:
+      feed-id: "%FeedId"
 
   local-jmx:
     name: Local JMX
@@ -1247,6 +1347,8 @@ managed-servers:
     - Hawkular
     wait-for:
     - name: java.lang:type=Runtime
+    metric-labels:
+      feed-id: "%FeedId"
 
   remote-dmr:
   - name: Remote DMR
@@ -1269,6 +1371,8 @@ managed-servers:
     - Clustering
     wait-for:
     - name: /
+    metric-labels:
+      feed-id: "%FeedId"
 
   remote-jmx:
   - name: Remote Jolokia Server
@@ -1279,6 +1383,8 @@ managed-servers:
     - Memory Pool
     wait-for:
     - name: java.lang:type=Runtime
+    metric-labels:
+      feed-id: "%FeedId"
 
 platform:
   enabled:      true

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <version.io.prometheus.simpleclient.hotspot>0.1.0</version.io.prometheus.simpleclient.hotspot>
     <version.io.prometheus.simpleclient.httpserver>0.1.0</version.io.prometheus.simpleclient.httpserver>
     <version.org.hamcrest>1.3</version.org.hamcrest>
-    <version.org.hawkular.commons>1.0.0.Final-SRC-revision-055e4393b2a1944cda2d97955ba7771bb61041a6</version.org.hawkular.commons>
+    <version.org.hawkular.commons>1.0.0.Final-SNAPSHOT</version.org.hawkular.commons>
     <version.org.jboss.aesh>0.66.7</version.org.jboss.aesh>
     <version.org.jgrapht>0.9.1</version.org.jgrapht>
     <version.org.jolokia>1.3.5</version.org.jolokia>


### PR DESCRIPTION
This looks to be working and can be merged.
We now need to add these metric family/metric labels to the inventory Metrics domain object so they can be stored as first class fields and not as these generic properties.