### PR TITLE
clean up yaml

### DIFF
--- a/eap6-support/hawkular-javaagent-wildfly-feature-pack-eap6/src/main/resources/featurepack/content/standalone/configuration/hawkular-javaagent-config.yaml
+++ b/eap6-support/hawkular-javaagent-wildfly-feature-pack-eap6/src/main/resources/featurepack/content/standalone/configuration/hawkular-javaagent-config.yaml
@@ -31,15 +31,15 @@ metrics-exporter:
   config-file: EAP6
 
 diagnostics:
-  enabled:    true
-  interval:   1
+  enabled: true
+  interval: 1
   time-units: minutes
 
 storage-adapter:
-  feed-id:   "${hawkular.rest.feedId:autogenerate}"
-  url:       "${hawkular.rest.url:http://hawkular-server:8080}"
-  username:  "${env.HAWKULAR_USER}"
-  password:  "${env.HAWKULAR_PASSWORD}"
+  feed-id: "${hawkular.rest.feedId:autogenerate}"
+  url: "${hawkular.rest.url:http://hawkular-server:8080}"
+  username: "${env.HAWKULAR_USER}"
+  password: "${env.HAWKULAR_PASSWORD}"
 
 # MANAGED SERVERS
 
@@ -117,5 +117,5 @@ managed-servers:
       feed_id: "%FeedId"
 
 platform:
-  enabled:      true
-  #machine-id:   my-machine-id-here
+  enabled: true
+  #machine-id: my-machine-id-here

--- a/hawkular-javaagent-itest-parent/hawkular-javaagent-all-itests/hawkular-javaagent-cmdgw-itest/src/test/resources/hawkular-javaagent-itest-config.yaml
+++ b/hawkular-javaagent-itest-parent/hawkular-javaagent-all-itests/hawkular-javaagent-cmdgw-itest/src/test/resources/hawkular-javaagent-itest-config.yaml
@@ -31,15 +31,15 @@ metrics-exporter:
   config-file: WF10
 
 diagnostics:
-  enabled:    true
-  interval:   1
+  enabled: true
+  interval: 1
   time-units: minutes
 
 storage-adapter:
-  feed-id:   "${hawkular.rest.feedId:autogenerate}"
-  url:       "${hawkular.rest.url:http://hawkular-server:8080}"
-  username:  "${env.HAWKULAR_USER}"
-  password:  "${env.HAWKULAR_PASSWORD}"
+  feed-id: "${hawkular.rest.feedId:autogenerate}"
+  url: "${hawkular.rest.url:http://hawkular-server:8080}"
+  username: "${env.HAWKULAR_USER}"
+  password: "${env.HAWKULAR_PASSWORD}"
 
 resource-type-set-jmx:
 - name: For Integration Test
@@ -225,5 +225,5 @@ managed-servers:
       feed_id: "%FeedId"
 
 platform:
-  enabled:      true
-  #machine-id:   my-machine-id-here
+  enabled: true
+  #machine-id: my-machine-id-here

--- a/hawkular-javaagent-itest-parent/hawkular-javaagent-all-itests/hawkular-javaagent-domain-itest/src/test/resources/hawkular-javaagent-itest-config.yaml
+++ b/hawkular-javaagent-itest-parent/hawkular-javaagent-all-itests/hawkular-javaagent-domain-itest/src/test/resources/hawkular-javaagent-itest-config.yaml
@@ -31,15 +31,15 @@ metrics-exporter:
   config-file: WF10
 
 diagnostics:
-  enabled:    true
-  interval:   1
+  enabled: true
+  interval: 1
   time-units: minutes
 
 storage-adapter:
-  feed-id:   "${hawkular.rest.feedId:autogenerate}"
-  url:       "${hawkular.rest.url:http://hawkular-server:8080}"
-  username:  "${env.HAWKULAR_USER}"
-  password:  "${env.HAWKULAR_PASSWORD}"
+  feed-id: "${hawkular.rest.feedId:autogenerate}"
+  url: "${hawkular.rest.url:http://hawkular-server:8080}"
+  username: "${env.HAWKULAR_USER}"
+  password: "${env.HAWKULAR_PASSWORD}"
 
 resource-type-set-jmx:
 - name: For Integration Test
@@ -210,5 +210,5 @@ managed-servers:
       feed_id: "%FeedId"
 
 platform:
-  enabled:      true
-  #machine-id:   my-machine-id-here
+  enabled: true
+  #machine-id: my-machine-id-here

--- a/hawkular-javaagent-wildfly-feature-pack/src/main/resources/featurepack/content/standalone/configuration/hawkular-javaagent-config.yaml
+++ b/hawkular-javaagent-wildfly-feature-pack/src/main/resources/featurepack/content/standalone/configuration/hawkular-javaagent-config.yaml
@@ -31,15 +31,15 @@ metrics-exporter:
   config-file: WF10
 
 diagnostics:
-  enabled:    true
-  interval:   1
+  enabled: true
+  interval: 1
   time-units: minutes
 
 storage-adapter:
-  feed-id:   "${hawkular.rest.feedId:autogenerate}"
-  url:       "${hawkular.rest.url:http://hawkular-server:8080}"
-  username:  "${env.HAWKULAR_USER}"
-  password:  "${env.HAWKULAR_PASSWORD}"
+  feed-id: "${hawkular.rest.feedId:autogenerate}"
+  url: "${hawkular.rest.url:http://hawkular-server:8080}"
+  username: "${env.HAWKULAR_USER}"
+  password: "${env.HAWKULAR_PASSWORD}"
 
 # MANAGED SERVERS
 
@@ -116,5 +116,5 @@ managed-servers:
       feed_id: "%FeedId"
 
 platform:
-  enabled:      true
-  #machine-id:   my-machine-id-here
+  enabled: true
+  #machine-id: my-machine-id-here


### PR DESCRIPTION
This is a PR that doesn't change any functionality - but it does clean up the yaml config files. There are lots of trivial changes here (we had some weird spacing/indentation in many values and quoted things we didn't need to) - just doing this all at once to make the yaml files more consistent and will avoid irrelevant diffs later if this gets fixed little by little. Just do it all now in this PR. Similar PR was done to the server-side configs in commons.

