### PR TITLE
do not abort agent startup if the metrics endpoint fails to start

### DIFF
--- a/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/service/AgentCoreEngine.java
+++ b/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/service/AgentCoreEngine.java
@@ -327,7 +327,11 @@ public abstract class AgentCoreEngine {
             protocolServices.start();
 
             // start the metrics exporter if enabled
-            startMetricsExporter();
+            try {
+                startMetricsExporter();
+            } catch (Exception e) {
+                log.errorf(e, "Cannot start metrics exporter - continuing but no metrics will be available");
+            }
 
             setStatus(ServiceStatus.RUNNING);
 


### PR DESCRIPTION
I think we want the agent to keep going. But we'll log an ugly error to inform the user that the agent can't serve metrics.