### PR TITLE
HAWKULAR-1349 Let JmxScrape fetch individual MBeans

### DIFF
--- a/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/prometheus/JmxCollector.java
+++ b/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/prometheus/JmxCollector.java
@@ -1,0 +1,492 @@
+/*
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.agent.monitor.prometheus;
+
+import static java.lang.String.format;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+
+import org.yaml.snakeyaml.Yaml;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.Counter;
+
+/*
+    Forked from collector-0.1.0.jar
+    https://github.com/prometheus/jmx_exporter/blob/parent-0.1.0/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
+
+    Added support for whitelistObjectInstances/blacklistObjectInstances
+
+    https://issues.jboss.org/browse/WFCORE-3461
+    https://github.com/prometheus/jmx_exporter/pull/217
+ */
+public class JmxCollector extends Collector implements Collector.Describable {
+    static final Counter configReloadSuccess = Counter.build()
+            .name("jmx_config_reload_success_total")
+            .help("Number of times configuration have successfully been reloaded.").register();
+
+    static final Counter configReloadFailure = Counter.build()
+            .name("jmx_config_reload_failure_total")
+            .help("Number of times configuration have failed to be reloaded.").register();
+
+    private static final Logger LOGGER = Logger.getLogger(JmxCollector.class.getName());
+
+    private static class Rule {
+        Pattern pattern;
+        String name;
+        String value;
+        Double valueFactor = 1.0;
+        String help;
+        boolean attrNameSnakeCase;
+        Type type = Type.UNTYPED;
+        ArrayList<String> labelNames;
+        ArrayList<String> labelValues;
+    }
+
+    private static class Config {
+        Integer startDelaySeconds = 0;
+        String jmxUrl = "";
+        String username = "";
+        String password = "";
+        boolean ssl = false;
+        boolean lowercaseOutputName;
+        boolean lowercaseOutputLabelNames;
+        List<ObjectName> whitelistObjectInstances = new ArrayList<ObjectName>();
+        List<ObjectName> blacklistObjectInstances = new ArrayList<ObjectName>();
+        List<ObjectName> whitelistObjectNames = new ArrayList<ObjectName>();
+        List<ObjectName> blacklistObjectNames = new ArrayList<ObjectName>();
+        ArrayList<Rule> rules = new ArrayList<Rule>();
+        long lastUpdate = 0L;
+    }
+
+    private Config config;
+    private File configFile;
+    private long createTimeNanoSecs = System.nanoTime();
+
+    private static final Pattern snakeCasePattern = Pattern.compile("([a-z0-9])([A-Z])");
+
+    public JmxCollector(File in) throws IOException, MalformedObjectNameException {
+        configFile = in;
+        config = loadConfig((Map<String, Object>)new Yaml().load(new FileReader(in)));
+        config.lastUpdate = configFile.lastModified();
+    }
+
+    public JmxCollector(String yamlConfig) throws MalformedObjectNameException {
+        config = loadConfig((Map<String, Object>)new Yaml().load(yamlConfig));
+    }
+
+    private void reloadConfig() {
+        try {
+            FileReader fr = new FileReader(configFile);
+
+            try {
+                Map<String, Object> newYamlConfig = (Map<String, Object>)new Yaml().load(fr);
+                config = loadConfig(newYamlConfig);
+                config.lastUpdate = configFile.lastModified();
+                configReloadSuccess.inc();
+            } catch (Exception e) {
+                LOGGER.severe("Configuration reload failed: " + e.toString());
+                configReloadFailure.inc();
+            } finally {
+                fr.close();
+            }
+
+        } catch (IOException e) {
+            LOGGER.severe("Configuration reload failed: " + e.toString());
+            configReloadFailure.inc();
+        }
+    }
+
+    private Config loadConfig(Map<String, Object> yamlConfig) throws MalformedObjectNameException {
+        Config cfg = new Config();
+
+        if (yamlConfig == null) {  // Yaml config empty, set config to empty map.
+            yamlConfig = new HashMap<String, Object>();
+        }
+
+        if (yamlConfig.containsKey("startDelaySeconds")) {
+            try {
+                cfg.startDelaySeconds = (Integer) yamlConfig.get("startDelaySeconds");
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("Invalid number provided for startDelaySeconds", e);
+            }
+        }
+        if (yamlConfig.containsKey("hostPort")) {
+            if (yamlConfig.containsKey("jmxUrl")) {
+                throw new IllegalArgumentException("At most one of hostPort and jmxUrl must be provided");
+            }
+            cfg.jmxUrl ="service:jmx:rmi:///jndi/rmi://" + (String)yamlConfig.get("hostPort") + "/jmxrmi";
+        } else if (yamlConfig.containsKey("jmxUrl")) {
+            cfg.jmxUrl = (String)yamlConfig.get("jmxUrl");
+        }
+
+        if (yamlConfig.containsKey("username")) {
+            cfg.username = (String)yamlConfig.get("username");
+        }
+
+        if (yamlConfig.containsKey("password")) {
+            cfg.password = (String)yamlConfig.get("password");
+        }
+
+        if (yamlConfig.containsKey("ssl")) {
+            cfg.ssl = (Boolean)yamlConfig.get("ssl");
+        }
+
+        if (yamlConfig.containsKey("lowercaseOutputName")) {
+            cfg.lowercaseOutputName = (Boolean)yamlConfig.get("lowercaseOutputName");
+        }
+
+        if (yamlConfig.containsKey("lowercaseOutputLabelNames")) {
+            cfg.lowercaseOutputLabelNames = (Boolean)yamlConfig.get("lowercaseOutputLabelNames");
+        }
+
+        if (yamlConfig.containsKey("whitelistObjectInstances")) {
+            List<Object> names = (List<Object>) yamlConfig.get("whitelistObjectInstances");
+            for(Object name : names) {
+                cfg.whitelistObjectInstances.add(new ObjectName((String)name));
+            }
+        }
+
+        if (yamlConfig.containsKey("blacklistObjectInstances")) {
+            List<Object> names = (List<Object>) yamlConfig.get("blacklistObjectInstances");
+            for(Object name : names) {
+                cfg.blacklistObjectInstances.add(new ObjectName((String)name));
+            }
+        }
+
+        if (yamlConfig.containsKey("whitelistObjectNames")) {
+            List<Object> names = (List<Object>) yamlConfig.get("whitelistObjectNames");
+            for(Object name : names) {
+                cfg.whitelistObjectNames.add(new ObjectName((String)name));
+            }
+        } else {
+            cfg.whitelistObjectNames.add(null);
+        }
+
+        if (yamlConfig.containsKey("blacklistObjectNames")) {
+            List<Object> names = (List<Object>) yamlConfig.get("blacklistObjectNames");
+            for (Object name : names) {
+                cfg.blacklistObjectNames.add(new ObjectName((String)name));
+            }
+        }
+
+        if (yamlConfig.containsKey("rules")) {
+            List<Map<String,Object>> configRules = (List<Map<String,Object>>) yamlConfig.get("rules");
+            for (Map<String, Object> ruleObject : configRules) {
+                Map<String, Object> yamlRule = ruleObject;
+                Rule rule = new Rule();
+                cfg.rules.add(rule);
+                if (yamlRule.containsKey("pattern")) {
+                    rule.pattern = Pattern.compile("^.*(?:" + (String)yamlRule.get("pattern") + ").*$");
+                }
+                if (yamlRule.containsKey("name")) {
+                    rule.name = (String)yamlRule.get("name");
+                }
+                if (yamlRule.containsKey("value")) {
+                    rule.value = String.valueOf(yamlRule.get("value"));
+                }
+                if (yamlRule.containsKey("valueFactor")) {
+                    String valueFactor = String.valueOf(yamlRule.get("valueFactor"));
+                    try {
+                        rule.valueFactor = Double.valueOf(valueFactor);
+                    } catch (NumberFormatException e) {
+                        // use default value
+                    }
+                }
+                if (yamlRule.containsKey("attrNameSnakeCase")) {
+                    rule.attrNameSnakeCase = (Boolean)yamlRule.get("attrNameSnakeCase");
+                }
+                if (yamlRule.containsKey("type")) {
+                    rule.type = Type.valueOf((String)yamlRule.get("type"));
+                }
+                if (yamlRule.containsKey("help")) {
+                    rule.help = (String)yamlRule.get("help");
+                }
+                if (yamlRule.containsKey("labels")) {
+                    TreeMap labels = new TreeMap((Map<String, Object>)yamlRule.get("labels"));
+                    rule.labelNames = new ArrayList<String>();
+                    rule.labelValues = new ArrayList<String>();
+                    for (Map.Entry<String, Object> entry : (Set<Map.Entry<String, Object>>)labels.entrySet()) {
+                        rule.labelNames.add(entry.getKey());
+                        rule.labelValues.add((String)entry.getValue());
+                    }
+                }
+
+                // Validation.
+                if ((rule.labelNames != null || rule.help != null) && rule.name == null) {
+                    throw new IllegalArgumentException("Must provide name, if help or labels are given: " + yamlRule);
+                }
+                if (rule.name != null && rule.pattern == null) {
+                    throw new IllegalArgumentException("Must provide pattern, if name is given: " + yamlRule);
+                }
+            }
+        } else {
+            // Default to a single default rule.
+            cfg.rules.add(new Rule());
+        }
+
+        return cfg;
+
+    }
+
+    class Receiver implements JmxScraper.MBeanReceiver {
+        Map<String, MetricFamilySamples> metricFamilySamplesMap =
+                new HashMap<String, MetricFamilySamples>();
+
+        private static final char SEP = '_';
+
+        private final Pattern unsafeChars = Pattern.compile("[^a-zA-Z0-9:_]");
+        private final Pattern multipleUnderscores = Pattern.compile("__+");
+
+        // [] and () are special in regexes, so swtich to <>.
+        private String angleBrackets(String s) {
+            return "<" + s.substring(1, s.length() - 1) + ">";
+        }
+
+        private String safeName(String s) {
+            // Change invalid chars to underscore, and merge underscores.
+            return multipleUnderscores.matcher(unsafeChars.matcher(s).replaceAll("_")).replaceAll("_");
+        }
+
+        void addSample(MetricFamilySamples.Sample sample, Type type, String help) {
+            MetricFamilySamples mfs = metricFamilySamplesMap.get(sample.name);
+            if (mfs == null) {
+                // JmxScraper.MBeanReceiver is only called from one thread,
+                // so there's no race here.
+                mfs = new MetricFamilySamples(sample.name, type, help, new ArrayList<MetricFamilySamples.Sample>());
+                metricFamilySamplesMap.put(sample.name, mfs);
+            }
+            mfs.samples.add(sample);
+        }
+
+        private void defaultExport(
+                String domain,
+                LinkedHashMap<String, String> beanProperties,
+                LinkedList<String> attrKeys,
+                String attrName,
+                String attrType,
+                String help,
+                Object value,
+                Type type) {
+            StringBuilder name = new StringBuilder();
+            name.append(domain);
+            if (beanProperties.size() > 0) {
+                name.append(SEP);
+                name.append(beanProperties.values().iterator().next());
+            }
+            for (String k : attrKeys) {
+                name.append(SEP);
+                name.append(k);
+            }
+            name.append(SEP);
+            name.append(attrName);
+            String fullname = safeName(name.toString());
+
+            if (config.lowercaseOutputName) {
+                fullname = fullname.toLowerCase();
+            }
+
+            List<String> labelNames = new ArrayList<String>();
+            List<String> labelValues = new ArrayList<String>();
+            if (beanProperties.size() > 1) {
+                Iterator<Map.Entry<String, String>> iter = beanProperties.entrySet().iterator();
+                // Skip the first one, it's been used in the name.
+                iter.next();
+                while (iter.hasNext()) {
+                    Map.Entry<String, String> entry = iter.next();
+                    String labelName = safeName(entry.getKey());
+                    if (config.lowercaseOutputLabelNames) {
+                        labelName = labelName.toLowerCase();
+                    }
+                    labelNames.add(labelName);
+                    labelValues.add(entry.getValue());
+                }
+            }
+
+            addSample(new MetricFamilySamples.Sample(fullname, labelNames, labelValues, ((Number)value).doubleValue()),
+                    type, help);
+        }
+
+        public void recordBean(
+                String domain,
+                LinkedHashMap<String, String> beanProperties,
+                LinkedList<String> attrKeys,
+                String attrName,
+                String attrType,
+                String attrDescription,
+                Object beanValue) {
+
+            String beanName = domain + angleBrackets(beanProperties.toString()) + angleBrackets(attrKeys.toString());
+            // attrDescription tends not to be useful, so give the fully qualified name too.
+            String help = attrDescription + " (" + beanName + attrName + ")";
+            String attrNameSnakeCase = snakeCasePattern.matcher(attrName).replaceAll("$1_$2").toLowerCase();
+
+            for (Rule rule : config.rules) {
+                Matcher matcher = null;
+                String matchName = beanName + (rule.attrNameSnakeCase ? attrNameSnakeCase : attrName);
+                if (rule.pattern != null) {
+                    matcher = rule.pattern.matcher(matchName + ": " + beanValue);
+                    if (!matcher.matches()) {
+                        continue;
+                    }
+                }
+
+                Number value;
+                if (rule.value != null && !rule.value.isEmpty()) {
+                    String val = matcher.replaceAll(rule.value);
+
+                    try {
+                        beanValue = Double.valueOf(val);
+                    } catch (NumberFormatException e) {
+                        LOGGER.fine("Unable to parse configured value '" + val + "' to number for bean: " + beanName + attrName + ": " + beanValue);
+                        return;
+                    }
+                }
+                if (beanValue instanceof Number) {
+                    value = ((Number)beanValue).doubleValue() * rule.valueFactor;
+                } else if (beanValue instanceof Boolean) {
+                    value = (Boolean)beanValue ? 1 : 0;
+                } else {
+                    LOGGER.fine("Ignoring unsupported bean: " + beanName + attrName + ": " + beanValue);
+                    return;
+                }
+
+                // If there's no name provided, use default export format.
+                if (rule.name == null) {
+                    defaultExport(domain, beanProperties, attrKeys, rule.attrNameSnakeCase ? attrNameSnakeCase : attrName, attrType, help, value, rule.type);
+                    return;
+                }
+
+                // Matcher is set below here due to validation in the constructor.
+                String name = safeName(matcher.replaceAll(rule.name));
+                if (name.isEmpty()) {
+                    return;
+                }
+                if (config.lowercaseOutputName) {
+                    name = name.toLowerCase();
+                }
+
+                // Set the help.
+                if (rule.help != null) {
+                    help = matcher.replaceAll(rule.help);
+                }
+
+                // Set the labels.
+                ArrayList<String> labelNames = new ArrayList<String>();
+                ArrayList<String> labelValues = new ArrayList<String>();
+                if (rule.labelNames != null) {
+                    for (int i = 0; i < rule.labelNames.size(); i++) {
+                        final String unsafeLabelName = rule.labelNames.get(i);
+                        final String labelValReplacement = rule.labelValues.get(i);
+                        try {
+                            String labelName = safeName(matcher.replaceAll(unsafeLabelName));
+                            String labelValue = matcher.replaceAll(labelValReplacement);
+                            if (config.lowercaseOutputLabelNames) {
+                                labelName = labelName.toLowerCase();
+                            }
+                            if (!labelName.isEmpty() && !labelValue.isEmpty()) {
+                                labelNames.add(labelName);
+                                labelValues.add(labelValue);
+                            }
+                        } catch (Exception e) {
+                            throw new RuntimeException(
+                                    format("Matcher '%s' unable to use: '%s' value: '%s'", matcher, unsafeLabelName, labelValReplacement), e);
+                        }
+                    }
+                }
+
+                // Add to samples.
+                LOGGER.fine("add metric sample: " + name + " " + labelNames + " " + labelValues + " " + value.doubleValue());
+                addSample(new MetricFamilySamples.Sample(name, labelNames, labelValues, value.doubleValue()), rule.type, help);
+                return;
+            }
+        }
+
+    }
+
+    public List<MetricFamilySamples> collect() {
+        if (configFile != null) {
+            long mtime = configFile.lastModified();
+            if (mtime > config.lastUpdate) {
+                LOGGER.fine("Configuration file changed, reloading...");
+                reloadConfig();
+            }
+        }
+
+        Receiver receiver = new Receiver();
+        JmxScraper scraper = new JmxScraper(config.jmxUrl,
+                config.username,
+                config.password,
+                config.ssl,
+                config.whitelistObjectInstances,
+                config.blacklistObjectInstances,
+                config.whitelistObjectNames,
+                config.blacklistObjectNames,
+                receiver);
+        long start = System.nanoTime();
+        double error = 0;
+        if ((config.startDelaySeconds > 0) &&
+                ((start - createTimeNanoSecs) / 1000000000L < config.startDelaySeconds)) {
+            throw new IllegalStateException("JMXCollector waiting for startDelaySeconds");
+        }
+        try {
+            scraper.doScrape();
+        } catch (Exception e) {
+            error = 1;
+            StringWriter sw = new StringWriter();
+            e.printStackTrace(new PrintWriter(sw));
+            LOGGER.severe("JMX scrape failed: " + sw.toString());
+        }
+        List<MetricFamilySamples> mfsList = new ArrayList<MetricFamilySamples>();
+        mfsList.addAll(receiver.metricFamilySamplesMap.values());
+        List<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>();
+        samples.add(new MetricFamilySamples.Sample(
+                "jmx_scrape_duration_seconds", new ArrayList<String>(), new ArrayList<String>(), (System.nanoTime() - start) / 1.0E9));
+        mfsList.add(new MetricFamilySamples("jmx_scrape_duration_seconds", Type.GAUGE, "Time this JMX scrape took, in seconds.", samples));
+
+        samples = new ArrayList<MetricFamilySamples.Sample>();
+        samples.add(new MetricFamilySamples.Sample(
+                "jmx_scrape_error", new ArrayList<String>(), new ArrayList<String>(), error));
+        mfsList.add(new MetricFamilySamples("jmx_scrape_error", Type.GAUGE, "Non-zero if this scrape failed.", samples));
+        return mfsList;
+    }
+
+    public List<MetricFamilySamples> describe() {
+        List<MetricFamilySamples> sampleFamilies = new ArrayList<MetricFamilySamples>();
+        sampleFamilies.add(new MetricFamilySamples("jmx_scrape_duration_seconds", Type.GAUGE, "Time this JMX scrape took, in seconds.", new ArrayList<MetricFamilySamples.Sample>()));
+        sampleFamilies.add(new MetricFamilySamples("jmx_scrape_error", Type.GAUGE, "Non-zero if this scrape failed.", new ArrayList<MetricFamilySamples.Sample>()));
+        return sampleFamilies;
+    }
+}

--- a/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/prometheus/JmxScraper.java
+++ b/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/prometheus/JmxScraper.java
@@ -1,0 +1,339 @@
+/*
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.agent.monitor.prometheus;
+
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.management.JMException;
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanInfo;
+import javax.management.MBeanServerConnection;
+import javax.management.ObjectInstance;
+import javax.management.ObjectName;
+import javax.management.openmbean.CompositeData;
+import javax.management.openmbean.CompositeType;
+import javax.management.openmbean.TabularData;
+import javax.management.openmbean.TabularType;
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
+import javax.management.remote.rmi.RMIConnectorServer;
+import javax.naming.Context;
+import javax.rmi.ssl.SslRMIClientSocketFactory;
+
+/*
+    Forked from collector-0.1.0.jar
+    https://github.com/prometheus/jmx_exporter/blob/parent-0.1.0/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
+
+    Added support for whitelistObjectInstances/blacklistObjectInstances
+
+    https://issues.jboss.org/browse/WFCORE-3461
+    https://github.com/prometheus/jmx_exporter/pull/217
+ */
+public class JmxScraper {
+    private static final Logger logger = Logger.getLogger(JmxScraper.class.getName());;
+    private static final Pattern PROPERTY_PATTERN = Pattern.compile(
+            "([^,=:\\*\\?]+)" + // Name - non-empty, anything but comma, equals, colon, star, or question mark
+                    "=" +  // Equals
+                    "(" + // Either
+                    "\"" + // Quoted
+                    "(?:" + // A possibly empty sequence of
+                    "[^\\\\\"]" + // Anything but backslash or quote
+                    "|\\\\\\\\" + // or an escaped backslash
+                    "|\\\\n" + // or an escaped newline
+                    "|\\\\\"" + // or an escaped quote
+                    "|\\\\\\?" + // or an escaped question mark
+                    "|\\\\\\*" + // or an escaped star
+                    ")*" +
+                    "\"" +
+                    "|" + // Or
+                    "[^,=:\"]*" + // Unquoted - can be empty, anything but comma, equals, colon, or quote
+                    ")");
+
+    public interface MBeanReceiver {
+        void recordBean(
+                String domain,
+                LinkedHashMap<String, String> beanProperties,
+                LinkedList<String> attrKeys,
+                String attrName,
+                String attrType,
+                String attrDescription,
+                Object value);
+    }
+
+    private MBeanReceiver receiver;
+    private String jmxUrl;
+    private String username;
+    private String password;
+    private boolean ssl;
+    private List<ObjectName> whitelistObjectInstances, blacklistObjectInstances;
+    private List<ObjectName> whitelistObjectNames, blacklistObjectNames;
+
+    public JmxScraper(String jmxUrl,
+                      String username,
+                      String password,
+                      boolean ssl,
+                      List<ObjectName> whitelistObjectInstances,
+                      List<ObjectName> blacklistObjectInstances,
+                      List<ObjectName> whitelistObjectNames,
+                      List<ObjectName> blacklistObjectNames,
+                      MBeanReceiver receiver) {
+        this.jmxUrl = jmxUrl;
+        this.receiver = receiver;
+        this.username = username;
+        this.password = password;
+        this.ssl = ssl;
+        this.whitelistObjectInstances = whitelistObjectInstances;
+        this.blacklistObjectInstances = blacklistObjectInstances;
+        this.whitelistObjectNames = whitelistObjectNames;
+        this.blacklistObjectNames = blacklistObjectNames;
+    }
+
+    /**
+     * Get a list of mbeans on host_port and scrape their values.
+     *
+     * Values are passed to the receiver in a single thread.
+     */
+    public void doScrape() throws Exception {
+        MBeanServerConnection beanConn;
+        JMXConnector jmxc = null;
+        if (jmxUrl.isEmpty()) {
+            beanConn = ManagementFactory.getPlatformMBeanServer();
+        } else {
+            Map<String, Object> environment = new HashMap<String, Object>();
+            if (username != null && username.length() != 0 && password != null && password.length() != 0) {
+                String[] credent = new String[] {username, password};
+                environment.put(javax.management.remote.JMXConnector.CREDENTIALS, credent);
+            }
+            if (ssl) {
+                environment.put(Context.SECURITY_PROTOCOL, "ssl");
+                SslRMIClientSocketFactory clientSocketFactory = new SslRMIClientSocketFactory();
+                environment.put(RMIConnectorServer.RMI_CLIENT_SOCKET_FACTORY_ATTRIBUTE, clientSocketFactory);
+                environment.put("com.sun.jndi.rmi.factory.socket", clientSocketFactory);
+            }
+
+            jmxc = JMXConnectorFactory.connect(new JMXServiceURL(jmxUrl), environment);
+            beanConn = jmxc.getMBeanServerConnection();
+        }
+        try {
+            // Query MBean names, see #89 for reasons queryMBeans() is used instead of queryNames()
+            Set<ObjectInstance> mBeanNames = new HashSet();
+            for (ObjectName name : whitelistObjectNames) {
+                mBeanNames.addAll(beanConn.queryMBeans(name, null));
+            }
+            for (ObjectName name : whitelistObjectInstances) {
+                mBeanNames.add(beanConn.getObjectInstance(name));
+            }
+            for (ObjectName name : blacklistObjectNames) {
+                mBeanNames.removeAll(beanConn.queryMBeans(name, null));
+            }
+            for (ObjectName name : blacklistObjectInstances) {
+                mBeanNames.remove(beanConn.getObjectInstance(name));
+            }
+            for (ObjectInstance name : mBeanNames) {
+                long start = System.nanoTime();
+                scrapeBean(beanConn, name.getObjectName());
+                logger.fine("TIME: " + (System.nanoTime() - start) + " ns for " + name.getObjectName().toString());
+            }
+        } finally {
+            if (jmxc != null) {
+                jmxc.close();
+            }
+        }
+    }
+
+    private void scrapeBean(MBeanServerConnection beanConn, ObjectName mbeanName) {
+        MBeanInfo info;
+        try {
+            info = beanConn.getMBeanInfo(mbeanName);
+        } catch (IOException e) {
+            logScrape(mbeanName.toString(), "getMBeanInfo Fail: " + e);
+            return;
+        } catch (JMException e) {
+            logScrape(mbeanName.toString(), "getMBeanInfo Fail: " + e);
+            return;
+        }
+        MBeanAttributeInfo[] attrInfos = info.getAttributes();
+
+        for (int idx = 0; idx < attrInfos.length; ++idx) {
+            MBeanAttributeInfo attr = attrInfos[idx];
+            if (!attr.isReadable()) {
+                logScrape(mbeanName, attr, "not readable");
+                continue;
+            }
+
+            Object value;
+            try {
+                value = beanConn.getAttribute(mbeanName, attr.getName());
+            } catch(Exception e) {
+                logScrape(mbeanName, attr, "Fail: " + e);
+                continue;
+            }
+
+            logScrape(mbeanName, attr, "process");
+            processBeanValue(
+                    mbeanName.getDomain(),
+                    getKeyPropertyList(mbeanName),
+                    new LinkedList<String>(),
+                    attr.getName(),
+                    attr.getType(),
+                    attr.getDescription(),
+                    value
+            );
+        }
+    }
+
+    static LinkedHashMap<String, String> getKeyPropertyList(ObjectName mbeanName) {
+        // Implement a version of ObjectName.getKeyPropertyList that returns the
+        // properties in the ordered they were added (the ObjectName stores them
+        // in the order they were added).
+        LinkedHashMap<String, String> output = new LinkedHashMap<String, String>();
+        String properties = mbeanName.getKeyPropertyListString();
+        Matcher match = PROPERTY_PATTERN.matcher(properties);
+        while (match.lookingAt()) {
+            output.put(match.group(1), match.group(2));
+            properties = properties.substring(match.end());
+            if (properties.startsWith(",")) {
+                properties = properties.substring(1);
+            }
+            match.reset(properties);
+        }
+        return output;
+    }
+
+    /**
+     * Recursive function for exporting the values of an mBean.
+     * JMX is a very open technology, without any prescribed way of declaring mBeans
+     * so this function tries to do a best-effort pass of getting the values/names
+     * out in a way it can be processed elsewhere easily.
+     */
+    private void processBeanValue(
+            String domain,
+            LinkedHashMap<String, String> beanProperties,
+            LinkedList<String> attrKeys,
+            String attrName,
+            String attrType,
+            String attrDescription,
+            Object value) {
+        if (value == null) {
+            logScrape(domain + beanProperties + attrName, "null");
+        } else if (value instanceof Number || value instanceof String || value instanceof Boolean) {
+            logScrape(domain + beanProperties + attrName, value.toString());
+            this.receiver.recordBean(
+                    domain,
+                    beanProperties,
+                    attrKeys,
+                    attrName,
+                    attrType,
+                    attrDescription,
+                    value);
+        } else if (value instanceof CompositeData) {
+            logScrape(domain + beanProperties + attrName, "compositedata");
+            CompositeData composite = (CompositeData) value;
+            CompositeType type = composite.getCompositeType();
+            attrKeys = new LinkedList<String>(attrKeys);
+            attrKeys.add(attrName);
+            for(String key : type.keySet()) {
+                String typ = type.getType(key).getTypeName();
+                Object valu = composite.get(key);
+                processBeanValue(
+                        domain,
+                        beanProperties,
+                        attrKeys,
+                        key,
+                        typ,
+                        type.getDescription(),
+                        valu);
+            }
+        } else if (value instanceof TabularData) {
+            // I don't pretend to have a good understanding of TabularData.
+            // The real world usage doesn't appear to match how they were
+            // meant to be used according to the docs. I've only seen them
+            // used as 'key' 'value' pairs even when 'value' is itself a
+            // CompositeData of multiple values.
+            logScrape(domain + beanProperties + attrName, "tabulardata");
+            TabularData tds = (TabularData) value;
+            TabularType tt = tds.getTabularType();
+
+            List<String> rowKeys = tt.getIndexNames();
+            LinkedHashMap<String, String> l2s = new LinkedHashMap<String, String>(beanProperties);
+
+            CompositeType type = tt.getRowType();
+            Set<String> valueKeys = new TreeSet<String>(type.keySet());
+            valueKeys.removeAll(rowKeys);
+
+            LinkedList<String> extendedAttrKeys = new LinkedList<String>(attrKeys);
+            extendedAttrKeys.add(attrName);
+            for (Object valu : tds.values()) {
+                if (valu instanceof CompositeData) {
+                    CompositeData composite = (CompositeData) valu;
+                    for (String idx : rowKeys) {
+                        l2s.put(idx, composite.get(idx).toString());
+                    }
+                    for(String valueIdx : valueKeys) {
+                        LinkedList<String> attrNames = extendedAttrKeys;
+                        String typ = type.getType(valueIdx).getTypeName();
+                        String name = valueIdx;
+                        if (valueIdx.toLowerCase().equals("value")) {
+                            // Skip appending 'value' to the name
+                            attrNames = attrKeys;
+                            name = attrName;
+                        }
+                        processBeanValue(
+                                domain,
+                                l2s,
+                                attrNames,
+                                name,
+                                typ,
+                                type.getDescription(),
+                                composite.get(valueIdx));
+                    }
+                } else {
+                    logScrape(domain, "not a correct tabulardata format");
+                }
+            }
+        } else if (value.getClass().isArray()) {
+            logScrape(domain, "arrays are unsupported");
+        } else {
+            logScrape(domain + beanProperties, attrType + " is not exported");
+        }
+    }
+
+    /**
+     * For debugging.
+     */
+    private static void logScrape(ObjectName mbeanName, MBeanAttributeInfo attr, String msg) {
+        logScrape(mbeanName + "'_'" + attr.getName(), msg);
+    }
+    private static void logScrape(String name, String msg) {
+        logger.log(Level.FINE, "scrape: '" + name + "': " + msg);
+    }
+}
+

--- a/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/prometheus/WebServer.java
+++ b/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/prometheus/WebServer.java
@@ -22,7 +22,6 @@ import java.net.InetSocketAddress;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.exporter.HTTPServer;
 import io.prometheus.client.hotspot.DefaultExports;
-import io.prometheus.jmx.JmxCollector;
 
 public class WebServer {
 

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <version.io.prometheus.simpleclient.hotspot>0.1.0</version.io.prometheus.simpleclient.hotspot>
     <version.io.prometheus.simpleclient.httpserver>0.1.0</version.io.prometheus.simpleclient.httpserver>
     <version.org.hamcrest>1.3</version.org.hamcrest>
-    <version.org.hawkular.commons>1.0.0.Final-SRC-revision-83f9e852aadd5f58f04f349d2b3395eba334b9ca</version.org.hawkular.commons>
+    <version.org.hawkular.commons>1.0.0.Final-SRC-revision-643697a944c214896f37fb8f4e2229627a728dcd</version.org.hawkular.commons>
     <version.org.jboss.aesh>0.66.7</version.org.jboss.aesh>
     <version.org.jgrapht>0.9.1</version.org.jgrapht>
     <version.org.jolokia>1.3.5</version.org.jolokia>


### PR DESCRIPTION
Context for this fix is the following:
- Wildfly/EAP has an MBean which is special and may not appear in queryNames/queryMBeans.
- This MBean is important for availability information.
Instead to "hack" and add any kind of "hardcoded" name in the code, I think a better approach is to let in the config to query patterns names (with wildcards) and individual instances.
Then, this can be prepared for future use cases, too.
Note, this will be fixed in Wildfly Core, but we need to live with WF10, WF11 and EAP6/EAP7 which will have this (and other similar) situations.

Also, this fix needs another PR on commons to modify the jmx-exporter configuration. 