### PR TITLE
[HAWKULAR-1316] Added info on docs about oc 3.7 command

### DIFF
--- a/docker-dist/README.adoc
+++ b/docker-dist/README.adoc
@@ -95,7 +95,7 @@ docker run --env-file hawkular-env-file -v /opt/hawkular/hawkular-services-publi
 
 If running in OpenShift or Kubernetes you will need to pass to the pod a secret which contains the ca certificate.
 
-For instance, if the public CA certificate used to sign the Hawkular Services server is located at /opt/hawkular/hawkular-services-public.pem then you will need to run the following command before deploying your pod:
+For instance, if the public CA certificate used to sign the Hawkular Services server is located at /opt/hawkular/hawkular-services-public.pem then you will need to run the following command (Available on https://github.com/openshift/origin/releases/[oc 3.7]) before deploying your pod:
 
 ```bash
 oc create secret generic hawkular-javaagent-example-ca --from-file=hawkular-services-ca.crt=/opt/hawkular/hawkular-services-public.pem


### PR DESCRIPTION
I could not use the the command to generate secrets (` oc create secret generic hawkular-javaagent-example-ca --from-file=hawkular-services-ca.crt=/opt/hawkular/hawkular-services-public.pem`) because it is specific from oc 3.7+. 

I think it should be good to advise the users to have that version to use the command