### PR TITLE
Update docker agent to work in domain mode

### DIFF
--- a/docker-dist/Dockerfile
+++ b/docker-dist/Dockerfile
@@ -20,10 +20,8 @@ FROM jboss/wildfly:11.0.0.Final
 MAINTAINER Hawkular project <hawkular-dev@lists.jboss.org>
 
 # ADD test-simple.war /opt/jboss/wildfly/standalone/deployments/
-COPY target/hawkular-javaagent.jar $JBOSS_HOME/bin/
-COPY target/hawkular-javaagent-config.yaml /opt/hawkular/configuration/
-
-ADD src/main/resources/run_hawkular_javaagent.sh /opt/hawkular/bin/run_hawkular_agent.sh
+COPY target/hawkular $JBOSS_HOME/
+COPY src/main/resources/run_hawkular_javaagent.sh /opt/hawkular/bin/run_hawkular_agent.sh
 
 ENV HAWKULAR_URL=http://hawkular:8080 \
     HAWKULAR_USER=jdoe \
@@ -35,19 +33,12 @@ ENV HAWKULAR_URL=http://hawkular:8080 \
 EXPOSE 8080 9090 9779
 
 USER root
-RUN printf 'JAVA_OPTS="$JAVA_OPTS' >> $JBOSS_HOME/bin/standalone.conf
-RUN printf 'HOST_CONTROLLER_JAVA_OPTS="$HOST_CONTROLLER_JAVA_OPTS' >> $JBOSS_HOME/bin/domain.conf
-RUN printf ' -Djboss.modules.system.pkgs=org.jboss.byteman,org.jboss.logmanager -Djava.util.logging.manager=org.jboss.logmanager.LogManager -javaagent:$JBOSS_HOME/bin/hawkular-javaagent.jar=config=/opt/hawkular/configuration/hawkular-javaagent-config.yaml,delay=10' \
-| tee -a $JBOSS_HOME/bin/standalone.conf $JBOSS_HOME/bin/domain.conf  > /dev/null
-RUN printf ' -Djboss.host.server-excluded-properties=jboss.modules.system.pkgs,java.util.logging.manager' >> $JBOSS_HOME/bin/domain.conf
-RUN printf ' -Dhawkular.rest.url=${HAWKULAR_URL} -Dhawkular.agent.immutable=${HAWKULAR_AGENT_IMMUTABLE} -Dhawkular.agent.in-container=${HAWKULAR_AGENT_IMMUTABLE} -Dhawkular.agent.metrics.port=${HAWKULAR_AGENT_METRICS_PORT}"\n' \
-| tee -a $JBOSS_HOME/bin/standalone.conf $JBOSS_HOME/bin/domain.conf  > /dev/null
 
 
 RUN yum install --quiet -y openssl && \
     rm -rf /var/cache/yum && \
-    chown -RH jboss:0 $JBOSS_HOME/standalone $JAVA_HOME/jre/lib/security/cacerts /opt/hawkular && \
-    chmod -R ug+rw $JBOSS_HOME/standalone $JAVA_HOME/jre/lib/security/cacerts /opt/hawkular && \
+    chown -RH jboss:0 $JBOSS_HOME $JAVA_HOME/jre/lib/security/cacerts /opt/hawkular && \
+    chmod -R ug+rw $JBOSS_HOME $JAVA_HOME/jre/lib/security/cacerts /opt/hawkular && \
     chmod -R a+rw /opt/hawkular/ && \
     chmod -R a+x $JBOSS_HOME
 

--- a/docker-dist/pom.xml
+++ b/docker-dist/pom.xml
@@ -100,7 +100,6 @@
                   <artifactId>hawkular-javaagent-wildfly-dist</artifactId>
                   <type>zip</type>
                   <outputDirectory>${project.build.directory}</outputDirectory>
-                  <includes>**/hawkular-javaagent-config.yaml</includes>
                 </artifactItem>
               </artifactItems>
             </configuration>
@@ -116,8 +115,20 @@
             <phase>generate-resources</phase>
             <configuration>
               <target>
-                <move file="${project.build.directory}/hawkular-javaagent-${project.version}-shaded.jar" tofile="${project.build.directory}/hawkular-javaagent.jar" />
-                <move file="${project.build.directory}/hawkular-javaagent-wildfly-dist-${project.version}/standalone/configuration/hawkular-javaagent-config.yaml" tofile="${project.build.directory}/hawkular-javaagent-config.yaml" />
+                <!-- Global -->
+                <move file="${project.build.directory}/hawkular-javaagent-${project.version}-shaded.jar" tofile="${project.build.directory}/hawkular/bin/hawkular-javaagent.jar" />
+                <move file="${project.build.directory}/hawkular-javaagent-wildfly-dist-${project.version}/bin/start-with-hawkular.sh" tofile="${project.build.directory}/hawkular/bin/start-with-hawkular.sh" />
+
+                <!-- Standalone -->
+                <move file="${project.build.directory}/hawkular-javaagent-wildfly-dist-${project.version}/standalone/configuration/hawkular-javaagent-config.yaml" tofile="${project.build.directory}/hawkular/standalone/configuration/hawkular-javaagent-config.yaml" />
+                <move file="${project.build.directory}/hawkular-javaagent-wildfly-dist-${project.version}/bin/standalone.conf" tofile="${project.build.directory}/hawkular/bin/standalone.conf" />
+
+                <!-- Domain -->
+                <move file="${project.build.directory}/hawkular-javaagent-wildfly-dist-${project.version}/domain/configuration/hawkular-javaagent-config-domain.yaml" tofile="${project.build.directory}/hawkular/domain/configuration/hawkular-javaagent-config-domain.yaml" />
+                <move file="${project.build.directory}/hawkular-javaagent-wildfly-dist-${project.version}/domain/configuration/hawkular-javaagent-config-metrics-only.yaml" tofile="${project.build.directory}/hawkular/domain/configuration/hawkular-javaagent-config-metrics-only.yaml" />
+                <move file="${project.build.directory}/hawkular-javaagent-wildfly-dist-${project.version}/domain/configuration/host-hawkular.xml" tofile="${project.build.directory}/hawkular/domain/configuration/host-hawkular.xml" />
+                <move file="${project.build.directory}/hawkular-javaagent-wildfly-dist-${project.version}/bin/domain.conf" tofile="${project.build.directory}/hawkular/bin/domain.conf" />
+
               </target>
             </configuration>
             <goals>

--- a/docker-dist/src/main/resources/run_hawkular_javaagent.sh
+++ b/docker-dist/src/main/resources/run_hawkular_javaagent.sh
@@ -29,7 +29,11 @@ import_hawkular_services_public_key() {
 }
 
 run_hawkular_agent() {
-    ${JBOSS_HOME}/bin/${HAWKULAR_AGENT_MODE}.sh -b 0.0.0.0
+    local START_WITH_HAWKULAR_PARAMS="-s ${HAWKULAR_URL}"
+    if [[ "${HAWKULAR_AGENT_MODE}" == "domain" ]]; then
+      START_WITH_HAWKULAR_PARAMS="$START_WITH_HAWKULAR_PARAMS -d"
+    fi
+    ${JBOSS_HOME}/bin/start-with-hawkular.sh ${START_WITH_HAWKULAR_PARAMS} "$@"
 }
 
 main() {
@@ -37,9 +41,6 @@ main() {
   if [[ "${HAWKULAR_AGENT_MODE}" != "standalone" ]] && [[ "${HAWKULAR_AGENT_MODE}" != "domain" ]]; then
     echo 'HAWKULAR_AGENT_MODE must be set to "standalone" or "domain", found:' ${HAWKULAR_AGENT_MODE}
     exit
-  fi
-  if [[ "${HAWKULAR_AGENT_MODE}" == "domain" ]]; then
-    sed -i "s|WF10|WF10-DOMAIN|g" /opt/hawkular/configuration/hawkular-javaagent-config.yaml
   fi
   import_hawkular_services_public_key
   run_hawkular_agent "$@"

--- a/hawkular-javaagent-wildfly-feature-pack/src/main/resources/featurepack/content/bin/start-with-hawkular.sh
+++ b/hawkular-javaagent-wildfly-feature-pack/src/main/resources/featurepack/content/bin/start-with-hawkular.sh
@@ -21,7 +21,7 @@ _METRICS_HOST=`hostname`
 usage() {
   echo "Usage: $0"
   echo "  -d|--domain - to run in domain mode as opposed to standalone mode"
-  echo "  -s|--server <server-name> - the host where the Hawkular Server is running"
+  echo "  -s|--server <server-url> - the url where the Hawkular Server is running"
   echo "  -u|--username <username> - the username to use when logging into the Hawkular Server"
   echo "  -p|--password <password> - the username credentials"
   echo "  [-h|--metrics-host <host/IP>] - the hostname to bind the metrics exporter"
@@ -73,7 +73,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [ -z "$_SERVER" ]; then
-  echo "Specify the server"
+  echo "Specify the server url"
   usage
   exit 1
 fi
@@ -95,8 +95,8 @@ export HAWKULAR_PASSWORD
 
 _DIR="$( cd "$( dirname "${0}" )" && pwd )"
 if [ -z "$_DOMAIN_MODE" ]; then
-  ${_DIR}/standalone.sh -Dhawkular.rest.url=http://${_SERVER}:8080 -Dhawkular.agent.metrics.host=${_METRICS_HOST} ${_ARGS}
+  ${_DIR}/standalone.sh -Dhawkular.rest.url=${_SERVER} -Dhawkular.agent.metrics.host=${_METRICS_HOST} ${_ARGS}
 else
-  ${_DIR}/domain.sh --host-config=host-hawkular.xml -Dhawkular.rest.url=http://${_SERVER}:8080 -Dhawkular.agent.metrics.host=${_METRICS_HOST} ${_ARGS}
+  ${_DIR}/domain.sh --host-config=host-hawkular.xml -Dhawkular.rest.url=${_SERVER} -Dhawkular.agent.metrics.host=${_METRICS_HOST} ${_ARGS}
 fi
 


### PR DESCRIPTION
Also updates `start-with-hawkular.sh` to expect server url instead of hostname.
This allows to specify https (if needed) or a different port.