### PR TITLE
adds a "version" JMX attribute to the agent mbean

### DIFF
--- a/hawkular-javaagent/src/main/java/org/hawkular/agent/javaagent/JavaAgentEngine.java
+++ b/hawkular-javaagent/src/main/java/org/hawkular/agent/javaagent/JavaAgentEngine.java
@@ -52,6 +52,7 @@ import org.hawkular.agent.monitor.config.AgentCoreEngineConfiguration.MetricsExp
 import org.hawkular.agent.monitor.protocol.dmr.ModelControllerClientFactory;
 import org.hawkular.agent.monitor.service.AgentCoreEngine;
 import org.hawkular.agent.monitor.service.ServiceStatus;
+import org.hawkular.agent.monitor.service.Version;
 import org.hawkular.bus.common.BasicMessage;
 
 /**
@@ -210,6 +211,11 @@ public class JavaAgentEngine extends AgentCoreEngine implements JavaAgentMXBean 
     }
 
     // JMX Interface
+
+    @Override
+    public String getVersion() {
+        return Version.getVersionString();
+    }
 
     @Override
     public boolean getImmutable() {

--- a/hawkular-javaagent/src/main/java/org/hawkular/agent/javaagent/JavaAgentMXBean.java
+++ b/hawkular-javaagent/src/main/java/org/hawkular/agent/javaagent/JavaAgentMXBean.java
@@ -23,6 +23,8 @@ public interface JavaAgentMXBean {
 
     // JMX Attributes
 
+    String getVersion();
+
     boolean getImmutable();
 
     boolean getInContainer();


### PR DESCRIPTION
We will need this in the future so we can collect it as a resource property later.