### PR TITLE
add metrics endpoint to agent config

### DIFF
--- a/eap6-support/hawkular-javaagent-wildfly-feature-pack-eap6/src/main/resources/featurepack/content/standalone/configuration/hawkular-javaagent-config.yaml
+++ b/eap6-support/hawkular-javaagent-wildfly-feature-pack-eap6/src/main/resources/featurepack/content/standalone/configuration/hawkular-javaagent-config.yaml
@@ -1175,6 +1175,8 @@ resource-type-set-jmx:
       attribute: Immutable
     - name: In Container
       attribute: InContainer
+    - name: Metrics Endpoint
+      attribute: MetricsEndpoint
     operation-jmx:
     - name: Start
       internal-name: start

--- a/hawkular-javaagent-itest-parent/hawkular-javaagent-all-itests/hawkular-javaagent-cmdgw-itest/src/test/resources/hawkular-javaagent-itest-config.yaml
+++ b/hawkular-javaagent-itest-parent/hawkular-javaagent-all-itests/hawkular-javaagent-cmdgw-itest/src/test/resources/hawkular-javaagent-itest-config.yaml
@@ -1303,6 +1303,8 @@ resource-type-set-jmx:
       attribute: Immutable
     - name: In Container
       attribute: InContainer
+    - name: Metrics Endpoint
+      attribute: MetricsEndpoint
     operation-jmx:
     - name: Start
       internal-name: start

--- a/hawkular-javaagent-itest-parent/hawkular-javaagent-all-itests/hawkular-javaagent-domain-itest/src/test/resources/hawkular-javaagent-itest-config.yaml
+++ b/hawkular-javaagent-itest-parent/hawkular-javaagent-all-itests/hawkular-javaagent-domain-itest/src/test/resources/hawkular-javaagent-itest-config.yaml
@@ -1303,6 +1303,8 @@ resource-type-set-jmx:
       attribute: Immutable
     - name: In Container
       attribute: InContainer
+    - name: Metrics Endpoint
+      attribute: MetricsEndpoint
     operation-jmx:
     - name: Start
       internal-name: start

--- a/hawkular-javaagent-wildfly-feature-pack/src/main/resources/featurepack/content/standalone/configuration/hawkular-javaagent-config.yaml
+++ b/hawkular-javaagent-wildfly-feature-pack/src/main/resources/featurepack/content/standalone/configuration/hawkular-javaagent-config.yaml
@@ -1303,6 +1303,8 @@ resource-type-set-jmx:
       attribute: Immutable
     - name: In Container
       attribute: InContainer
+    - name: Metrics Endpoint
+      attribute: MetricsEndpoint
     operation-jmx:
     - name: Start
       internal-name: start

--- a/hawkular-javaagent/src/main/java/org/hawkular/agent/javaagent/JavaAgentEngine.java
+++ b/hawkular-javaagent/src/main/java/org/hawkular/agent/javaagent/JavaAgentEngine.java
@@ -48,6 +48,7 @@ import org.hawkular.agent.javaagent.log.JavaAgentLoggers;
 import org.hawkular.agent.javaagent.log.MsgLogger;
 import org.hawkular.agent.monitor.cmd.Command;
 import org.hawkular.agent.monitor.config.AgentCoreEngineConfiguration;
+import org.hawkular.agent.monitor.config.AgentCoreEngineConfiguration.MetricsExporterConfiguration;
 import org.hawkular.agent.monitor.protocol.dmr.ModelControllerClientFactory;
 import org.hawkular.agent.monitor.service.AgentCoreEngine;
 import org.hawkular.agent.monitor.service.ServiceStatus;
@@ -218,6 +219,12 @@ public class JavaAgentEngine extends AgentCoreEngine implements JavaAgentMXBean 
     @Override
     public boolean getInContainer() {
         return getConfiguration().getGlobalConfiguration().isInContainer();
+    }
+
+    @Override
+    public String getMetricsEndpoint() {
+        MetricsExporterConfiguration mec = getConfiguration().getMetricsExporterConfiguration();
+        return String.format("%s:%d", mec.getHost(), mec.getPort());
     }
 
     @Override

--- a/hawkular-javaagent/src/main/java/org/hawkular/agent/javaagent/JavaAgentMXBean.java
+++ b/hawkular-javaagent/src/main/java/org/hawkular/agent/javaagent/JavaAgentMXBean.java
@@ -27,6 +27,8 @@ public interface JavaAgentMXBean {
 
     boolean getInContainer();
 
+    String getMetricsEndpoint();
+
     // JMX Operations
     void start();
 

--- a/hawkular-javaagent/src/test/resources/real-config-jmx.yaml
+++ b/hawkular-javaagent/src/test/resources/real-config-jmx.yaml
@@ -108,6 +108,8 @@ resource-type-set-jmx:
       attribute: Immutable
     - name: In Container
       attribute: InContainer
+    - name: Metrics Endpoint
+      attribute: MetricsEndpoint
     operation-jmx:
     - name: Start
       internal-name: start


### PR DESCRIPTION
The resource config properties on agent resource now has a new "Metrics Endpoint" value so you can figure out where to scrape the metrics.

```
{
  "id": "mazzlap~Local JMX~org.hawkular:type=hawkular-javaagent",
  "name": "Hawkular Java Agent",
  "feedId": "mazzlap",
  "type": {
    "id": "Hawkular Java Agent",
    ...
    "properties": {}
  },
...
  "config": {
    "Immutable": "false",
    "Metrics Endpoint": "127.0.0.1:9779",   <-- THE NEW CONFIG
    "In Container": "false"
  }
}
```