### PR TITLE
HAWKULAR-1318: Fix reference to server url

### DIFF
--- a/docker-dist/Dockerfile
+++ b/docker-dist/Dockerfile
@@ -39,7 +39,7 @@ RUN printf 'HOST_CONTROLLER_JAVA_OPTS="$HOST_CONTROLLER_JAVA_OPTS' >> $JBOSS_HOM
 RUN printf ' -Djboss.modules.system.pkgs=org.jboss.byteman,org.jboss.logmanager -Djava.util.logging.manager=org.jboss.logmanager.LogManager -javaagent:$JBOSS_HOME/bin/hawkular-javaagent.jar=config=/opt/hawkular/configuration/hawkular-javaagent-config.yaml,delay=10' \
 | tee -a $JBOSS_HOME/bin/standalone.conf $JBOSS_HOME/bin/domain.conf  > /dev/null
 RUN printf ' -Djboss.host.server-excluded-properties=jboss.modules.system.pkgs,java.util.logging.manager' >> $JBOSS_HOME/bin/domain.conf
-RUN printf ' -Dhawkular.rest.url=${HAWKULAR_URL} -Dhawkular.agent.immutable=${HAWKULAR_IMMUTABLE} -Dhawkular.agent.in-container=${HAWKULAR_IMMUTABLE}"\n' \
+RUN printf ' -Dhawkular.rest.host=${HAWKULAR_URL} -Dhawkular.agent.immutable=${HAWKULAR_IMMUTABLE} -Dhawkular.agent.in-container=${HAWKULAR_IMMUTABLE}"\n' \
 | tee -a $JBOSS_HOME/bin/standalone.conf $JBOSS_HOME/bin/domain.conf  > /dev/null
 
 

--- a/docker-dist/README.adoc
+++ b/docker-dist/README.adoc
@@ -62,7 +62,7 @@ oc create secret generic hawkular-javaagent-example --from-env-file=hawkular-env
 Once you have create your secret, you can then deploy the 'hawkular-javaagent-example.yaml' deployment
 
 ```bash
-oc create hawkular-javaagent-example.yaml
+oc create -f hawkular-javaagent-example.yaml
 ```
 
 This should create a deployment in your current project with a single replica.

--- a/docker-dist/hawkular-javaagent-example.yaml
+++ b/docker-dist/hawkular-javaagent-example.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: hawkular-javaagent-example
-        image: hawkular/wildfly-hawkular-javaagent:hawkular-1259
+        image: hawkular/wildfly-hawkular-javaagent:latest
         ports:
         - containerPort: 8080
         env:

--- a/docker-dist/src/main/resources/run_hawkular_javaagent.sh
+++ b/docker-dist/src/main/resources/run_hawkular_javaagent.sh
@@ -29,7 +29,7 @@ import_hawkular_services_public_key() {
 }
 
 run_hawkular_agent() {
-    ${JBOSS_HOME}/bin/${HAWKULAR_MODE}.sh -b 0.0.0.0
+    exec ${JBOSS_HOME}/bin/${HAWKULAR_MODE}.sh -b 0.0.0.0
 }
 
 main() {


### PR DESCRIPTION
Fixes an issue where we cannot pass to the agent the correct Hawkular Services URL.

Also fixes a typo, switches to using the 'latest' docker image in our OpenShift templates, and updates to use 'exec' when running the server so that it can be more cleanly stopped.